### PR TITLE
NSubstitute DLL for .NET Standard 2.0

### DIFF
--- a/LICENSE.md.meta
+++ b/LICENSE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e27b2525fd24d29479ab82f6ee289a23
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: eac15733d158abc4da9511de06aee5f6
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests.meta
+++ b/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c92cbcb4a0cc18b4d8ed0c01b97b9f8b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Maze.TestingToolkit.Tests.asmdef
+++ b/Tests/Maze.TestingToolkit.Tests.asmdef
@@ -1,0 +1,21 @@
+{
+    "name": "Maze.TestingToolkit.Tests",
+    "rootNamespace": "Maze.TestingToolkit.Tests",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll",
+        "NSubstitute.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Tests/Maze.TestingToolkit.Tests.asmdef.meta
+++ b/Tests/Maze.TestingToolkit.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bb69a54654f5a59438c7f3d6d3c5f5d1
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Plugins.meta
+++ b/Tests/Plugins.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9519d1f552b2e3342b05d7974e02daa1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Plugins/castle.core.5.2.1.meta
+++ b/Tests/Plugins/castle.core.5.2.1.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8f40d5e41b17b5f42af2db23666c8b65
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Plugins/castle.core.5.2.1/Castle.Core.dll
+++ b/Tests/Plugins/castle.core.5.2.1/Castle.Core.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b87b378d30890bda7ba14a591a4f53d7b56816ee6e30b4421091d12f013ea1e
+size 387584

--- a/Tests/Plugins/castle.core.5.2.1/Castle.Core.dll.meta
+++ b/Tests/Plugins/castle.core.5.2.1/Castle.Core.dll.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: afae6c709c920af469f3ef708c39557a

--- a/Tests/Plugins/castle.core.5.2.1/Castle.Core.xml
+++ b/Tests/Plugins/castle.core.5.2.1/Castle.Core.xml
@@ -1,0 +1,5976 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>Castle.Core</name>
+    </assembly>
+    <members>
+        <member name="T:Castle.Components.DictionaryAdapter.AbstractDictionaryAdapter">
+            <summary>
+            Abstract adapter for the <see cref="T:System.Collections.IDictionary"/> support
+            needed by the <see cref="T:Castle.Components.DictionaryAdapter.DictionaryAdapterFactory"/>
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.AbstractDictionaryAdapter.Add(System.Object,System.Object)">
+            <summary>
+            Adds an element with the provided key and value to the <see cref="T:System.Collections.IDictionary"></see> object.
+            </summary>
+            <param name="key">The <see cref="T:System.Object"></see> to use as the key of the element to add.</param>
+            <param name="value">The <see cref="T:System.Object"></see> to use as the value of the element to add.</param>
+            <exception cref="T:System.ArgumentException">An element with the same key already exists in the <see cref="T:System.Collections.IDictionary"></see> object. </exception>
+            <exception cref="T:System.ArgumentNullException">key is null. </exception>
+            <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.IDictionary"></see> is read-only.-or- The <see cref="T:System.Collections.IDictionary"></see> has a fixed size. </exception>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.AbstractDictionaryAdapter.Clear">
+            <summary>
+            Removes all elements from the <see cref="T:System.Collections.IDictionary"></see> object.
+            </summary>
+            <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.IDictionary"></see> object is read-only. </exception>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.AbstractDictionaryAdapter.Contains(System.Object)">
+            <summary>
+            Determines whether the <see cref="T:System.Collections.IDictionary"></see> object contains an element with the specified key.
+            </summary>
+            <param name="key">The key to locate in the <see cref="T:System.Collections.IDictionary"></see> object.</param>
+            <returns>
+            true if the <see cref="T:System.Collections.IDictionary"></see> contains an element with the key; otherwise, false.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">key is null. </exception>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.AbstractDictionaryAdapter.GetEnumerator">
+            <summary>
+            Returns an <see cref="T:System.Collections.IDictionaryEnumerator"></see> object for the <see cref="T:System.Collections.IDictionary"></see> object.
+            </summary>
+            <returns>
+            An <see cref="T:System.Collections.IDictionaryEnumerator"></see> object for the <see cref="T:System.Collections.IDictionary"></see> object.
+            </returns>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.AbstractDictionaryAdapter.IsFixedSize">
+            <summary>
+            Gets a value indicating whether the <see cref="T:System.Collections.IDictionary"></see> object has a fixed size.
+            </summary>
+            <returns>true if the <see cref="T:System.Collections.IDictionary"></see> object has a fixed size; otherwise, false.</returns>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.AbstractDictionaryAdapter.IsReadOnly">
+            <summary>
+            Gets a value indicating whether the <see cref="T:System.Collections.IDictionary"></see> object is read-only.
+            </summary>
+            <returns>true if the <see cref="T:System.Collections.IDictionary"></see> object is read-only; otherwise, false.</returns>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.AbstractDictionaryAdapter.Keys">
+            <summary>
+            Gets an <see cref="T:System.Collections.ICollection"></see> object containing the keys of the <see cref="T:System.Collections.IDictionary"></see> object.
+            </summary>
+            <returns>An <see cref="T:System.Collections.ICollection"></see> object containing the keys of the <see cref="T:System.Collections.IDictionary"></see> object.</returns>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.AbstractDictionaryAdapter.Remove(System.Object)">
+            <summary>
+            Removes the element with the specified key from the <see cref="T:System.Collections.IDictionary"></see> object.
+            </summary>
+            <param name="key">The key of the element to remove.</param>
+            <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.IDictionary"></see> object is read-only.-or- The <see cref="T:System.Collections.IDictionary"></see> has a fixed size. </exception>
+            <exception cref="T:System.ArgumentNullException">key is null. </exception>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.AbstractDictionaryAdapter.Values">
+            <summary>
+            Gets an <see cref="T:System.Collections.ICollection"></see> object containing the values in the <see cref="T:System.Collections.IDictionary"></see> object.
+            </summary>
+            <returns>An <see cref="T:System.Collections.ICollection"></see> object containing the values in the <see cref="T:System.Collections.IDictionary"></see> object.</returns>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.AbstractDictionaryAdapter.Item(System.Object)">
+            <summary>
+            Gets or sets the <see cref="T:System.Object"/> with the specified key.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.AbstractDictionaryAdapter.CopyTo(System.Array,System.Int32)">
+            <summary>
+            Copies the elements of the <see cref="T:System.Collections.ICollection"></see> to an <see cref="T:System.Array"></see>, starting at a particular <see cref="T:System.Array"></see> index.
+            </summary>
+            <param name="array">The one-dimensional <see cref="T:System.Array"></see> that is the destination of the elements copied from <see cref="T:System.Collections.ICollection"></see>. The <see cref="T:System.Array"></see> must have zero-based indexing.</param>
+            <param name="index">The zero-based index in array at which copying begins.</param>
+            <exception cref="T:System.ArgumentNullException">array is null. </exception>
+            <exception cref="T:System.ArgumentException">The type of the source <see cref="T:System.Collections.ICollection"></see> cannot be cast automatically to the type of the destination array. </exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">index is less than zero. </exception>
+            <exception cref="T:System.ArgumentException">array is multidimensional.-or- index is equal to or greater than the length of array.-or- The number of elements in the source <see cref="T:System.Collections.ICollection"></see> is greater than the available space from index to the end of the destination array. </exception>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.AbstractDictionaryAdapter.Count">
+            <summary>
+            Gets the number of elements contained in the <see cref="T:System.Collections.ICollection"></see>.
+            </summary>
+            <returns>The number of elements contained in the <see cref="T:System.Collections.ICollection"></see>.</returns>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.AbstractDictionaryAdapter.IsSynchronized">
+            <summary>
+            Gets a value indicating whether access to the <see cref="T:System.Collections.ICollection"></see> is synchronized (thread safe).
+            </summary>
+            <returns>true if access to the <see cref="T:System.Collections.ICollection"></see> is synchronized (thread safe); otherwise, false.</returns>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.AbstractDictionaryAdapter.SyncRoot">
+            <summary>
+            Gets an object that can be used to synchronize access to the <see cref="T:System.Collections.ICollection"></see>.
+            </summary>
+            <returns>An object that can be used to synchronize access to the <see cref="T:System.Collections.ICollection"></see>.</returns>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.AbstractDictionaryAdapter.System#Collections#IEnumerable#GetEnumerator">
+            <summary>
+            Returns an enumerator that iterates through a collection.
+            </summary>
+            <returns>
+            An <see cref="T:System.Collections.IEnumerator"></see> object that can be used to iterate through the collection.
+            </returns>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.AbstractDictionaryAdapterVisitor">
+            <summary>
+            Abstract implementation of <see cref="T:Castle.Components.DictionaryAdapter.IDictionaryAdapterVisitor"/>.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.ComponentAttribute">
+            <summary>
+            Identifies a property should be represented as a nested component.
+            </summary>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.ComponentAttribute.NoPrefix">
+            <summary>
+            Applies no prefix.
+            </summary>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.ComponentAttribute.Prefix">
+            <summary>
+            Gets or sets the prefix.
+            </summary>
+            <value>The prefix.</value>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.DictionaryAdapterAttribute">
+            <summary>
+            Identifies the dictionary adapter types.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.DictionaryBehaviorAttribute">
+            <summary>
+            Assigns a specific dictionary key.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.FetchAttribute">
+            <summary>
+            Identifies an interface or property to be pre-fetched.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.FetchAttribute.#ctor">
+            <summary>
+            Instructs fetching to occur.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.FetchAttribute.#ctor(System.Boolean)">
+            <summary>
+            Instructs fetching according to <paramref name="fetch"/>
+            </summary>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.FetchAttribute.Fetch">
+            <summary>
+            Gets whether or not fetching should occur.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.GroupAttribute">
+            <summary>
+            Assigns a property to a group.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.GroupAttribute.#ctor(System.Object)">
+            <summary>
+            Constructs a group assignment.
+            </summary>
+            <param name="group">The group name.</param>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.GroupAttribute.#ctor(System.Object[])">
+            <summary>
+            Constructs a group assignment.
+            </summary>
+            <param name="group">The group name.</param>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.GroupAttribute.Group">
+            <summary>
+            Gets the group the property is assigned to.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.IfExistsAttribute">
+            <summary>
+            Suppresses any on-demand behaviors.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.KeyAttribute">
+            <summary>
+            Assigns a specific dictionary key.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.KeyAttribute.#ctor(System.String)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Castle.Components.DictionaryAdapter.KeyAttribute"/> class.
+            </summary>
+            <param name="key">The key.</param>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.KeyAttribute.#ctor(System.String[])">
+            <summary>
+            Initializes a new instance of the <see cref="T:Castle.Components.DictionaryAdapter.KeyAttribute"/> class.
+            </summary>
+            <param name="keys">The compound key.</param>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.KeyPrefixAttribute">
+            <summary>
+            Assigns a prefix to the keyed properties of an interface.
+            </summary>
+            <remarks>
+            Key prefixes are not inherited by sub-interfaces.
+            </remarks>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.KeyPrefixAttribute.#ctor">
+            <summary>
+            Initializes a default instance of the <see cref="T:Castle.Components.DictionaryAdapter.KeyPrefixAttribute"/> class.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.KeyPrefixAttribute.#ctor(System.String)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Castle.Components.DictionaryAdapter.KeyPrefixAttribute"/> class.
+            </summary>
+            <param name="keyPrefix">The prefix for the keyed properties of the interface.</param>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.KeyPrefixAttribute.KeyPrefix">
+            <summary>
+            Gets the prefix key added to the properties of the interface.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.KeySubstitutionAttribute">
+            <summary>
+            Substitutes part of key with another string.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.KeySubstitutionAttribute.#ctor(System.String,System.String)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Castle.Components.DictionaryAdapter.KeySubstitutionAttribute"/> class.
+            </summary>
+            <param name="oldValue">The old value.</param>
+            <param name="newValue">The new value.</param>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.MultiLevelEditAttribute">
+            <summary>
+            Requests support for multi-level editing.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.NewGuidAttribute">
+            <summary>
+            Generates a new GUID on demand.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.OnDemandAttribute">
+            <summary>
+            Support for on-demand value resolution.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.ReferenceAttribute">
+            <summary>
+            Specifies assignment by reference rather than by copying.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.RemoveIfAttribute">
+            <summary>
+            Removes a property if matches value.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.RemoveIfEmptyAttribute">
+            <summary>
+            Removes a property if null or empty string, guid or collection.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.StringFormatAttribute">
+            <summary>
+            Provides simple string formatting from existing properties.
+            </summary>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.StringFormatAttribute.Format">
+            <summary>
+            Gets the string format.
+            </summary>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.StringFormatAttribute.Properties">
+            <summary>
+            Gets the format properties.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.StringListAttribute">
+            <summary>
+            Identifies a property should be represented as a delimited string value.
+            </summary>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.StringListAttribute.Separator">
+            <summary>
+            Gets the separator.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.StringValuesAttribute">
+            <summary>
+            Converts all properties to strings.
+            </summary>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.StringValuesAttribute.Format">
+            <summary>
+            Gets or sets the format.
+            </summary>
+            <value>The format.</value>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.SuppressNotificationsAttribute">
+            <summary>
+            Suppress property change notifications.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.TypeKeyPrefixAttribute">
+            <summary>
+            Assigns a prefix to the keyed properties using the interface name.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.VolatileAttribute">
+            <summary>
+            Indicates that underlying values are changeable and should not be cached.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.Xml.XmlAdapter.#ctor(Castle.Components.DictionaryAdapter.Xml.IXmlNode,Castle.Components.DictionaryAdapter.Xml.XmlReferenceManager)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Castle.Components.DictionaryAdapter.Xml.XmlAdapter"/> class
+            that represents a child object in a larger object graph.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.DefaultPropertyGetter">
+            <summary>
+            Manages conversion between property values.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.DefaultPropertyGetter.#ctor(System.ComponentModel.TypeConverter)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Castle.Components.DictionaryAdapter.DefaultPropertyGetter"/> class.
+            </summary>
+            <param name="converter">The converter.</param>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.DefaultPropertyGetter.ExecutionOrder">
+            <summary>
+            
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.DefaultPropertyGetter.GetPropertyValue(Castle.Components.DictionaryAdapter.IDictionaryAdapter,System.String,System.Object,Castle.Components.DictionaryAdapter.PropertyDescriptor,System.Boolean)">
+            <summary>
+            Gets the effective dictionary value.
+            </summary>
+            <param name="dictionaryAdapter">The dictionary adapter.</param>
+            <param name="key">The key.</param>
+            <param name="storedValue">The stored value.</param>
+            <param name="property">The property.</param>
+            <param name="ifExists">true if return only existing.</param>
+            <returns>The effective property value.</returns>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.DictionaryAdapterFactory">
+            <summary>
+            Uses Reflection.Emit to expose the properties of a dictionary
+            through a dynamic implementation of a typed interface.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.DictionaryAdapterFactory.GetAdapter``1(System.Collections.IDictionary)">
+            <inheritdoc />
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.DictionaryAdapterFactory.GetAdapter(System.Type,System.Collections.IDictionary)">
+            <inheritdoc />
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.DictionaryAdapterFactory.GetAdapter(System.Type,System.Collections.IDictionary,Castle.Components.DictionaryAdapter.PropertyDescriptor)">
+            <inheritdoc />
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.DictionaryAdapterFactory.GetAdapter``2(System.Collections.Generic.IDictionary{System.String,``1})">
+            <inheritdoc />
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.DictionaryAdapterFactory.GetAdapter``1(System.Type,System.Collections.Generic.IDictionary{System.String,``0})">
+            <inheritdoc />
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.DictionaryAdapterFactory.GetAdapter``1(System.Collections.Specialized.NameValueCollection)">
+            <inheritdoc />
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.DictionaryAdapterFactory.GetAdapter(System.Type,System.Collections.Specialized.NameValueCollection)">
+            <inheritdoc />
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.DictionaryAdapterFactory.GetAdapter``1(System.Xml.XmlNode)">
+            <inheritdoc />
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.DictionaryAdapterFactory.GetAdapter(System.Type,System.Xml.XmlNode)">
+            <inheritdoc />
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.DictionaryAdapterFactory.GetAdapterMeta(System.Type)">
+            <inheritdoc />
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.DictionaryAdapterFactory.GetAdapterMeta(System.Type,Castle.Components.DictionaryAdapter.PropertyDescriptor)">
+            <inheritdoc />
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.DictionaryAdapterFactory.GetAdapterMeta(System.Type,Castle.Components.DictionaryAdapter.DictionaryAdapterMeta)">
+            <inheritdoc />
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.DynamicDictionary">
+            <summary>
+            Wraps a <see cref="T:System.Collections.IDictionary"/> with a dynamic object to expose a bit better looking API.
+            The implementation is trivial and assumes keys are <see cref="T:System.String"/>s.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.IDictionaryAdapter">
+            <summary>
+            Contract for manipulating the Dictionary adapter.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.IDictionaryAdapterFactory">
+            <summary>
+            Defines the contract for building typed dictionary adapters.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryAdapterFactory.GetAdapter``1(System.Collections.IDictionary)">
+            <summary>
+            Gets a typed adapter bound to the <see cref="T:System.Collections.IDictionary"/>.
+            </summary>
+            <typeparam name="T">The typed interface.</typeparam>
+            <param name="dictionary">The underlying source of properties.</param>
+            <returns>An implementation of the typed interface bound to the dictionary.</returns>
+            <remarks>
+            The type represented by T must be an interface with properties.
+            </remarks>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryAdapterFactory.GetAdapter(System.Type,System.Collections.IDictionary)">
+            <summary>
+            Gets a typed adapter bound to the <see cref="T:System.Collections.IDictionary"/>.
+            </summary>
+            <param name="type">The typed interface.</param>
+            <param name="dictionary">The underlying source of properties.</param>
+            <returns>An implementation of the typed interface bound to the dictionary.</returns>
+            <remarks>
+            The type represented by T must be an interface with properties.
+            </remarks>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryAdapterFactory.GetAdapter(System.Type,System.Collections.IDictionary,Castle.Components.DictionaryAdapter.PropertyDescriptor)">
+            <summary>
+            Gets a typed adapter bound to the <see cref="T:System.Collections.IDictionary"/>.
+            </summary>
+            <param name="type">The typed interface.</param>
+            <param name="dictionary">The underlying source of properties.</param>
+            <param name="descriptor">The property descriptor.</param>
+            <returns>An implementation of the typed interface bound to the dictionary.</returns>
+            <remarks>
+            The type represented by T must be an interface with properties.
+            </remarks>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryAdapterFactory.GetAdapter``1(System.Collections.Specialized.NameValueCollection)">
+            <summary>
+            Gets a typed adapter bound to the <see cref="T:System.Collections.Specialized.NameValueCollection"/>.
+            </summary>
+            <typeparam name="T">The typed interface.</typeparam>
+            <param name="nameValues">The underlying source of properties.</param>
+            <returns>An implementation of the typed interface bound to the namedValues.</returns>
+            <remarks>
+            The type represented by T must be an interface with properties.
+            </remarks>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryAdapterFactory.GetAdapter(System.Type,System.Collections.Specialized.NameValueCollection)">
+            <summary>
+            Gets a typed adapter bound to the <see cref="T:System.Collections.Specialized.NameValueCollection"/>.
+            </summary>
+            <param name="type">The typed interface.</param>
+            <param name="nameValues">The underlying source of properties.</param>
+            <returns>An implementation of the typed interface bound to the namedValues.</returns>
+            <remarks>
+            The type represented by T must be an interface with properties.
+            </remarks>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryAdapterFactory.GetAdapter``1(System.Xml.XmlNode)">
+            <summary>
+            Gets a typed adapter bound to the <see cref="T:System.Xml.XmlNode"/>.
+            </summary>
+            <typeparam name="T">The typed interface.</typeparam>
+            <param name="xmlNode">The underlying source of properties.</param>
+            <returns>An implementation of the typed interface bound to the <see cref="T:System.Xml.XmlNode"/>.</returns>
+            <remarks>
+            The type represented by T must be an interface with properties.
+            </remarks>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryAdapterFactory.GetAdapter(System.Type,System.Xml.XmlNode)">
+            <summary>
+            Gets a typed adapter bound to the <see cref="T:System.Xml.XmlNode"/>.
+            </summary>
+            <param name="type">The typed interface.</param>
+            <param name="xmlNode">The underlying source of properties.</param>
+            <returns>An implementation of the typed interface bound to the <see cref="T:System.Xml.XmlNode"/>.</returns>
+            <remarks>
+            The type represented by T must be an interface with properties.
+            </remarks>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryAdapterFactory.GetAdapterMeta(System.Type)">
+            <summary>
+            Gets the <see cref="T:Castle.Components.DictionaryAdapter.DictionaryAdapterMeta"/> associated with the type.
+            </summary>
+            <param name="type">The typed interface.</param>
+            <returns>The adapter meta-data.</returns>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryAdapterFactory.GetAdapterMeta(System.Type,Castle.Components.DictionaryAdapter.PropertyDescriptor)">
+            <summary>
+            Gets the <see cref="T:Castle.Components.DictionaryAdapter.DictionaryAdapterMeta"/> associated with the type.
+            </summary>
+            <param name="type">The typed interface.</param>
+            <param name="descriptor">The property descriptor.</param>
+            <returns>The adapter meta-data.</returns>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryAdapterFactory.GetAdapterMeta(System.Type,Castle.Components.DictionaryAdapter.DictionaryAdapterMeta)">
+            <summary>
+            Gets the <see cref="T:Castle.Components.DictionaryAdapter.DictionaryAdapterMeta"/> associated with the type.
+            </summary>
+            <param name="type">The typed interface.</param>
+            <param name="other">Another <see cref="T:Castle.Components.DictionaryAdapter.DictionaryAdapterMeta"/> from which to copy behaviors.</param>
+            <returns>The adapter meta-data.</returns>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.IDictionaryAdapterVisitor">
+            <summary>
+            Contract for traversing a <see cref="T:Castle.Components.DictionaryAdapter.IDictionaryAdapter"/>.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.IDictionaryBehavior">
+            <summary>
+            Defines the contract for customizing dictionary access.
+            </summary>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.IDictionaryBehavior.ExecutionOrder">
+            <summary>
+            Determines relative order to apply related behaviors.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryBehavior.Copy">
+            <summary>
+            Copies the dictionary behavior.
+            </summary>
+            <returns>null if should not be copied.  Otherwise copy.</returns>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.IDictionaryBehaviorBuilder">
+            <summary>
+            Defines the contract for building <see cref="T:Castle.Components.DictionaryAdapter.IDictionaryBehavior"/>s.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryBehaviorBuilder.BuildBehaviors">
+            <summary>
+            Builds the dictionary behaviors.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.IDictionaryCreate">
+            <summary>
+            Contract for creating additional Dictionary adapters.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.IDictionaryEdit">
+            <summary>
+            Contract for editing the Dictionary adapter.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.IDictionaryInitializer">
+            <summary>
+             Contract for dictionary initialization.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryInitializer.Initialize(Castle.Components.DictionaryAdapter.IDictionaryAdapter,System.Object[])">
+            <summary>
+            Performs any initialization of the <see cref="T:Castle.Components.DictionaryAdapter.IDictionaryAdapter"/>
+            </summary>
+            <param name="dictionaryAdapter">The dictionary adapter.</param>
+            <param name="behaviors">The dictionary behaviors.</param>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.IDictionaryKeyBuilder">
+            <summary>
+            Defines the contract for building typed dictionary keys.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryKeyBuilder.GetKey(Castle.Components.DictionaryAdapter.IDictionaryAdapter,System.String,Castle.Components.DictionaryAdapter.PropertyDescriptor)">
+            <summary>
+            Builds the specified key.
+            </summary>
+            <param name="dictionaryAdapter">The dictionary adapter.</param>
+            <param name="key">The current key.</param>
+            <param name="property">The property.</param>
+            <returns>The updated key</returns>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.IDictionaryMetaInitializer">
+            <summary>
+             Contract for dictionary meta-data initialization.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryMetaInitializer.Initialize(Castle.Components.DictionaryAdapter.IDictionaryAdapterFactory,Castle.Components.DictionaryAdapter.DictionaryAdapterMeta)">
+            <summary>
+            	Initializes the given <see cref="T:Castle.Components.DictionaryAdapter.DictionaryAdapterMeta"/> object.
+            </summary>
+            <param name="factory">The dictionary adapter factory.</param>
+            <param name="dictionaryMeta">The dictionary adapter meta.</param>
+            
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryMetaInitializer.ShouldHaveBehavior(System.Object)">
+            <summary>
+            	Determines whether the given behavior should be included in a new
+            	<see cref="T:Castle.Components.DictionaryAdapter.DictionaryAdapterMeta"/> object.
+            </summary>
+            <param name="behavior">A dictionary behavior or annotation.</param>
+            <returns>True if the behavior should be included; otherwise, false.</returns>
+            <remarks>
+            	<see cref="T:Castle.Components.DictionaryAdapter.IDictionaryMetaInitializer"/> behaviors are always included,
+            	regardless of the result of this method.
+            </remarks>
+            
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.IDictionaryNotify">
+            <summary>
+            Contract for managing Dictionary adapter notifications.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.IDictionaryPropertyGetter">
+            <summary>
+            Defines the contract for retrieving dictionary values.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryPropertyGetter.GetPropertyValue(Castle.Components.DictionaryAdapter.IDictionaryAdapter,System.String,System.Object,Castle.Components.DictionaryAdapter.PropertyDescriptor,System.Boolean)">
+            <summary>
+            Gets the effective dictionary value.
+            </summary>
+            <param name="dictionaryAdapter">The dictionary adapter.</param>
+            <param name="key">The key.</param>
+            <param name="storedValue">The stored value.</param>
+            <param name="property">The property.</param>
+            <param name="ifExists">true if return only existing.</param>
+            <returns>The effective property value.</returns>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.IDictionaryPropertySetter">
+            <summary>
+            Defines the contract for updating dictionary values.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryPropertySetter.SetPropertyValue(Castle.Components.DictionaryAdapter.IDictionaryAdapter,System.String,System.Object@,Castle.Components.DictionaryAdapter.PropertyDescriptor)">
+            <summary>
+            Sets the stored dictionary value.
+            </summary>
+            <param name="dictionaryAdapter">The dictionary adapter.</param>
+            <param name="key">The key.</param>
+            <param name="value">The stored value.</param>
+            <param name="property">The property.</param>
+            <returns>true if the property should be stored.</returns>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.IDictionaryValidate">
+            <summary>
+            Contract for validating Dictionary adapter.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.IDictionaryValidator">
+            <summary>
+            Contract for dictionary validation.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryValidator.IsValid(Castle.Components.DictionaryAdapter.IDictionaryAdapter)">
+            <summary>
+            Determines if <see cref="T:Castle.Components.DictionaryAdapter.IDictionaryAdapter"/> is valid.
+            </summary>
+            <param name="dictionaryAdapter">The dictionary adapter.</param>
+            <returns>true if valid.</returns>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryValidator.Validate(Castle.Components.DictionaryAdapter.IDictionaryAdapter)">
+            <summary>
+            Validates the <see cref="T:Castle.Components.DictionaryAdapter.IDictionaryAdapter"/>.
+            </summary>
+            <param name="dictionaryAdapter">The dictionary adapter.</param>
+            <returns>The error summary information.</returns>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryValidator.Validate(Castle.Components.DictionaryAdapter.IDictionaryAdapter,Castle.Components.DictionaryAdapter.PropertyDescriptor)">
+            <summary>
+            Validates the <see cref="T:Castle.Components.DictionaryAdapter.IDictionaryAdapter"/> for a property.
+            </summary>
+            <param name="dictionaryAdapter">The dictionary adapter.</param>
+            <param name="property">The property to validate.</param>
+            <returns>The property summary information.</returns>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IDictionaryValidator.Invalidate(Castle.Components.DictionaryAdapter.IDictionaryAdapter)">
+            <summary>
+            Invalidates any results cached by the validator.
+            </summary>
+            <param name="dictionaryAdapter">The dictionary adapter.</param>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.IPropertyDescriptorInitializer">
+            <summary>
+             Contract for property descriptor initialization.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.IPropertyDescriptorInitializer.Initialize(Castle.Components.DictionaryAdapter.PropertyDescriptor,System.Object[])">
+            <summary>
+            Performs any initialization of the <see cref="T:Castle.Components.DictionaryAdapter.PropertyDescriptor"/>
+            </summary>
+            <param name="propertyDescriptor">The property descriptor.</param>
+            <param name="behaviors">The property behaviors.</param>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.NameValueCollectionAdapter">
+            <summary>
+            
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.NameValueCollectionAdapter.#ctor(System.Collections.Specialized.NameValueCollection)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Castle.Components.DictionaryAdapter.NameValueCollectionAdapter"/> class.
+            </summary>
+            <param name="nameValues">The name values.</param>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.NameValueCollectionAdapter.IsReadOnly">
+            <summary>
+            Gets a value indicating whether the <see cref="T:System.Collections.IDictionary"></see> object is read-only.
+            </summary>
+            <returns>true if the <see cref="T:System.Collections.IDictionary"></see> object is read-only; otherwise, false.</returns>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.NameValueCollectionAdapter.Contains(System.Object)">
+            <summary>
+            Determines whether the <see cref="T:System.Collections.IDictionary"></see> object contains an element with the specified key.
+            </summary>
+            <param name="key">The key to locate in the <see cref="T:System.Collections.IDictionary"></see> object.</param>
+            <returns>
+            true if the <see cref="T:System.Collections.IDictionary"></see> contains an element with the key; otherwise, false.
+            </returns>
+            <exception cref="T:System.ArgumentNullException">key is null. </exception>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.NameValueCollectionAdapter.Item(System.Object)">
+            <summary>
+            Gets or sets the <see cref="T:System.Object"/> with the specified key.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.NameValueCollectionAdapter.Adapt(System.Collections.Specialized.NameValueCollection)">
+            <summary>
+            Adapts the specified name values.
+            </summary>
+            <param name="nameValues">The name values.</param>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.PropertyDescriptor">
+            <summary>
+            Describes a dictionary property.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.PropertyDescriptor.#ctor">
+            <summary>
+            Initializes an empty <see cref="T:Castle.Components.DictionaryAdapter.PropertyDescriptor"/> class.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.PropertyDescriptor.#ctor(System.Reflection.PropertyInfo,System.Object[])">
+            <summary>
+            Initializes a new instance of the <see cref="T:Castle.Components.DictionaryAdapter.PropertyDescriptor"/> class.
+            </summary>
+            <param name="property">The property.</param>
+            <param name="annotations">The annotations.</param>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.PropertyDescriptor.#ctor(System.Object[])">
+            <summary>
+            Initializes a new instance <see cref="T:Castle.Components.DictionaryAdapter.PropertyDescriptor"/> class.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.PropertyDescriptor.#ctor(Castle.Components.DictionaryAdapter.PropertyDescriptor,System.Boolean)">
+            <summary>
+             Copies an existing instance of the <see cref="T:Castle.Components.DictionaryAdapter.PropertyDescriptor"/> class.
+            </summary>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.PropertyDescriptor.ExecutionOrder">
+            <summary>
+            
+            </summary>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.PropertyDescriptor.PropertyName">
+            <summary>
+            Gets the property name.
+            </summary>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.PropertyDescriptor.PropertyType">
+            <summary>
+            Gets the property type.
+            </summary>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.PropertyDescriptor.Property">
+            <summary>
+            Gets the property.
+            </summary>
+            <value>The property.</value>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.PropertyDescriptor.IsDynamicProperty">
+            <summary>
+            Returns true if the property is dynamic.
+            </summary>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.PropertyDescriptor.State">
+            <summary>
+            Gets additional state.
+            </summary>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.PropertyDescriptor.Fetch">
+            <summary>
+            Determines if property should be fetched.
+            </summary>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.PropertyDescriptor.IfExists">
+            <summary>
+            Determines if property must exist first.
+            </summary>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.PropertyDescriptor.SuppressNotifications">
+            <summary>
+            Determines if notifications should occur.
+            </summary>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.PropertyDescriptor.Annotations">
+            <summary>
+            Gets the property behaviors.
+            </summary>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.PropertyDescriptor.TypeConverter">
+            <summary>
+            Gets the type converter.
+            </summary>
+            <value>The type converter.</value>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.PropertyDescriptor.ExtendedProperties">
+            <summary>
+            Gets the extended properties.
+            </summary>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.PropertyDescriptor.Behaviors">
+            <summary>
+            Gets the setter.
+            </summary>
+            <value>The setter.</value>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.PropertyDescriptor.KeyBuilders">
+            <summary>
+            Gets the key builders.
+            </summary>
+            <value>The key builders.</value>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.PropertyDescriptor.Setters">
+            <summary>
+            Gets the setter.
+            </summary>
+            <value>The setter.</value>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.PropertyDescriptor.Getters">
+            <summary>
+            Gets the getter.
+            </summary>
+            <value>The getter.</value>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.PropertyDescriptor.Initializers">
+            <summary>
+            Gets the initializers.
+            </summary>
+            <value>The initializers.</value>
+        </member>
+        <member name="P:Castle.Components.DictionaryAdapter.PropertyDescriptor.MetaInitializers">
+            <summary>
+            Gets the meta-data initializers.
+            </summary>
+            <value>The meta-data initializers.</value>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.PropertyDescriptor.GetKey(Castle.Components.DictionaryAdapter.IDictionaryAdapter,System.String,Castle.Components.DictionaryAdapter.PropertyDescriptor)">
+            <summary>
+            Gets the key.
+            </summary>
+            <param name="dictionaryAdapter">The dictionary adapter.</param>
+            <param name="key">The key.</param>
+            <param name="descriptor">The descriptor.</param>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.PropertyDescriptor.GetPropertyValue(Castle.Components.DictionaryAdapter.IDictionaryAdapter,System.String,System.Object,Castle.Components.DictionaryAdapter.PropertyDescriptor,System.Boolean)">
+            <summary>
+            Gets the property value.
+            </summary>
+            <param name="dictionaryAdapter">The dictionary adapter.</param>
+            <param name="key">The key.</param>
+            <param name="storedValue">The stored value.</param>
+            <param name="descriptor">The descriptor.</param>
+            <param name="ifExists">true if return only existing.</param>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.PropertyDescriptor.SetPropertyValue(Castle.Components.DictionaryAdapter.IDictionaryAdapter,System.String,System.Object@,Castle.Components.DictionaryAdapter.PropertyDescriptor)">
+            <summary>
+            Sets the property value.
+            </summary>
+            <param name="dictionaryAdapter">The dictionary adapter.</param>
+            <param name="key">The key.</param>
+            <param name="value">The value.</param>
+            <param name="descriptor">The descriptor.</param>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.PropertyDescriptor.AddBehavior(Castle.Components.DictionaryAdapter.IDictionaryBehavior)">
+            <summary>
+            Adds a single behavior.
+            </summary>
+            <param name="behavior">The behavior.</param>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.PropertyDescriptor.AddBehaviors(Castle.Components.DictionaryAdapter.IDictionaryBehavior[])">
+            <summary>
+            Adds the behaviors.
+            </summary>
+            <param name="behaviors">The behaviors.</param>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.PropertyDescriptor.AddBehaviors(System.Collections.Generic.IEnumerable{Castle.Components.DictionaryAdapter.IDictionaryBehavior})">
+            <summary>
+            Adds the behaviors.
+            </summary>
+            <param name="behaviors">The behaviors.</param>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.PropertyDescriptor.CopyBehaviors(Castle.Components.DictionaryAdapter.PropertyDescriptor)">
+            <summary>
+            Copies the behaviors to the other <see cref="T:Castle.Components.DictionaryAdapter.PropertyDescriptor"/>
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.PropertyDescriptor.Copy">
+            <summary>
+            Copies the <see cref="T:Castle.Components.DictionaryAdapter.PropertyDescriptor"/>
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.BindingList`1">
+            <summary>
+              Provides a generic collection that supports data binding.
+            </summary>
+            <remarks>
+              This class wraps the CLR <see cref="T:System.ComponentModel.BindingList`1"/>
+              in order to implement the Castle-specific <see cref="T:Castle.Components.DictionaryAdapter.IBindingList`1"/>.
+            </remarks>
+            <typeparam name="T">The type of elements in the list.</typeparam>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.BindingList`1.#ctor">
+            <summary>
+              Initializes a new instance of the <see cref="T:Castle.Components.DictionaryAdapter.BindingList`1"/> class
+              using default values.
+            </summary>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.BindingList`1.#ctor(System.Collections.Generic.IList{`0})">
+            <summary>
+              Initializes a new instance of the <see cref="T:Castle.Components.DictionaryAdapter.BindingList`1"/> class
+              with the specified list.
+            </summary>
+            <param name="list">
+              An <see cref="T:System.Collections.Generic.IList`1"/> of items
+              to be contained in the <see cref="T:Castle.Components.DictionaryAdapter.BindingList`1"/>.
+            </param>
+        </member>
+        <member name="M:Castle.Components.DictionaryAdapter.BindingList`1.#ctor(System.ComponentModel.BindingList{`0})">
+            <summary>
+              Initializes a new instance of the <see cref="T:Castle.Components.DictionaryAdapter.BindingList`1"/> class
+              wrapping the specified <see cref="T:System.ComponentModel.BindingList`1"/> instance.
+            </summary>
+            <param name="list">
+              A <see cref="T:System.ComponentModel.BindingList`1"/>
+              to be wrapped by the <see cref="T:Castle.Components.DictionaryAdapter.BindingList`1"/>.
+            </param>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.ICondition">
+            <summary>
+            Contract for value matching.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.IDynamicValue">
+            <summary>
+            Contract for dynamic value resolution.
+            </summary>
+        </member>
+        <member name="T:Castle.Components.DictionaryAdapter.IDynamicValue`1">
+            <summary>
+            Contract for typed dynamic value resolution.
+            </summary>
+            <typeparam name="T"></typeparam>
+        </member>
+        <member name="T:Castle.Core.Configuration.AbstractConfiguration">
+            <summary>
+              This is an abstract <see cref = "T:Castle.Core.Configuration.IConfiguration" /> implementation
+              that deals with methods that can be abstracted away
+              from underlying implementations.
+            </summary>
+            <remarks>
+              <para><b>AbstractConfiguration</b> makes easier to implementers 
+                to create a new version of <see cref = "T:Castle.Core.Configuration.IConfiguration" /></para>
+            </remarks>
+        </member>
+        <member name="P:Castle.Core.Configuration.AbstractConfiguration.Attributes">
+            <summary>
+              Gets node attributes.
+            </summary>
+            <value>
+              All attributes of the node.
+            </value>
+        </member>
+        <member name="P:Castle.Core.Configuration.AbstractConfiguration.Children">
+            <summary>
+              Gets all child nodes.
+            </summary>
+            <value>The <see cref = "T:Castle.Core.Configuration.ConfigurationCollection" /> of child nodes.</value>
+        </member>
+        <member name="P:Castle.Core.Configuration.AbstractConfiguration.Name">
+            <summary>
+              Gets the name of the <see cref = "T:Castle.Core.Configuration.IConfiguration" />.
+            </summary>
+            <value>
+              The Name of the <see cref = "T:Castle.Core.Configuration.IConfiguration" />.
+            </value>
+        </member>
+        <member name="P:Castle.Core.Configuration.AbstractConfiguration.Value">
+            <summary>
+              Gets the value of <see cref = "T:Castle.Core.Configuration.IConfiguration" />.
+            </summary>
+            <value>
+              The Value of the <see cref = "T:Castle.Core.Configuration.IConfiguration" />.
+            </value>
+        </member>
+        <member name="M:Castle.Core.Configuration.AbstractConfiguration.GetValue(System.Type,System.Object)">
+            <summary>
+              Gets the value of the node and converts it
+              into specified <see cref = "T:System.Type" />.
+            </summary>
+            <param name = "type">The <see cref = "T:System.Type" /></param>
+            <param name = "defaultValue">
+              The Default value returned if the conversion fails.
+            </param>
+            <returns>The Value converted into the specified type.</returns>
+        </member>
+        <member name="T:Castle.Core.Configuration.ConfigurationCollection">
+            <summary>
+            A collection of <see cref="T:Castle.Core.Configuration.IConfiguration"/> objects.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Configuration.ConfigurationCollection.#ctor">
+            <summary>
+            Creates a new instance of <c>ConfigurationCollection</c>.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Configuration.ConfigurationCollection.#ctor(System.Collections.Generic.IEnumerable{Castle.Core.Configuration.IConfiguration})">
+            <summary>
+            Creates a new instance of <c>ConfigurationCollection</c>.
+            </summary>
+        </member>
+        <member name="T:Castle.Core.Configuration.IConfiguration">
+            <summary>
+            <see cref="T:Castle.Core.Configuration.IConfiguration"/> is a interface encapsulating a configuration node
+            used to retrieve configuration values.
+            </summary>
+        </member>
+        <member name="P:Castle.Core.Configuration.IConfiguration.Name">
+            <summary>
+            Gets the name of the node.
+            </summary>
+            <value>
+            The Name of the node.
+            </value> 
+        </member>
+        <member name="P:Castle.Core.Configuration.IConfiguration.Value">
+            <summary>
+            Gets the value of the node.
+            </summary>
+            <value>
+            The Value of the node.
+            </value> 
+        </member>
+        <member name="P:Castle.Core.Configuration.IConfiguration.Children">
+            <summary>
+            Gets an <see cref="T:Castle.Core.Configuration.ConfigurationCollection"/> of <see cref="T:Castle.Core.Configuration.IConfiguration"/>
+            elements containing all node children.
+            </summary>
+            <value>The Collection of child nodes.</value>
+        </member>
+        <member name="P:Castle.Core.Configuration.IConfiguration.Attributes">
+            <summary>
+            Gets an <see cref="T:System.Collections.IDictionary"/> of the configuration attributes.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Configuration.IConfiguration.GetValue(System.Type,System.Object)">
+            <summary>
+            Gets the value of the node and converts it 
+            into specified <see cref="T:System.Type"/>.
+            </summary>
+            <param name="type">The <see cref="T:System.Type"/></param>
+            <param name="defaultValue">
+            The Default value returned if the conversion fails.
+            </param>
+            <returns>The Value converted into the specified type.</returns>
+        </member>
+        <member name="M:Castle.Core.Configuration.MutableConfiguration.#ctor(System.String)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Castle.Core.Configuration.MutableConfiguration"/> class.
+            </summary>
+            <param name="name">The name.</param>
+        </member>
+        <member name="P:Castle.Core.Configuration.MutableConfiguration.Value">
+            <summary>
+            Gets the value of <see cref="T:Castle.Core.Configuration.IConfiguration"/>.
+            </summary>
+            <value>
+            The Value of the <see cref="T:Castle.Core.Configuration.IConfiguration"/>.
+            </value>
+        </member>
+        <member name="M:Castle.Core.Configuration.Xml.XmlConfigurationDeserializer.Deserialize(System.Xml.XmlNode)">
+            <summary>
+              Deserializes the specified node into an abstract representation of configuration.
+            </summary>
+            <param name = "node">The node.</param>
+        </member>
+        <member name="M:Castle.Core.Configuration.Xml.XmlConfigurationDeserializer.GetConfigValue(System.String)">
+            <summary>
+              If a config value is an empty string we return null, this is to keep
+              backward compatibility with old code
+            </summary>
+        </member>
+        <member name="T:Castle.Core.Internal.AttributesUtil">
+            <summary>
+              Helper class for retrieving attributes.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Internal.AttributesUtil.GetAttribute``1(System.Type)">
+            <summary>
+            Gets the attribute.
+            </summary>
+            <param name="type">The type.</param>
+            <returns>The type attribute.</returns>
+        </member>
+        <member name="M:Castle.Core.Internal.AttributesUtil.GetAttributes``1(System.Type)">
+            <summary>
+            Gets the attributes. Does not consider inherited attributes!
+            </summary>
+            <param name="type">The type.</param>
+            <returns>The type attributes.</returns>
+        </member>
+        <member name="M:Castle.Core.Internal.AttributesUtil.GetAttribute``1(System.Reflection.MemberInfo)">
+            <summary>
+            Gets the attribute.
+            </summary>
+            <param name="member">The member.</param>
+            <returns>The member attribute.</returns>
+        </member>
+        <member name="M:Castle.Core.Internal.AttributesUtil.GetAttributes``1(System.Reflection.MemberInfo)">
+            <summary>
+            Gets the attributes. Does not consider inherited attributes!
+            </summary>
+            <param name="member">The member.</param>
+            <returns>The member attributes.</returns>
+        </member>
+        <member name="M:Castle.Core.Internal.AttributesUtil.GetTypeAttribute``1(System.Type)">
+            <summary>
+              Gets the type attribute.
+            </summary>
+            <param name = "type">The type.</param>
+            <returns>The type attribute.</returns>
+        </member>
+        <member name="M:Castle.Core.Internal.AttributesUtil.GetTypeAttributes``1(System.Type)">
+            <summary>
+              Gets the type attributes.
+            </summary>
+            <param name = "type">The type.</param>
+            <returns>The type attributes.</returns>
+        </member>
+        <member name="M:Castle.Core.Internal.AttributesUtil.GetTypeConverter(System.Reflection.MemberInfo)">
+            <summary>
+            Gets the type converter.
+            </summary>
+            <param name="member">The member.</param>
+        </member>
+        <member name="F:Castle.Core.Internal.InternalsVisible.ToCastleCore">
+            <summary>
+              Constant to use when making assembly internals visible to Castle.Core 
+              <c>[assembly: InternalsVisibleTo(CoreInternalsVisible.ToCastleCore)]</c>
+            </summary>
+        </member>
+        <member name="F:Castle.Core.Internal.InternalsVisible.ToDynamicProxyGenAssembly2">
+            <summary>
+              Constant to use when making assembly internals visible to proxy types generated by DynamicProxy. Required when proxying internal types.
+              <c>[assembly: InternalsVisibleTo(CoreInternalsVisible.ToDynamicProxyGenAssembly2)]</c>
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Internal.TypeExtensions.GetBestName(System.Type)">
+            <summary>
+            Find the best available name to describe a type.
+            </summary>
+            <remarks>
+            Usually the best name will be <see cref="P:System.Type.FullName"/>, but
+            sometimes that's null (see http://msdn.microsoft.com/en-us/library/system.type.fullname%28v=vs.110%29.aspx)
+            in which case the method falls back to <see cref="P:System.Reflection.MemberInfo.Name"/>.
+            </remarks>
+            <param name="type">the type to name</param>
+            <returns>the best name</returns>
+        </member>
+        <member name="T:Castle.Core.IServiceEnabledComponent">
+            <summary>
+            Defines that the implementation wants a 
+            <see cref="T:System.IServiceProvider"/> in order to 
+            access other components. The creator must be aware
+            that the component might (or might not) implement 
+            the interface.
+            </summary>
+            <remarks>
+            Used by Castle Project components to, for example, 
+            gather logging factories
+            </remarks>
+        </member>
+        <member name="T:Castle.Core.IServiceProviderEx">
+            <summary>
+            Increments <c>IServiceProvider</c> with a generic service resolution operation.
+            </summary>
+        </member>
+        <member name="T:Castle.Core.IServiceProviderExAccessor">
+            <summary>
+            This interface should be implemented by classes
+            that are available in a bigger context, exposing
+            the container to different areas in the same application.
+            <para>
+            For example, in Web application, the (global) HttpApplication
+            subclasses should implement this interface to expose 
+            the configured container
+            </para>
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.AbstractExtendedLoggerFactory.Create(System.Type)">
+            <summary>
+              Creates a new extended logger, getting the logger name from the specified type.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.AbstractExtendedLoggerFactory.Create(System.String)">
+            <summary>
+              Creates a new extended logger.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.AbstractExtendedLoggerFactory.Create(System.Type,Castle.Core.Logging.LoggerLevel)">
+            <summary>
+              Creates a new extended logger, getting the logger name from the specified type.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.AbstractExtendedLoggerFactory.Create(System.String,Castle.Core.Logging.LoggerLevel)">
+            <summary>
+              Creates a new extended logger.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.AbstractExtendedLoggerFactory.Castle#Core#Logging#ILoggerFactory#Create(System.Type)">
+            <summary>
+              Creates a new logger, getting the logger name from the specified type.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.AbstractExtendedLoggerFactory.Castle#Core#Logging#ILoggerFactory#Create(System.String)">
+            <summary>
+              Creates a new logger.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.AbstractExtendedLoggerFactory.Castle#Core#Logging#ILoggerFactory#Create(System.Type,Castle.Core.Logging.LoggerLevel)">
+            <summary>
+              Creates a new logger, getting the logger name from the specified type.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.AbstractExtendedLoggerFactory.Castle#Core#Logging#ILoggerFactory#Create(System.String,Castle.Core.Logging.LoggerLevel)">
+            <summary>
+              Creates a new logger.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.AbstractExtendedLoggerFactory.GetConfigFile(System.String)">
+            <summary>
+              Gets the configuration file.
+            </summary>
+            <param name = "fileName">i.e. log4net.config</param>
+        </member>
+        <member name="M:Castle.Core.Logging.AbstractLoggerFactory.GetConfigFile(System.String)">
+            <summary>
+              Gets the configuration file.
+            </summary>
+            <param name = "fileName">i.e. log4net.config</param>
+        </member>
+        <member name="T:Castle.Core.Logging.ConsoleLogger">
+            <summary>
+            The Logger sending everything to the standard output streams.
+            This is mainly for the cases when you have a utility that
+            does not have a logger to supply.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.ConsoleLogger.#ctor">
+            <summary>
+              Creates a new ConsoleLogger with the <c>Level</c>
+              set to <c>LoggerLevel.Debug</c> and the <c>Name</c>
+              set to <c>string.Empty</c>.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.ConsoleLogger.#ctor(Castle.Core.Logging.LoggerLevel)">
+            <summary>
+              Creates a new ConsoleLogger with the <c>Name</c>
+              set to <c>string.Empty</c>.
+            </summary>
+            <param name = "logLevel">The logs Level.</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ConsoleLogger.#ctor(System.String)">
+            <summary>
+              Creates a new ConsoleLogger with the <c>Level</c>
+              set to <c>LoggerLevel.Debug</c>.
+            </summary>
+            <param name = "name">The logs Name.</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ConsoleLogger.#ctor(System.String,Castle.Core.Logging.LoggerLevel)">
+            <summary>
+              Creates a new ConsoleLogger.
+            </summary>
+            <param name = "name">The logs Name.</param>
+            <param name = "logLevel">The logs Level.</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ConsoleLogger.Log(Castle.Core.Logging.LoggerLevel,System.String,System.String,System.Exception)">
+            <summary>
+              A Common method to log.
+            </summary>
+            <param name = "loggerLevel">The level of logging</param>
+            <param name = "loggerName">The name of the logger</param>
+            <param name = "message">The Message</param>
+            <param name = "exception">The Exception</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ConsoleLogger.CreateChildLogger(System.String)">
+            <summary>
+              Returns a new <c>ConsoleLogger</c> with the name
+              added after this loggers name, with a dot in between.
+            </summary>
+            <param name = "loggerName">The added hierarchical name.</param>
+            <returns>A new <c>ConsoleLogger</c>.</returns>
+        </member>
+        <member name="T:Castle.Core.Logging.DiagnosticsLogger">
+            <summary>
+              The Logger using standard Diagnostics namespace.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.DiagnosticsLogger.#ctor(System.String)">
+            <summary>
+              Creates a logger based on <see cref = "T:System.Diagnostics.EventLog" />.
+            </summary>
+            <param name = "logName"><see cref = "P:System.Diagnostics.EventLog.Log" /></param>
+        </member>
+        <member name="M:Castle.Core.Logging.DiagnosticsLogger.#ctor(System.String,System.String)">
+            <summary>
+              Creates a logger based on <see cref = "T:System.Diagnostics.EventLog" />.
+            </summary>
+            <param name = "logName"><see cref = "P:System.Diagnostics.EventLog.Log" /></param>
+            <param name = "source"><see cref = "P:System.Diagnostics.EventLog.Source" /></param>
+        </member>
+        <member name="M:Castle.Core.Logging.DiagnosticsLogger.#ctor(System.String,System.String,System.String)">
+            <summary>
+              Creates a logger based on <see cref = "T:System.Diagnostics.EventLog" />.
+            </summary>
+            <param name = "logName"><see cref = "P:System.Diagnostics.EventLog.Log" /></param>
+            <param name = "machineName"><see cref = "P:System.Diagnostics.EventLog.MachineName" /></param>
+            <param name = "source"><see cref = "P:System.Diagnostics.EventLog.Source" /></param>
+        </member>
+        <member name="T:Castle.Core.Logging.IContextProperties">
+            <summary>
+              Interface for Context Properties implementations
+            </summary>
+            <remarks>
+              <para>
+                This interface defines a basic property get set accessor.
+              </para>
+              <para>
+                Based on the ContextPropertiesBase of log4net, by Nicko Cadell.
+              </para>
+            </remarks>
+        </member>
+        <member name="P:Castle.Core.Logging.IContextProperties.Item(System.String)">
+            <summary>
+              Gets or sets the value of a property
+            </summary>
+            <value>
+              The value for the property with the specified key
+            </value>
+            <remarks>
+              <para>
+                Gets or sets the value of a property
+              </para>
+            </remarks>
+        </member>
+        <member name="T:Castle.Core.Logging.IExtendedLogger">
+            <summary>
+              Provides an interface that supports <see cref = "T:Castle.Core.Logging.ILogger" /> and
+              allows the storage and retrieval of Contexts. These are supported in
+              both log4net and NLog.
+            </summary>
+        </member>
+        <member name="P:Castle.Core.Logging.IExtendedLogger.GlobalProperties">
+            <summary>
+              Exposes the Global Context of the extended logger.
+            </summary>
+        </member>
+        <member name="P:Castle.Core.Logging.IExtendedLogger.ThreadProperties">
+            <summary>
+              Exposes the Thread Context of the extended logger.
+            </summary>
+        </member>
+        <member name="P:Castle.Core.Logging.IExtendedLogger.ThreadStacks">
+            <summary>
+              Exposes the Thread Stack of the extended logger.
+            </summary>
+        </member>
+        <member name="T:Castle.Core.Logging.IExtendedLoggerFactory">
+            <summary>
+              Provides a factory that can produce either <see cref = "T:Castle.Core.Logging.ILogger" /> or
+              <see cref = "T:Castle.Core.Logging.IExtendedLogger" /> classes.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.IExtendedLoggerFactory.Create(System.Type)">
+            <summary>
+              Creates a new extended logger, getting the logger name from the specified type.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.IExtendedLoggerFactory.Create(System.String)">
+            <summary>
+              Creates a new extended logger.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.IExtendedLoggerFactory.Create(System.Type,Castle.Core.Logging.LoggerLevel)">
+            <summary>
+              Creates a new extended logger, getting the logger name from the specified type.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.IExtendedLoggerFactory.Create(System.String,Castle.Core.Logging.LoggerLevel)">
+            <summary>
+              Creates a new extended logger.
+            </summary>
+        </member>
+        <member name="T:Castle.Core.Logging.ILogger">
+            <summary>
+              Manages logging.
+            </summary>
+            <remarks>
+              This is a facade for the different logging subsystems.
+              It offers a simplified interface that follows IOC patterns
+              and a simplified priority/level/severity abstraction.
+            </remarks>
+        </member>
+        <member name="P:Castle.Core.Logging.ILogger.IsTraceEnabled">
+            <summary>
+              Determines if messages of priority "trace" will be logged.
+            </summary>
+            <value>True if "trace" messages will be logged.</value>
+        </member>
+        <member name="P:Castle.Core.Logging.ILogger.IsDebugEnabled">
+            <summary>
+              Determines if messages of priority "debug" will be logged.
+            </summary>
+            <value>True if "debug" messages will be logged.</value>
+        </member>
+        <member name="P:Castle.Core.Logging.ILogger.IsErrorEnabled">
+            <summary>
+              Determines if messages of priority "error" will be logged.
+            </summary>
+            <value>True if "error" messages will be logged.</value>
+        </member>
+        <member name="P:Castle.Core.Logging.ILogger.IsFatalEnabled">
+            <summary>
+              Determines if messages of priority "fatal" will be logged.
+            </summary>
+            <value>True if "fatal" messages will be logged.</value>
+        </member>
+        <member name="P:Castle.Core.Logging.ILogger.IsInfoEnabled">
+            <summary>
+              Determines if messages of priority "info" will be logged.
+            </summary>
+            <value>True if "info" messages will be logged.</value>
+        </member>
+        <member name="P:Castle.Core.Logging.ILogger.IsWarnEnabled">
+            <summary>
+              Determines if messages of priority "warn" will be logged.
+            </summary>
+            <value>True if "warn" messages will be logged.</value>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.CreateChildLogger(System.String)">
+            <summary>
+              Create a new child logger.
+              The name of the child logger is [current-loggers-name].[passed-in-name]
+            </summary>
+            <param name = "loggerName">The Subname of this logger.</param>
+            <returns>The New ILogger instance.</returns>
+            <exception cref = "T:System.ArgumentException">If the name has an empty element name.</exception>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.Trace(System.String)">
+            <summary>
+              Logs a trace message.
+            </summary>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.Trace(System.Func{System.String})">
+            <summary>
+              Logs a trace message with lazily constructed message. The message will be constructed only if the <see cref = "P:Castle.Core.Logging.ILogger.IsTraceEnabled" /> is true.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.Trace(System.String,System.Exception)">
+            <summary>
+              Logs a trace message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.TraceFormat(System.String,System.Object[])">
+            <summary>
+              Logs a trace message.
+            </summary>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.TraceFormat(System.Exception,System.String,System.Object[])">
+            <summary>
+              Logs a trace message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.TraceFormat(System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs a trace message.
+            </summary>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.TraceFormat(System.Exception,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs a trace message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.Debug(System.String)">
+            <summary>
+              Logs a debug message.
+            </summary>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.Debug(System.Func{System.String})">
+            <summary>
+              Logs a debug message with lazily constructed message. The message will be constructed only if the <see cref = "P:Castle.Core.Logging.ILogger.IsDebugEnabled" /> is true.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.Debug(System.String,System.Exception)">
+            <summary>
+              Logs a debug message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.DebugFormat(System.String,System.Object[])">
+            <summary>
+              Logs a debug message.
+            </summary>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.DebugFormat(System.Exception,System.String,System.Object[])">
+            <summary>
+              Logs a debug message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.DebugFormat(System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs a debug message.
+            </summary>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.DebugFormat(System.Exception,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs a debug message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.Error(System.String)">
+            <summary>
+              Logs an error message.
+            </summary>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.Error(System.Func{System.String})">
+            <summary>
+              Logs an error message with lazily constructed message. The message will be constructed only if the <see cref = "P:Castle.Core.Logging.ILogger.IsErrorEnabled" /> is true.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.Error(System.String,System.Exception)">
+            <summary>
+              Logs an error message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.ErrorFormat(System.String,System.Object[])">
+            <summary>
+              Logs an error message.
+            </summary>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.ErrorFormat(System.Exception,System.String,System.Object[])">
+            <summary>
+              Logs an error message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.ErrorFormat(System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs an error message.
+            </summary>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.ErrorFormat(System.Exception,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs an error message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.Fatal(System.String)">
+            <summary>
+              Logs a fatal message.
+            </summary>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.Fatal(System.Func{System.String})">
+            <summary>
+              Logs a fatal message with lazily constructed message. The message will be constructed only if the <see cref = "P:Castle.Core.Logging.ILogger.IsFatalEnabled" /> is true.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.Fatal(System.String,System.Exception)">
+            <summary>
+              Logs a fatal message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.FatalFormat(System.String,System.Object[])">
+            <summary>
+              Logs a fatal message.
+            </summary>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.FatalFormat(System.Exception,System.String,System.Object[])">
+            <summary>
+              Logs a fatal message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.FatalFormat(System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs a fatal message.
+            </summary>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.FatalFormat(System.Exception,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs a fatal message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.Info(System.String)">
+            <summary>
+              Logs an info message.
+            </summary>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.Info(System.Func{System.String})">
+            <summary>
+              Logs a info message with lazily constructed message. The message will be constructed only if the <see cref = "P:Castle.Core.Logging.ILogger.IsInfoEnabled" /> is true.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.Info(System.String,System.Exception)">
+            <summary>
+              Logs an info message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.InfoFormat(System.String,System.Object[])">
+            <summary>
+              Logs an info message.
+            </summary>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.InfoFormat(System.Exception,System.String,System.Object[])">
+            <summary>
+              Logs an info message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.InfoFormat(System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs an info message.
+            </summary>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.InfoFormat(System.Exception,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs an info message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.Warn(System.String)">
+            <summary>
+              Logs a warn message.
+            </summary>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.Warn(System.Func{System.String})">
+            <summary>
+              Logs a warn message with lazily constructed message. The message will be constructed only if the <see cref = "P:Castle.Core.Logging.ILogger.IsWarnEnabled" /> is true.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.Warn(System.String,System.Exception)">
+            <summary>
+              Logs a warn message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.WarnFormat(System.String,System.Object[])">
+            <summary>
+              Logs a warn message.
+            </summary>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.WarnFormat(System.Exception,System.String,System.Object[])">
+            <summary>
+              Logs a warn message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.WarnFormat(System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs a warn message.
+            </summary>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.ILogger.WarnFormat(System.Exception,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs a warn message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="T:Castle.Core.Logging.ILoggerFactory">
+            <summary>
+              Manages the instantiation of <see cref = "T:Castle.Core.Logging.ILogger" />s.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.ILoggerFactory.Create(System.Type)">
+            <summary>
+              Creates a new logger, getting the logger name from the specified type.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.ILoggerFactory.Create(System.String)">
+            <summary>
+              Creates a new logger.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.ILoggerFactory.Create(System.Type,Castle.Core.Logging.LoggerLevel)">
+            <summary>
+              Creates a new logger, getting the logger name from the specified type.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.ILoggerFactory.Create(System.String,Castle.Core.Logging.LoggerLevel)">
+            <summary>
+              Creates a new logger.
+            </summary>
+        </member>
+        <member name="T:Castle.Core.Logging.LevelFilteredLogger">
+            <summary>
+            The Level Filtered Logger class.  This is a base class which
+            provides a LogLevel attribute and reroutes all functions into
+            one Log method.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.#ctor">
+            <summary>
+              Creates a new <c>LevelFilteredLogger</c>.
+            </summary>
+        </member>
+        <member name="P:Castle.Core.Logging.LevelFilteredLogger.Level">
+            <value>
+              The <c>LoggerLevel</c> that this logger
+              will be using. Defaults to <c>LoggerLevel.Off</c>
+            </value>
+        </member>
+        <member name="P:Castle.Core.Logging.LevelFilteredLogger.Name">
+            <value>
+              The name that this logger will be using. 
+              Defaults to <c>string.Empty</c>
+            </value>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.Trace(System.String)">
+            <summary>
+              Logs a trace message.
+            </summary>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.Trace(System.Func{System.String})">
+            <summary>
+              Logs a trace message.
+            </summary>
+            <param name="messageFactory">A functor to create the message</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.Trace(System.String,System.Exception)">
+            <summary>
+              Logs a trace message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.TraceFormat(System.String,System.Object[])">
+            <summary>
+              Logs a trace message.
+            </summary>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.TraceFormat(System.Exception,System.String,System.Object[])">
+            <summary>
+              Logs a trace message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.TraceFormat(System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs a trace message.
+            </summary>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.TraceFormat(System.Exception,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs a trace message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.Debug(System.String)">
+            <summary>
+              Logs a debug message.
+            </summary>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.Debug(System.String,System.Exception)">
+            <summary>
+              Logs a debug message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.DebugFormat(System.String,System.Object[])">
+            <summary>
+              Logs a debug message.
+            </summary>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.DebugFormat(System.Exception,System.String,System.Object[])">
+            <summary>
+              Logs a debug message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.DebugFormat(System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs a debug message.
+            </summary>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.DebugFormat(System.Exception,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs a debug message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.Info(System.String)">
+            <summary>
+              Logs an info message.
+            </summary>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.Info(System.String,System.Exception)">
+            <summary>
+              Logs an info message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.InfoFormat(System.String,System.Object[])">
+            <summary>
+              Logs an info message.
+            </summary>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.InfoFormat(System.Exception,System.String,System.Object[])">
+            <summary>
+              Logs an info message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.InfoFormat(System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs an info message.
+            </summary>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.InfoFormat(System.Exception,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs an info message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.Warn(System.String)">
+            <summary>
+              Logs a warn message.
+            </summary>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.Warn(System.String,System.Exception)">
+            <summary>
+              Logs a warn message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.WarnFormat(System.String,System.Object[])">
+            <summary>
+              Logs a warn message.
+            </summary>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.WarnFormat(System.Exception,System.String,System.Object[])">
+            <summary>
+              Logs a warn message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.WarnFormat(System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs a warn message.
+            </summary>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.WarnFormat(System.Exception,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs a warn message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.Error(System.String)">
+            <summary>
+              Logs an error message.
+            </summary>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.Error(System.String,System.Exception)">
+            <summary>
+              Logs an error message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.ErrorFormat(System.String,System.Object[])">
+            <summary>
+              Logs an error message.
+            </summary>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.ErrorFormat(System.Exception,System.String,System.Object[])">
+            <summary>
+              Logs an error message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.ErrorFormat(System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs an error message.
+            </summary>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.ErrorFormat(System.Exception,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs an error message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.Fatal(System.String)">
+            <summary>
+              Logs a fatal message.
+            </summary>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.Fatal(System.String,System.Exception)">
+            <summary>
+              Logs a fatal message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "message">The message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.FatalFormat(System.String,System.Object[])">
+            <summary>
+              Logs a fatal message.
+            </summary>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.FatalFormat(System.Exception,System.String,System.Object[])">
+            <summary>
+              Logs a fatal message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.FatalFormat(System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs a fatal message.
+            </summary>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.FatalFormat(System.Exception,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              Logs a fatal message.
+            </summary>
+            <param name = "exception">The exception to log</param>
+            <param name = "formatProvider">The format provider to use</param>
+            <param name = "format">Format string for the message to log</param>
+            <param name = "args">Format arguments for the message to log</param>
+        </member>
+        <member name="P:Castle.Core.Logging.LevelFilteredLogger.IsTraceEnabled">
+            <summary>
+              Determines if messages of priority "trace" will be logged.
+            </summary>
+            <value><c>true</c> if log level flags include the <see cref = "F:Castle.Core.Logging.LoggerLevel.Trace" /> bit</value>
+        </member>
+        <member name="P:Castle.Core.Logging.LevelFilteredLogger.IsDebugEnabled">
+            <summary>
+              Determines if messages of priority "debug" will be logged.
+            </summary>
+            <value><c>true</c> if log level flags include the <see cref = "F:Castle.Core.Logging.LoggerLevel.Debug" /> bit</value>
+        </member>
+        <member name="P:Castle.Core.Logging.LevelFilteredLogger.IsInfoEnabled">
+            <summary>
+              Determines if messages of priority "info" will be logged.
+            </summary>
+            <value><c>true</c> if log level flags include the <see cref = "F:Castle.Core.Logging.LoggerLevel.Info" /> bit</value>
+        </member>
+        <member name="P:Castle.Core.Logging.LevelFilteredLogger.IsWarnEnabled">
+            <summary>
+              Determines if messages of priority "warn" will be logged.
+            </summary>
+            <value><c>true</c> if log level flags include the <see cref = "F:Castle.Core.Logging.LoggerLevel.Warn" /> bit</value>
+        </member>
+        <member name="P:Castle.Core.Logging.LevelFilteredLogger.IsErrorEnabled">
+            <summary>
+              Determines if messages of priority "error" will be logged.
+            </summary>
+            <value><c>true</c> if log level flags include the <see cref = "F:Castle.Core.Logging.LoggerLevel.Error" /> bit</value>
+        </member>
+        <member name="P:Castle.Core.Logging.LevelFilteredLogger.IsFatalEnabled">
+            <summary>
+              Determines if messages of priority "fatal" will be logged.
+            </summary>
+            <value><c>true</c> if log level flags include the <see cref = "F:Castle.Core.Logging.LoggerLevel.Fatal" /> bit</value>
+        </member>
+        <member name="M:Castle.Core.Logging.LevelFilteredLogger.Log(Castle.Core.Logging.LoggerLevel,System.String,System.String,System.Exception)">
+            <summary>
+              Implementors output the log content by implementing this method only.
+              Note that exception can be null
+            </summary>
+        </member>
+        <member name="T:Castle.Core.Logging.LoggerLevel">
+            <summary>
+              Supporting Logger levels.
+            </summary>
+        </member>
+        <member name="F:Castle.Core.Logging.LoggerLevel.Off">
+            <summary>
+              Logging will be off
+            </summary>
+        </member>
+        <member name="F:Castle.Core.Logging.LoggerLevel.Fatal">
+            <summary>
+              Fatal logging level
+            </summary>
+        </member>
+        <member name="F:Castle.Core.Logging.LoggerLevel.Error">
+            <summary>
+              Error logging level
+            </summary>
+        </member>
+        <member name="F:Castle.Core.Logging.LoggerLevel.Warn">
+            <summary>
+              Warn logging level
+            </summary>
+        </member>
+        <member name="F:Castle.Core.Logging.LoggerLevel.Info">
+            <summary>
+              Info logging level
+            </summary>
+        </member>
+        <member name="F:Castle.Core.Logging.LoggerLevel.Debug">
+            <summary>
+              Debug logging level
+            </summary>
+        </member>
+        <member name="F:Castle.Core.Logging.LoggerLevel.Trace">
+            <summary>
+              Trace logging level
+            </summary>
+        </member>
+        <member name="T:Castle.Core.Logging.NullLogFactory">
+            <summary>
+            NullLogFactory used when logging is turned off.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogFactory.Create(System.String)">
+            <summary>
+              Creates an instance of ILogger with the specified name.
+            </summary>
+            <param name = "name">Name.</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogFactory.Create(System.String,Castle.Core.Logging.LoggerLevel)">
+            <summary>
+              Creates an instance of ILogger with the specified name and LoggerLevel.
+            </summary>
+            <param name = "name">Name.</param>
+            <param name = "level">Level.</param>
+        </member>
+        <member name="T:Castle.Core.Logging.NullLogger">
+            <summary>
+              The Null Logger class.  This is useful for implementations where you need
+              to provide a logger to a utility class, but do not want any output from it.
+              It also helps when you have a utility that does not have a logger to supply.
+            </summary>
+        </member>
+        <member name="P:Castle.Core.Logging.NullLogger.GlobalProperties">
+            <summary>
+              Returns empty context properties.
+            </summary>
+        </member>
+        <member name="P:Castle.Core.Logging.NullLogger.ThreadProperties">
+            <summary>
+              Returns empty context properties.
+            </summary>
+        </member>
+        <member name="P:Castle.Core.Logging.NullLogger.ThreadStacks">
+            <summary>
+              Returns empty context stacks.
+            </summary>
+        </member>
+        <member name="P:Castle.Core.Logging.NullLogger.IsTraceEnabled">
+            <summary>
+              No-op.
+            </summary>
+            <value>false</value>
+        </member>
+        <member name="P:Castle.Core.Logging.NullLogger.IsDebugEnabled">
+            <summary>
+              No-op.
+            </summary>
+            <value>false</value>
+        </member>
+        <member name="P:Castle.Core.Logging.NullLogger.IsErrorEnabled">
+            <summary>
+              No-op.
+            </summary>
+            <value>false</value>
+        </member>
+        <member name="P:Castle.Core.Logging.NullLogger.IsFatalEnabled">
+            <summary>
+              No-op.
+            </summary>
+            <value>false</value>
+        </member>
+        <member name="P:Castle.Core.Logging.NullLogger.IsInfoEnabled">
+            <summary>
+              No-op.
+            </summary>
+            <value>false</value>
+        </member>
+        <member name="P:Castle.Core.Logging.NullLogger.IsWarnEnabled">
+            <summary>
+              No-op.
+            </summary>
+            <value>false</value>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.CreateChildLogger(System.String)">
+            <summary>
+              Returns this <c>NullLogger</c>.
+            </summary>
+            <param name = "loggerName">Ignored</param>
+            <returns>This ILogger instance.</returns>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.Trace(System.String)">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "message">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.Trace(System.String,System.Exception)">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "exception">Ignored</param>
+            <param name = "message">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.TraceFormat(System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.TraceFormat(System.Exception,System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "exception">Ignored</param>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.TraceFormat(System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "formatProvider">Ignored</param>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.TraceFormat(System.Exception,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "exception">Ignored</param>
+            <param name = "formatProvider">Ignored</param>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.Debug(System.String)">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "message">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.Debug(System.String,System.Exception)">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "exception">Ignored</param>
+            <param name = "message">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.DebugFormat(System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.DebugFormat(System.Exception,System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "exception">Ignored</param>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.DebugFormat(System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "formatProvider">Ignored</param>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.DebugFormat(System.Exception,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "exception">Ignored</param>
+            <param name = "formatProvider">Ignored</param>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.Error(System.String)">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "message">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.Error(System.String,System.Exception)">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "exception">Ignored</param>
+            <param name = "message">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.ErrorFormat(System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.ErrorFormat(System.Exception,System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "exception">Ignored</param>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.ErrorFormat(System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "formatProvider">Ignored</param>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.ErrorFormat(System.Exception,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "exception">Ignored</param>
+            <param name = "formatProvider">Ignored</param>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.Fatal(System.String)">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "message">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.Fatal(System.String,System.Exception)">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "exception">Ignored</param>
+            <param name = "message">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.FatalFormat(System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.FatalFormat(System.Exception,System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "exception">Ignored</param>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.FatalFormat(System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "formatProvider">Ignored</param>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.FatalFormat(System.Exception,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "exception">Ignored</param>
+            <param name = "formatProvider">Ignored</param>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.Info(System.String)">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "message">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.Info(System.String,System.Exception)">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "exception">Ignored</param>
+            <param name = "message">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.InfoFormat(System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.InfoFormat(System.Exception,System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "exception">Ignored</param>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.InfoFormat(System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "formatProvider">Ignored</param>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.InfoFormat(System.Exception,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "exception">Ignored</param>
+            <param name = "formatProvider">Ignored</param>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.Warn(System.String)">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "message">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.Warn(System.String,System.Exception)">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "exception">Ignored</param>
+            <param name = "message">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.WarnFormat(System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.WarnFormat(System.Exception,System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "exception">Ignored</param>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.WarnFormat(System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "formatProvider">Ignored</param>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="M:Castle.Core.Logging.NullLogger.WarnFormat(System.Exception,System.IFormatProvider,System.String,System.Object[])">
+            <summary>
+              No-op.
+            </summary>
+            <param name = "exception">Ignored</param>
+            <param name = "formatProvider">Ignored</param>
+            <param name = "format">Ignored</param>
+            <param name = "args">Ignored</param>
+        </member>
+        <member name="T:Castle.Core.Logging.StreamLogger">
+            <summary>
+            The Stream Logger class.  This class can stream log information
+            to any stream, it is suitable for storing a log file to disk,
+            or to a <c>MemoryStream</c> for testing your components.
+            </summary>
+            <remarks>
+            This logger is not thread safe.
+            </remarks>
+        </member>
+        <member name="M:Castle.Core.Logging.StreamLogger.#ctor(System.String,System.IO.Stream)">
+            <summary>
+              Creates a new <c>StreamLogger</c> with default encoding 
+              and buffer size. Initial Level is set to Debug.
+            </summary>
+            <param name = "name">
+              The name of the log.
+            </param>
+            <param name = "stream">
+              The stream that will be used for logging,
+              seeking while the logger is alive 
+            </param>
+        </member>
+        <member name="M:Castle.Core.Logging.StreamLogger.#ctor(System.String,System.IO.Stream,System.Text.Encoding)">
+            <summary>
+              Creates a new <c>StreamLogger</c> with default buffer size.
+              Initial Level is set to Debug.
+            </summary>
+            <param name = "name">
+              The name of the log.
+            </param>
+            <param name = "stream">
+              The stream that will be used for logging,
+              seeking while the logger is alive 
+            </param>
+            <param name = "encoding">
+              The encoding that will be used for this stream.
+              <see cref = "T:System.IO.StreamWriter" />
+            </param>
+        </member>
+        <member name="M:Castle.Core.Logging.StreamLogger.#ctor(System.String,System.IO.Stream,System.Text.Encoding,System.Int32)">
+            <summary>
+              Creates a new <c>StreamLogger</c>. 
+              Initial Level is set to Debug.
+            </summary>
+            <param name = "name">
+              The name of the log.
+            </param>
+            <param name = "stream">
+              The stream that will be used for logging,
+              seeking while the logger is alive 
+            </param>
+            <param name = "encoding">
+              The encoding that will be used for this stream.
+              <see cref = "T:System.IO.StreamWriter" />
+            </param>
+            <param name = "bufferSize">
+              The buffer size that will be used for this stream.
+              <see cref = "T:System.IO.StreamWriter" />
+            </param>
+        </member>
+        <member name="M:Castle.Core.Logging.StreamLogger.#ctor(System.String,System.IO.StreamWriter)">
+            <summary>
+              Creates a new <c>StreamLogger</c> with 
+              Debug as default Level.
+            </summary>
+            <param name = "name">The name of the log.</param>
+            <param name = "writer">The <c>StreamWriter</c> the log will write to.</param>
+        </member>
+        <member name="T:Castle.Core.Logging.StreamLoggerFactory">
+            <summary>
+              Creates <see cref = "T:Castle.Core.Logging.StreamLogger" /> outputting
+              to files. The name of the file is derived from the log name
+              plus the 'log' extension.
+            </summary>
+        </member>
+        <member name="T:Castle.Core.Logging.TraceLogger">
+            <summary>
+              The TraceLogger sends all logging to the System.Diagnostics.TraceSource
+              built into the .net framework.
+            </summary>
+            <remarks>
+              Logging can be configured in the system.diagnostics configuration 
+              section. 
+            
+              If logger doesn't find a source name with a full match it will
+              use source names which match the namespace partially. For example you can
+              configure from all castle components by adding a source name with the
+              name "Castle". 
+            
+              If no portion of the namespace matches the source named "Default" will
+              be used.
+            </remarks>
+        </member>
+        <member name="M:Castle.Core.Logging.TraceLogger.#ctor(System.String)">
+            <summary>
+            Build a new trace logger based on the named TraceSource
+            </summary>
+            <param name="name">The name used to locate the best TraceSource. In most cases comes from the using type's fullname.</param>
+        </member>
+        <member name="M:Castle.Core.Logging.TraceLogger.#ctor(System.String,Castle.Core.Logging.LoggerLevel)">
+            <summary>
+            Build a new trace logger based on the named TraceSource
+            </summary>
+            <param name="name">The name used to locate the best TraceSource. In most cases comes from the using type's fullname.</param>
+            <param name="level">The default logging level at which this source should write messages. In almost all cases this
+            default value will be overridden in the config file. </param>
+        </member>
+        <member name="M:Castle.Core.Logging.TraceLogger.CreateChildLogger(System.String)">
+            <summary>
+            Create a new child logger.
+            The name of the child logger is [current-loggers-name].[passed-in-name]
+            </summary>
+            <param name="loggerName">The Subname of this logger.</param>
+            <returns>The New ILogger instance.</returns> 
+        </member>
+        <member name="T:Castle.Core.Logging.TraceLoggerFactory">
+            <summary>
+              Used to create the TraceLogger implementation of ILogger interface. See <see cref = "T:Castle.Core.Logging.TraceLogger" />.
+            </summary>
+        </member>
+        <member name="T:Castle.Core.ProxyServices">
+            <summary>
+            List of utility methods related to dynamic proxy operations
+            </summary>
+        </member>
+        <member name="M:Castle.Core.ProxyServices.IsDynamicProxy(System.Type)">
+            <summary>
+            Determines whether the specified type is a proxy generated by
+            DynamicProxy (1 or 2).
+            </summary>
+            <param name="type">The type.</param>
+            <returns>
+            	<c>true</c> if it is a proxy; otherwise, <c>false</c>.
+            </returns>
+        </member>
+        <member name="T:Castle.Core.ReflectionBasedDictionaryAdapter">
+            <summary>
+            Readonly implementation of <see cref="T:System.Collections.IDictionary"/> which uses an anonymous object as its source. Uses names of properties as keys, and property values as... well - values. Keys are not case sensitive.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.ReflectionBasedDictionaryAdapter.#ctor(System.Object)">
+            <summary>
+              Initializes a new instance of the <see cref = "T:Castle.Core.ReflectionBasedDictionaryAdapter" /> class.
+            </summary>
+            <param name = "target">The target.</param>
+        </member>
+        <member name="P:Castle.Core.ReflectionBasedDictionaryAdapter.Count">
+            <summary>
+              Gets the number of elements contained in the <see cref = "T:System.Collections.ICollection" />.
+            </summary>
+            <returns>The number of elements contained in the <see cref = "T:System.Collections.ICollection" />.</returns>
+        </member>
+        <member name="P:Castle.Core.ReflectionBasedDictionaryAdapter.IsSynchronized">
+            <summary>
+              Gets a value indicating whether access to the <see cref = "T:System.Collections.ICollection" /> is synchronized (thread safe).
+            </summary>
+            <returns>true if access to the <see cref = "T:System.Collections.ICollection" /> is synchronized (thread safe); otherwise, false.</returns>
+        </member>
+        <member name="P:Castle.Core.ReflectionBasedDictionaryAdapter.SyncRoot">
+            <summary>
+              Gets an object that can be used to synchronize access to the <see cref = "T:System.Collections.ICollection" />.
+            </summary>
+            <returns>An object that can be used to synchronize access to the <see cref = "T:System.Collections.ICollection" />.</returns>
+        </member>
+        <member name="P:Castle.Core.ReflectionBasedDictionaryAdapter.IsReadOnly">
+            <summary>
+              Gets a value indicating whether the <see cref = "T:System.Collections.IDictionary" /> object is read-only.
+            </summary>
+            <returns>true if the <see cref = "T:System.Collections.IDictionary" /> object is read-only; otherwise, false.</returns>
+        </member>
+        <member name="P:Castle.Core.ReflectionBasedDictionaryAdapter.Item(System.Object)">
+            <summary>
+              Gets or sets the <see cref = "T:System.Object" /> with the specified key.
+            </summary>
+        </member>
+        <member name="P:Castle.Core.ReflectionBasedDictionaryAdapter.Keys">
+            <summary>
+              Gets an <see cref = "T:System.Collections.ICollection" /> object containing the keys of the <see
+               cref = "T:System.Collections.IDictionary" /> object.
+            </summary>
+            <returns>An <see cref = "T:System.Collections.ICollection" /> object containing the keys of the <see
+               cref = "T:System.Collections.IDictionary" /> object.</returns>
+        </member>
+        <member name="P:Castle.Core.ReflectionBasedDictionaryAdapter.Values">
+            <summary>
+              Gets an <see cref = "T:System.Collections.ICollection" /> object containing the values in the <see
+               cref = "T:System.Collections.IDictionary" /> object.
+            </summary>
+            <returns>An <see cref = "T:System.Collections.ICollection" /> object containing the values in the <see
+               cref = "T:System.Collections.IDictionary" /> object.</returns>
+        </member>
+        <member name="P:Castle.Core.ReflectionBasedDictionaryAdapter.System#Collections#IDictionary#IsFixedSize">
+            <summary>
+              Gets a value indicating whether the <see cref = "T:System.Collections.IDictionary" /> object has a fixed size.
+            </summary>
+            <returns>true if the <see cref = "T:System.Collections.IDictionary" /> object has a fixed size; otherwise, false.</returns>
+        </member>
+        <member name="M:Castle.Core.ReflectionBasedDictionaryAdapter.Add(System.Object,System.Object)">
+            <summary>
+              Adds an element with the provided key and value to the <see cref = "T:System.Collections.IDictionary" /> object.
+            </summary>
+            <param name = "key">The <see cref = "T:System.Object" /> to use as the key of the element to add.</param>
+            <param name = "value">The <see cref = "T:System.Object" /> to use as the value of the element to add.</param>
+            <exception cref = "T:System.ArgumentNullException">
+              <paramref name = "key" /> is null. </exception>
+            <exception cref = "T:System.ArgumentException">An element with the same key already exists in the <see
+               cref = "T:System.Collections.IDictionary" /> object. </exception>
+            <exception cref = "T:System.NotSupportedException">The <see cref = "T:System.Collections.IDictionary" /> is read-only.-or- The <see
+               cref = "T:System.Collections.IDictionary" /> has a fixed size. </exception>
+        </member>
+        <member name="M:Castle.Core.ReflectionBasedDictionaryAdapter.Clear">
+            <summary>
+              Removes all elements from the <see cref = "T:System.Collections.IDictionary" /> object.
+            </summary>
+            <exception cref = "T:System.NotSupportedException">The <see cref = "T:System.Collections.IDictionary" /> object is read-only. </exception>
+        </member>
+        <member name="M:Castle.Core.ReflectionBasedDictionaryAdapter.Contains(System.Object)">
+            <summary>
+              Determines whether the <see cref = "T:System.Collections.IDictionary" /> object contains an element with the specified key.
+            </summary>
+            <param name = "key">The key to locate in the <see cref = "T:System.Collections.IDictionary" /> object.</param>
+            <returns>
+              true if the <see cref = "T:System.Collections.IDictionary" /> contains an element with the key; otherwise, false.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">
+              <paramref name = "key" /> is null. </exception>
+        </member>
+        <member name="M:Castle.Core.ReflectionBasedDictionaryAdapter.Remove(System.Object)">
+            <summary>
+              Removes the element with the specified key from the <see cref = "T:System.Collections.IDictionary" /> object.
+            </summary>
+            <param name = "key">The key of the element to remove.</param>
+            <exception cref = "T:System.ArgumentNullException">
+              <paramref name = "key" /> is null. </exception>
+            <exception cref = "T:System.NotSupportedException">The <see cref = "T:System.Collections.IDictionary" /> object is read-only.-or- The <see
+               cref = "T:System.Collections.IDictionary" /> has a fixed size. </exception>
+        </member>
+        <member name="M:Castle.Core.ReflectionBasedDictionaryAdapter.GetEnumerator">
+            <summary>
+              Returns an enumerator that iterates through a collection.
+            </summary>
+            <returns>
+              An <see cref = "T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.
+            </returns>
+        </member>
+        <member name="M:Castle.Core.ReflectionBasedDictionaryAdapter.System#Collections#ICollection#CopyTo(System.Array,System.Int32)">
+            <summary>
+              Copies the elements of the <see cref = "T:System.Collections.ICollection" /> to an <see cref = "T:System.Array" />, starting at a particular <see
+               cref = "T:System.Array" /> index.
+            </summary>
+            <param name = "array">The one-dimensional <see cref = "T:System.Array" /> that is the destination of the elements copied from <see
+               cref = "T:System.Collections.ICollection" />. The <see cref = "T:System.Array" /> must have zero-based indexing.</param>
+            <param name = "index">The zero-based index in <paramref name = "array" /> at which copying begins.</param>
+            <exception cref = "T:System.ArgumentNullException">
+              <paramref name = "array" /> is null. </exception>
+            <exception cref = "T:System.ArgumentOutOfRangeException">
+              <paramref name = "index" /> is less than zero. </exception>
+            <exception cref = "T:System.ArgumentException">
+              <paramref name = "array" /> is multidimensional.-or- <paramref name = "index" /> is equal to or greater than the length of <paramref
+               name = "array" />.-or- The number of elements in the source <see cref = "T:System.Collections.ICollection" /> is greater than the available space from <paramref
+               name = "index" /> to the end of the destination <paramref name = "array" />. </exception>
+            <exception cref = "T:System.ArgumentException">The type of the source <see cref = "T:System.Collections.ICollection" /> cannot be cast automatically to the type of the destination <paramref
+               name = "array" />. </exception>
+        </member>
+        <member name="M:Castle.Core.ReflectionBasedDictionaryAdapter.System#Collections#IDictionary#GetEnumerator">
+            <summary>
+              Returns an <see cref = "T:System.Collections.IDictionaryEnumerator" /> object for the <see
+               cref = "T:System.Collections.IDictionary" /> object.
+            </summary>
+            <returns>
+              An <see cref = "T:System.Collections.IDictionaryEnumerator" /> object for the <see
+               cref = "T:System.Collections.IDictionary" /> object.
+            </returns>
+        </member>
+        <member name="M:Castle.Core.ReflectionBasedDictionaryAdapter.Read(System.Collections.IDictionary,System.Object)">
+            <summary>
+              Reads values of properties from <paramref name = "valuesAsAnonymousObject" /> and inserts them into <paramref
+               name = "targetDictionary" /> using property names as keys.
+            </summary>
+        </member>
+        <member name="T:Castle.Core.Resource.AbstractStreamResource">
+            <summary>
+            
+            </summary>
+        </member>
+        <member name="F:Castle.Core.Resource.AbstractStreamResource.createStream">
+            <summary>
+            This returns a new stream instance each time it is called.
+            It is the responsibility of the caller to dispose of this stream
+            </summary>
+        </member>
+        <member name="T:Castle.Core.Resource.FileResource">
+            <summary>
+            
+            </summary>
+        </member>
+        <member name="T:Castle.Core.Resource.FileResourceFactory">
+            <summary>
+            
+            </summary>
+        </member>
+        <member name="T:Castle.Core.Resource.IResource">
+            <summary>
+            Represents a 'streamable' resource. Can
+            be a file, a resource in an assembly.
+            </summary>
+        </member>
+        <member name="P:Castle.Core.Resource.IResource.FileBasePath">
+            <remarks>
+            Only valid for resources that
+            can be obtained through relative paths
+            </remarks>
+        </member>
+        <member name="M:Castle.Core.Resource.IResource.GetStreamReader">
+            <summary>
+            Returns a reader for the stream
+            </summary>
+            <remarks>
+            It's up to the caller to dispose the reader.
+            </remarks>
+        </member>
+        <member name="M:Castle.Core.Resource.IResource.GetStreamReader(System.Text.Encoding)">
+            <summary>
+            Returns a reader for the stream
+            </summary>
+            <remarks>
+            It's up to the caller to dispose the reader.
+            </remarks>
+        </member>
+        <member name="M:Castle.Core.Resource.IResource.CreateRelative(System.String)">
+            <summary>
+            Returns an instance of <see cref="T:Castle.Core.Resource.IResource"/>
+            created according to the <c>relativePath</c>
+            using itself as the root.
+            </summary>
+        </member>
+        <member name="T:Castle.Core.Resource.IResourceFactory">
+            <summary>
+            Depicts the contract for resource factories.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Resource.IResourceFactory.Accept(Castle.Core.Resource.CustomUri)">
+            <summary>
+            Used to check whether the resource factory
+            is able to deal with the given resource
+            identifier.
+            </summary>
+            <remarks>
+            Implementors should return <c>true</c>
+            only if the given identifier is supported
+            by the resource factory
+            </remarks>
+        </member>
+        <member name="M:Castle.Core.Resource.IResourceFactory.Create(Castle.Core.Resource.CustomUri)">
+            <summary>
+            Creates an <see cref="T:Castle.Core.Resource.IResource"/> instance
+            for the given resource identifier
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Resource.IResourceFactory.Create(Castle.Core.Resource.CustomUri,System.String)">
+            <summary>
+            Creates an <see cref="T:Castle.Core.Resource.IResource"/> instance
+            for the given resource identifier
+            </summary>
+        </member>
+        <member name="T:Castle.Core.Resource.StaticContentResource">
+            <summary>
+            Adapts a static string content as an <see cref="T:Castle.Core.Resource.IResource"/>
+            </summary>
+        </member>
+        <member name="T:Castle.Core.Resource.UncResource">
+            <summary>
+            Enable access to files on network shares
+            </summary>
+        </member>
+        <member name="T:Castle.Core.Smtp.DefaultSmtpSender">
+            <summary>
+            Default <see cref="T:Castle.Core.Smtp.IEmailSender"/> implementation.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Smtp.DefaultSmtpSender.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:Castle.Core.Smtp.DefaultSmtpSender"/> class based on the <see cref="T:System.Net.Mail.SmtpClient"/> configuration provided in the application configuration file.
+            </summary>
+            <remarks>
+            This constructor is based on the default <see cref="T:System.Net.Mail.SmtpClient"/> configuration in the application configuration file.
+            </remarks>
+        </member>
+        <member name="M:Castle.Core.Smtp.DefaultSmtpSender.#ctor(System.String)">
+            <summary>
+            This service implementation
+            requires a host name in order to work
+            </summary>
+            <param name="hostname">The smtp server name</param>
+        </member>
+        <member name="P:Castle.Core.Smtp.DefaultSmtpSender.Port">
+            <summary>
+            Gets or sets the port used to
+            access the SMTP server
+            </summary>
+        </member>
+        <member name="P:Castle.Core.Smtp.DefaultSmtpSender.Hostname">
+            <summary>
+            Gets the hostname.
+            </summary>
+            <value>The hostname.</value>
+        </member>
+        <member name="P:Castle.Core.Smtp.DefaultSmtpSender.AsyncSend">
+            <summary>
+            Gets or sets a value which is used to
+            configure if emails are going to be sent asynchronously or not.
+            </summary>
+        </member>
+        <member name="P:Castle.Core.Smtp.DefaultSmtpSender.Timeout">
+            <summary>
+            Gets or sets a value that specifies
+            the amount of time after which a synchronous Send call times out.
+            </summary>
+        </member>
+        <member name="P:Castle.Core.Smtp.DefaultSmtpSender.UseSsl">
+            <summary>
+            Gets or sets a value indicating whether the email should be sent using
+            a secure communication channel.
+            </summary>
+            <value><c>true</c> if should use SSL; otherwise, <c>false</c>.</value>
+        </member>
+        <member name="M:Castle.Core.Smtp.DefaultSmtpSender.Send(System.String,System.String,System.String,System.String)">
+            <summary>
+            Sends a message.
+            </summary>
+            <exception cref="T:System.ArgumentNullException">If any of the parameters is null</exception>
+            <param name="from">From field</param>
+            <param name="to">To field</param>
+            <param name="subject">e-mail's subject</param>
+            <param name="messageText">message's body</param>
+        </member>
+        <member name="M:Castle.Core.Smtp.DefaultSmtpSender.Send(System.Net.Mail.MailMessage)">
+            <summary>
+            Sends a message.
+            </summary>
+            <exception cref="T:System.ArgumentNullException">If the message is null</exception>
+            <param name="message">Message instance</param>
+        </member>
+        <member name="P:Castle.Core.Smtp.DefaultSmtpSender.Domain">
+            <summary>
+            Gets or sets the domain.
+            </summary>
+            <value>The domain.</value>
+        </member>
+        <member name="P:Castle.Core.Smtp.DefaultSmtpSender.UserName">
+            <summary>
+            Gets or sets the name of the user.
+            </summary>
+            <value>The name of the user.</value>
+        </member>
+        <member name="P:Castle.Core.Smtp.DefaultSmtpSender.Password">
+            <summary>
+            Gets or sets the password.
+            </summary>
+            <value>The password.</value>
+        </member>
+        <member name="M:Castle.Core.Smtp.DefaultSmtpSender.Configure(System.Net.Mail.SmtpClient)">
+            <summary>
+            Configures the sender
+            with port information and eventual credential
+            informed
+            </summary>
+            <param name="smtpClient">Message instance</param>
+        </member>
+        <member name="P:Castle.Core.Smtp.DefaultSmtpSender.HasCredentials">
+            <summary>
+            Gets a value indicating whether credentials were informed.
+            </summary>
+            <value>
+            <see langword="true"/> if this instance has credentials; otherwise, <see langword="false"/>.
+            </value>
+        </member>
+        <member name="T:Castle.Core.Smtp.IEmailSender">
+            <summary>
+            Email sender abstraction.
+            </summary>
+        </member>
+        <member name="M:Castle.Core.Smtp.IEmailSender.Send(System.String,System.String,System.String,System.String)">
+            <summary>
+            Sends a mail message.
+            </summary>
+            <param name="from">From field</param>
+            <param name="to">To field</param>
+            <param name="subject">E-mail's subject</param>
+            <param name="messageText">message's body</param>
+        </member>
+        <member name="M:Castle.Core.Smtp.IEmailSender.Send(System.Net.Mail.MailMessage)">
+            <summary>
+            Sends a <see cref="T:System.Net.Mail.MailMessage">message</see>. 
+            </summary>
+            <param name="message"><see cref="T:System.Net.Mail.MailMessage">Message</see> instance</param>
+        </member>
+        <member name="M:Castle.Core.Smtp.IEmailSender.Send(System.Collections.Generic.IEnumerable{System.Net.Mail.MailMessage})">
+            <summary>
+            Sends multiple <see cref="T:System.Net.Mail.MailMessage">messages</see>. 
+            </summary>
+            <param name="messages">List of <see cref="T:System.Net.Mail.MailMessage">messages</see></param>
+        </member>
+        <member name="T:Castle.DynamicProxy.Contributors.ITypeContributor">
+            <summary>
+              Interface describing elements composing generated type
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.Contributors.MembersCollector.AcceptMethod(System.Reflection.MethodInfo,System.Boolean,Castle.DynamicProxy.IProxyGenerationHook)">
+            <summary>
+              Performs some basic screening and invokes the <see cref = "T:Castle.DynamicProxy.IProxyGenerationHook" />
+              to select methods.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.Contributors.MembersCollector.AcceptMethodPreScreen(System.Reflection.MethodInfo,System.Boolean,Castle.DynamicProxy.IProxyGenerationHook)">
+            <summary>
+              Performs some basic screening to filter out non-interceptable methods.
+            </summary>
+            <remarks>
+              The <paramref name="hook"/> will get invoked for non-interceptable method notification only;
+              it does not get asked whether or not to intercept the <paramref name="method"/>.
+            </remarks>
+        </member>
+        <member name="T:Castle.DynamicProxy.Contributors.NonInheritableAttributesContributor">
+            <summary>
+              Reproduces the proxied type's non-inheritable custom attributes on the proxy type.
+            </summary>
+        </member>
+        <member name="T:Castle.DynamicProxy.Contributors.ProxyTargetAccessorContributor">
+            <summary>
+              Adds an implementation for <see cref="T:Castle.DynamicProxy.IProxyTargetAccessor"/> to the proxy type.
+            </summary>
+        </member>
+        <member name="T:Castle.DynamicProxy.CustomAttributeInfo">
+            <summary>
+            Encapsulates the information needed to build an attribute.
+            </summary>
+            <remarks>
+            Arrays passed to this class as constructor arguments or property or field values become owned by this class.
+            They should not be mutated after creation.
+            </remarks>
+        </member>
+        <member name="T:Castle.DynamicProxy.DefaultProxyBuilder">
+            <summary>
+              Default implementation of <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> interface producing in-memory proxy assemblies.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.DefaultProxyBuilder.#ctor">
+            <summary>
+              Initializes a new instance of the <see cref = "T:Castle.DynamicProxy.DefaultProxyBuilder" /> class with new <see cref = "P:Castle.DynamicProxy.DefaultProxyBuilder.ModuleScope" />.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.DefaultProxyBuilder.#ctor(Castle.DynamicProxy.ModuleScope)">
+            <summary>
+              Initializes a new instance of the <see cref = "T:Castle.DynamicProxy.DefaultProxyBuilder" /> class.
+            </summary>
+            <param name = "scope">The module scope for generated proxy types.</param>
+        </member>
+        <member name="M:Castle.DynamicProxy.ExceptionMessageBuilder.CreateInstructionsToMakeVisible(System.Reflection.Assembly)">
+            <summary>
+            Provides instructions that a user could follow to make a type or method in <paramref name="targetAssembly"/>
+            visible to DynamicProxy.</summary>
+            <param name="targetAssembly">The assembly containing the type or method.</param>
+            <returns>Instructions that a user could follow to make a type or method visible to DynamicProxy.</returns>
+        </member>
+        <member name="M:Castle.DynamicProxy.ExceptionMessageBuilder.CreateMessageForInaccessibleType(System.Type,System.Type)">
+            <summary>
+            Creates a message to inform clients that a proxy couldn't be created due to reliance on an
+            inaccessible type (perhaps itself).
+            </summary>
+            <param name="inaccessibleType">the inaccessible type that prevents proxy creation</param>
+            <param name="typeToProxy">the type that couldn't be proxied</param>
+        </member>
+        <member name="T:Castle.DynamicProxy.Generators.BaseProxyGenerator">
+            <summary>
+              Base class that exposes the common functionalities
+              to proxy generation.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.Generators.BaseProxyGenerator.AddMappingNoCheck(System.Type,Castle.DynamicProxy.Contributors.ITypeContributor,System.Collections.Generic.IDictionary{System.Type,Castle.DynamicProxy.Contributors.ITypeContributor})">
+            <summary>
+              It is safe to add mapping (no mapping for the interface exists)
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.Generators.BaseProxyGenerator.GenerateParameterlessConstructor(Castle.DynamicProxy.Generators.Emitters.ClassEmitter,System.Type,Castle.DynamicProxy.Generators.Emitters.SimpleAST.FieldReference)">
+            <summary>
+              Generates a parameters constructor that initializes the proxy
+              state with <see cref = "T:Castle.DynamicProxy.StandardInterceptor" /> just to make it non-null.
+              <para>
+                This constructor is important to allow proxies to be XML serializable
+              </para>
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.Generators.CacheKey.#ctor(System.Reflection.MemberInfo,System.Type,System.Type[],Castle.DynamicProxy.ProxyGenerationOptions)">
+            <summary>
+              Initializes a new instance of the <see cref = "T:Castle.DynamicProxy.Generators.CacheKey" /> class.
+            </summary>
+            <param name = "target">Target element. This is either target type or target method for invocation types.</param>
+            <param name = "type">The type of the proxy. This is base type for invocation types.</param>
+            <param name = "interfaces">The interfaces.</param>
+            <param name = "options">The options.</param>
+        </member>
+        <member name="M:Castle.DynamicProxy.Generators.CacheKey.#ctor(System.Type,System.Type[],Castle.DynamicProxy.ProxyGenerationOptions)">
+            <summary>
+              Initializes a new instance of the <see cref = "T:Castle.DynamicProxy.Generators.CacheKey" /> class.
+            </summary>
+            <param name = "target">Type of the target.</param>
+            <param name = "interfaces">The interfaces.</param>
+            <param name = "options">The options.</param>
+        </member>
+        <member name="T:Castle.DynamicProxy.Generators.Emitters.LdcOpCodesDictionary">
+            <summary>
+              Provides appropriate Ldc.X opcode for the type of primitive value to be loaded.
+            </summary>
+        </member>
+        <member name="T:Castle.DynamicProxy.Generators.Emitters.LdindOpCodesDictionary">
+            <summary>
+              Provides appropriate Ldind.X opcode for 
+              the type of primitive value to be loaded indirectly.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.Generators.Emitters.OpCodeUtil.EmitLoadIndirectOpCodeForType(System.Reflection.Emit.ILGenerator,System.Type)">
+            <summary>
+              Emits a load indirect opcode of the appropriate type for a value or object reference.
+              Pops a pointer off the evaluation stack, dereferences it and loads
+              a value of the specified type.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.Generators.Emitters.OpCodeUtil.EmitLoadOpCodeForDefaultValueOfType(System.Reflection.Emit.ILGenerator,System.Type)">
+            <summary>
+              Emits a load opcode of the appropriate kind for the constant default value of a
+              type, such as 0 for value types and null for reference types.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.Generators.Emitters.OpCodeUtil.EmitStoreIndirectOpCodeForType(System.Reflection.Emit.ILGenerator,System.Type)">
+            <summary>
+              Emits a store indirectopcode of the appropriate type for a value or object reference.
+              Pops a value of the specified type and a pointer off the evaluation stack, and
+              stores the value.
+            </summary>
+        </member>
+        <member name="T:Castle.DynamicProxy.Generators.Emitters.SimpleAST.IndirectReference">
+            <summary>
+              Wraps a reference that is passed 
+              ByRef and provides indirect load/store support.
+            </summary>
+        </member>
+        <member name="T:Castle.DynamicProxy.Generators.Emitters.StindOpCodesDictionary">
+            <summary>
+              Provides appropriate Stind.X opcode 
+              for the type of primitive value to be stored indirectly.
+            </summary>
+        </member>
+        <member name="T:Castle.DynamicProxy.Generators.INamingScope">
+            <summary>
+              Represents the scope of uniqueness of names for types and their members
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.Generators.INamingScope.GetUniqueName(System.String)">
+            <summary>
+              Gets a unique name based on <paramref name = "suggestedName" />
+            </summary>
+            <param name = "suggestedName">Name suggested by the caller</param>
+            <returns>Unique name based on <paramref name = "suggestedName" />.</returns>
+            <remarks>
+              Implementers should provide name as closely resembling <paramref name = "suggestedName" /> as possible.
+              Generally if no collision occurs it is suggested to return suggested name, otherwise append sequential suffix.
+              Implementers must return deterministic names, that is when <see cref = "M:Castle.DynamicProxy.Generators.INamingScope.GetUniqueName(System.String)" /> is called twice 
+              with the same suggested name, the same returned name should be provided each time. Non-deterministic return
+              values, like appending random suffices will break serialization of proxies.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.Generators.INamingScope.SafeSubScope">
+            <summary>
+              Returns new, disposable naming scope. It is responsibility of the caller to make sure that no naming collision
+              with enclosing scope, or other subscopes is possible.
+            </summary>
+            <returns>New naming scope.</returns>
+        </member>
+        <member name="M:Castle.DynamicProxy.Generators.InvocationTypeGenerator.GetBaseCtorArguments(System.Type,System.Reflection.ConstructorInfo@)">
+            <summary>
+              Generates the constructor for the class that extends
+              <see cref = "T:Castle.DynamicProxy.AbstractInvocation" />
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.Generators.MetaEvent.#ctor(System.Reflection.EventInfo,Castle.DynamicProxy.Generators.MetaMethod,Castle.DynamicProxy.Generators.MetaMethod,System.Reflection.EventAttributes)">
+            <summary>
+              Initializes a new instance of the <see cref = "T:Castle.DynamicProxy.Generators.MetaEvent" /> class.
+            </summary>
+            <param name = "event">The event.</param>
+            <param name = "adder">The add method.</param>
+            <param name = "remover">The remove method.</param>
+            <param name = "attributes">The attributes.</param>
+        </member>
+        <member name="T:Castle.DynamicProxy.IChangeProxyTarget">
+            <summary>
+              Exposes means to change target objects of proxies and invocations.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.IChangeProxyTarget.ChangeInvocationTarget(System.Object)">
+            <summary>
+              Changes the target object (<see cref = "P:Castle.DynamicProxy.IInvocation.InvocationTarget" />) of current <see cref = "T:Castle.DynamicProxy.IInvocation" />.
+            </summary>
+            <param name = "target">The new value of target of invocation.</param>
+            <remarks>
+              Although the method takes <see cref = "T:System.Object" /> the actual instance must be of type assignable to <see
+               cref = "P:Castle.DynamicProxy.IInvocation.TargetType" />, otherwise an <see cref = "T:System.InvalidCastException" /> will be thrown.
+              Also while it's technically legal to pass null reference (Nothing in Visual Basic) as <paramref name = "target" />, for obvious reasons Dynamic Proxy will not be able to call the intercepted method on such target.
+              In this case last interceptor in the pipeline mustn't call <see cref = "M:Castle.DynamicProxy.IInvocation.Proceed" /> or a <see
+               cref = "T:System.NotImplementedException" /> will be throws.
+              Also while it's technically legal to pass proxy itself as <paramref name = "target" />, this would create stack overflow.
+              In this case last interceptor in the pipeline mustn't call <see cref = "M:Castle.DynamicProxy.IInvocation.Proceed" /> or a <see
+               cref = "T:System.InvalidOperationException" /> will be throws.
+            </remarks>
+            <exception cref = "T:System.InvalidCastException">Thrown when <paramref name = "target" /> is not assignable to the proxied type.</exception>
+        </member>
+        <member name="M:Castle.DynamicProxy.IChangeProxyTarget.ChangeProxyTarget(System.Object)">
+            <summary>
+              Permanently changes the target object of the proxy. This does not affect target of the current invocation.
+            </summary>
+            <param name = "target">The new value of target of the proxy.</param>
+            <remarks>
+              Although the method takes <see cref = "T:System.Object" /> the actual instance must be of type assignable to proxy's target type, otherwise an <see
+               cref = "T:System.InvalidCastException" /> will be thrown.
+              Also while it's technically legal to pass null reference (Nothing in Visual Basic) as <paramref name = "target" />, for obvious reasons Dynamic Proxy will not be able to call the intercepted method on such target.
+              In this case last interceptor in the pipeline mustn't call <see cref = "M:Castle.DynamicProxy.IInvocation.Proceed" /> or a <see
+               cref = "T:System.NotImplementedException" /> will be throws.
+              Also while it's technically legal to pass proxy itself as <paramref name = "target" />, this would create stack overflow.
+              In this case last interceptor in the pipeline mustn't call <see cref = "M:Castle.DynamicProxy.IInvocation.Proceed" /> or a <see
+               cref = "T:System.InvalidOperationException" /> will be throws.
+            </remarks>
+            <exception cref = "T:System.InvalidCastException">Thrown when <paramref name = "target" /> is not assignable to the proxied type.</exception>
+        </member>
+        <member name="T:Castle.DynamicProxy.IInterceptor">
+            <summary>
+              Provides the main DynamicProxy extension point that allows member interception.
+            </summary>
+        </member>
+        <member name="T:Castle.DynamicProxy.IInterceptorSelector">
+            <summary>
+              Provides an extension point that allows proxies to choose specific interceptors on
+              a per method basis.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.IInterceptorSelector.SelectInterceptors(System.Type,System.Reflection.MethodInfo,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Selects the interceptors that should intercept calls to the given <paramref name = "method" />.
+            </summary>
+            <param name = "type">The type of the target object.</param>
+            <param name = "method">The method that will be intercepted.</param>
+            <param name = "interceptors">All interceptors registered with the proxy.</param>
+            <returns>An array of interceptors to invoke upon calling the <paramref name = "method" />.</returns>
+            <remarks>
+              This method is called only once per proxy instance, upon the first call to the
+              <paramref name = "method" />. Either an empty array or null are valid return values to indicate
+              that no interceptor should intercept calls to the method. Although it is not advised, it is
+              legal to return other <see cref = "T:Castle.DynamicProxy.IInterceptor" /> implementations than these provided in
+              <paramref name = "interceptors" />.
+            </remarks>
+        </member>
+        <member name="T:Castle.DynamicProxy.IInvocation">
+            <summary>
+              Encapsulates an invocation of a proxied method.
+            </summary>
+        </member>
+        <member name="P:Castle.DynamicProxy.IInvocation.Arguments">
+            <summary>
+              Gets the arguments that the <see cref = "P:Castle.DynamicProxy.IInvocation.Method" /> has been invoked with.
+            </summary>
+            <value>The arguments the method was invoked with.</value>
+        </member>
+        <member name="P:Castle.DynamicProxy.IInvocation.GenericArguments">
+            <summary>
+              Gets the generic arguments of the method.
+            </summary>
+            <value>The generic arguments, or null if not a generic method.</value>
+        </member>
+        <member name="P:Castle.DynamicProxy.IInvocation.InvocationTarget">
+            <summary>
+              Gets the object on which the invocation is performed. This is different from proxy object
+              because most of the time this will be the proxy target object.
+            </summary>
+            <seealso cref = "T:Castle.DynamicProxy.IChangeProxyTarget" />
+            <value>The invocation target.</value>
+        </member>
+        <member name="P:Castle.DynamicProxy.IInvocation.Method">
+            <summary>
+              Gets the <see cref = "T:System.Reflection.MethodInfo" /> representing the method being invoked on the proxy.
+            </summary>
+            <value>The <see cref = "T:System.Reflection.MethodInfo" /> representing the method being invoked.</value>
+        </member>
+        <member name="P:Castle.DynamicProxy.IInvocation.MethodInvocationTarget">
+            <summary>
+              For interface proxies, this will point to the <see cref = "T:System.Reflection.MethodInfo" /> on the target class.
+            </summary>
+            <value>The method invocation target.</value>
+        </member>
+        <member name="P:Castle.DynamicProxy.IInvocation.Proxy">
+            <summary>
+              Gets the proxy object on which the intercepted method is invoked.
+            </summary>
+            <value>Proxy object on which the intercepted method is invoked.</value>
+        </member>
+        <member name="P:Castle.DynamicProxy.IInvocation.ReturnValue">
+            <summary>
+              Gets or sets the return value of the method.
+            </summary>
+            <value>The return value of the method.</value>
+        </member>
+        <member name="P:Castle.DynamicProxy.IInvocation.TargetType">
+            <summary>
+              Gets the type of the target object for the intercepted method.
+            </summary>
+            <value>The type of the target object.</value>
+        </member>
+        <member name="M:Castle.DynamicProxy.IInvocation.GetArgumentValue(System.Int32)">
+            <summary>
+              Gets the value of the argument at the specified <paramref name = "index" />.
+            </summary>
+            <param name = "index">The index.</param>
+            <returns>The value of the argument at the specified <paramref name = "index" />.</returns>
+        </member>
+        <member name="M:Castle.DynamicProxy.IInvocation.GetConcreteMethod">
+            <summary>
+              Returns the concrete instantiation of the <see cref = "P:Castle.DynamicProxy.IInvocation.Method" /> on the proxy, with any generic
+              parameters bound to real types.
+            </summary>
+            <returns>
+              The concrete instantiation of the <see cref = "P:Castle.DynamicProxy.IInvocation.Method" /> on the proxy, or the <see cref = "P:Castle.DynamicProxy.IInvocation.Method" /> if
+              not a generic method.
+            </returns>
+            <remarks>
+              Can be slower than calling <see cref = "P:Castle.DynamicProxy.IInvocation.Method" />.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IInvocation.GetConcreteMethodInvocationTarget">
+            <summary>
+              Returns the concrete instantiation of <see cref = "P:Castle.DynamicProxy.IInvocation.MethodInvocationTarget" />, with any
+              generic parameters bound to real types.
+              For interface proxies, this will point to the <see cref = "T:System.Reflection.MethodInfo" /> on the target class.
+            </summary>
+            <returns>The concrete instantiation of <see cref = "P:Castle.DynamicProxy.IInvocation.MethodInvocationTarget" />, or
+              <see cref = "P:Castle.DynamicProxy.IInvocation.MethodInvocationTarget" /> if not a generic method.</returns>
+            <remarks>
+              In debug builds this can be slower than calling <see cref = "P:Castle.DynamicProxy.IInvocation.MethodInvocationTarget" />.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IInvocation.Proceed">
+            <summary>
+              Proceeds the call to the next interceptor in line, and ultimately to the target method.
+            </summary>
+            <remarks>
+              Since interface proxies without a target don't have the target implementation to proceed to,
+              it is important, that the last interceptor does not call this method, otherwise a
+              <see cref = "T:System.NotImplementedException" /> will be thrown.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IInvocation.CaptureProceedInfo">
+            <summary>
+              Returns an object describing the <see cref="M:Castle.DynamicProxy.IInvocation.Proceed"/> operation for this <see cref="T:Castle.DynamicProxy.IInvocation"/>
+              at this specific point during interception.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.IInvocation.SetArgumentValue(System.Int32,System.Object)">
+            <summary>
+              Overrides the value of an argument at the given <paramref name = "index" /> with the
+              new <paramref name = "value" /> provided.
+            </summary>
+            <remarks>
+              This method accepts an <see cref = "T:System.Object" />, however the value provided must be compatible
+              with the type of the argument defined on the method, otherwise an exception will be thrown.
+            </remarks>
+            <param name = "index">The index of the argument to override.</param>
+            <param name = "value">The new value for the argument.</param>
+        </member>
+        <member name="T:Castle.DynamicProxy.IInvocationProceedInfo">
+            <summary>
+              Describes the <see cref="M:Castle.DynamicProxy.IInvocation.Proceed"/> operation for an <see cref="T:Castle.DynamicProxy.IInvocation"/>
+              at a specific point during interception.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.IInvocationProceedInfo.Invoke">
+            <summary>
+              Executes the <see cref="M:Castle.DynamicProxy.IInvocation.Proceed"/> operation described by this instance.
+            </summary>
+            <exception cref="T:System.NotImplementedException">There is no interceptor, nor a proxy target object, to proceed to.</exception>
+        </member>
+        <member name="M:Castle.DynamicProxy.Internal.AttributeUtil.ShouldSkipAttributeReplication(System.Type,System.Boolean)">
+            <summary>
+              Attributes should be replicated if they are non-inheritable,
+              but there are some special cases where the attributes means
+              something to the CLR, where they should be skipped.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.Internal.TypeUtil.GetAllInstanceMethods(System.Type)">
+            <summary>
+              Returns the methods implemented by a type. Use this instead of Type.GetMethods to filter out duplicate MethodInfos
+              sometimes reported by the latter. The test suite documents cases where such duplicates may occur.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.Internal.TypeUtil.GetAllInterfaces(System.Type[])">
+            <summary>
+              Returns list of all unique interfaces implemented given types, including their base interfaces.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.Internal.TypeUtil.IsDelegateType(System.Type)">
+            <summary>
+              Checks whether the specified <paramref name="type"/> is a delegate type (i.e. a direct subclass of <see cref="T:System.MulticastDelegate"/>).
+            </summary>
+        </member>
+        <member name="T:Castle.DynamicProxy.IProxyBuilder">
+            <summary>
+              Abstracts the implementation of proxy type construction.
+            </summary>
+        </member>
+        <member name="P:Castle.DynamicProxy.IProxyBuilder.Logger">
+            <summary>
+              Gets or sets the <see cref = "T:Castle.Core.Logging.ILogger" /> that this <see cref = "T:Castle.DynamicProxy.ProxyGenerator" /> logs to.
+            </summary>
+        </member>
+        <member name="P:Castle.DynamicProxy.IProxyBuilder.ModuleScope">
+            <summary>
+              Gets the <see cref = "P:Castle.DynamicProxy.IProxyBuilder.ModuleScope" /> associated with this builder.
+            </summary>
+            <value>The module scope associated with this builder.</value>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyBuilder.CreateClassProxyType(System.Type,System.Type[],Castle.DynamicProxy.ProxyGenerationOptions)">
+            <summary>
+              Creates a proxy type for given <paramref name = "classToProxy" />, implementing <paramref
+               name = "additionalInterfacesToProxy" />, using <paramref name = "options" /> provided.
+            </summary>
+            <param name = "classToProxy">The class type to proxy.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types to proxy.</param>
+            <param name = "options">The proxy generation options.</param>
+            <returns>The generated proxy type.</returns>
+            <remarks>
+              Implementers should return a proxy type for the specified class and interfaces.
+              Additional interfaces should be only 'mark' interfaces, that is, they should work like interface proxy without target. (See <see
+               cref = "M:Castle.DynamicProxy.IProxyBuilder.CreateInterfaceProxyTypeWithoutTarget(System.Type,System.Type[],Castle.DynamicProxy.ProxyGenerationOptions)" /> method.)
+            </remarks>
+            <exception cref = "T:System.ArgumentException">Thrown when <paramref name = "classToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when <paramref name = "classToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is not public.
+              Note that to avoid this exception, you can mark offending type internal, and define <see
+               cref = "T:System.Runtime.CompilerServices.InternalsVisibleToAttribute" /> 
+              pointing to Castle Dynamic Proxy assembly, in assembly containing that type, if this is appropriate.</exception>
+            <seealso cref = "T:Castle.DynamicProxy.Generators.ClassProxyGenerator" />
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyBuilder.CreateInterfaceProxyTypeWithTarget(System.Type,System.Type[],System.Type,Castle.DynamicProxy.ProxyGenerationOptions)">
+            <summary>
+              Creates a proxy type that proxies calls to <paramref name = "interfaceToProxy" /> members on <paramref
+               name = "targetType" />, implementing <paramref name = "additionalInterfacesToProxy" />, using <paramref
+               name = "options" /> provided.
+            </summary>
+            <param name = "interfaceToProxy">The interface type to proxy.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types to proxy.</param>
+            <param name = "targetType">Type implementing <paramref name = "interfaceToProxy" /> on which calls to the interface members should be intercepted.</param>
+            <param name = "options">The proxy generation options.</param>
+            <returns>The generated proxy type.</returns>
+            <remarks>
+              Implementers should return a proxy type for the specified interface that 'proceeds' executions to the specified target.
+              Additional interfaces should be only 'mark' interfaces, that is, they should work like interface proxy without target. (See <see
+               cref = "M:Castle.DynamicProxy.IProxyBuilder.CreateInterfaceProxyTypeWithoutTarget(System.Type,System.Type[],Castle.DynamicProxy.ProxyGenerationOptions)" /> method.)
+            </remarks>
+            <exception cref = "T:System.ArgumentException">Thrown when <paramref name = "interfaceToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when <paramref name = "interfaceToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is not public.
+              Note that to avoid this exception, you can mark offending type internal, and define <see
+               cref = "T:System.Runtime.CompilerServices.InternalsVisibleToAttribute" /> 
+              pointing to Castle Dynamic Proxy assembly, in assembly containing that type, if this is appropriate.</exception>
+            <seealso cref = "T:Castle.DynamicProxy.Generators.InterfaceProxyWithTargetGenerator" />
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyBuilder.CreateInterfaceProxyTypeWithTargetInterface(System.Type,System.Type[],Castle.DynamicProxy.ProxyGenerationOptions)">
+            <summary>
+              Creates a proxy type for given <paramref name = "interfaceToProxy" /> and <parmaref
+               name = "additionalInterfacesToProxy" /> that delegates all calls to the provided interceptors and allows interceptors to switch the actual target of invocation.
+            </summary>
+            <param name = "interfaceToProxy">The interface type to proxy.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types to proxy.</param>
+            <param name = "options">The proxy generation options.</param>
+            <returns>The generated proxy type.</returns>
+            <remarks>
+              Implementers should return a proxy type for the specified interface(s) that delegate all executions to the specified interceptors
+              and uses an instance of the interface as their targets (i.e. <see cref = "P:Castle.DynamicProxy.IInvocation.InvocationTarget" />), rather than a class. All <see
+               cref = "T:Castle.DynamicProxy.IInvocation" /> classes should then implement <see cref = "T:Castle.DynamicProxy.IChangeProxyTarget" /> interface,
+              to allow interceptors to switch invocation target with instance of another type implementing called interface.
+            </remarks>
+            <exception cref = "T:System.ArgumentException">Thrown when <paramref name = "interfaceToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when <paramref name = "interfaceToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is not public.
+              Note that to avoid this exception, you can mark offending type internal, and define <see
+               cref = "T:System.Runtime.CompilerServices.InternalsVisibleToAttribute" /> 
+              pointing to Castle Dynamic Proxy assembly, in assembly containing that type, if this is appropriate.</exception>
+            <seealso cref = "T:Castle.DynamicProxy.Generators.InterfaceProxyWithTargetInterfaceGenerator" />
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyBuilder.CreateInterfaceProxyTypeWithoutTarget(System.Type,System.Type[],Castle.DynamicProxy.ProxyGenerationOptions)">
+            <summary>
+              Creates a proxy type for given <paramref name = "interfaceToProxy" /> that delegates all calls to the provided interceptors.
+            </summary>
+            <param name = "interfaceToProxy">The interface type to proxy.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types to proxy.</param>
+            <param name = "options">The proxy generation options.</param>
+            <returns>The generated proxy type.</returns>
+            <remarks>
+              Implementers should return a proxy type for the specified interface and additional interfaces that delegate all executions to the specified interceptors.
+            </remarks>
+            <exception cref = "T:System.ArgumentException">Thrown when <paramref name = "interfaceToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when <paramref name = "interfaceToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is not public.
+              Note that to avoid this exception, you can mark offending type internal, and define <see
+               cref = "T:System.Runtime.CompilerServices.InternalsVisibleToAttribute" /> 
+              pointing to Castle Dynamic Proxy assembly, in assembly containing that type, if this is appropriate.</exception>
+            <seealso cref = "T:Castle.DynamicProxy.Generators.InterfaceProxyWithoutTargetGenerator" />
+        </member>
+        <member name="T:Castle.DynamicProxy.IProxyGenerationHook">
+            <summary>
+              Used during the target type inspection process. Implementors have a chance to customize the
+              proxy generation process.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerationHook.MethodsInspected">
+            <summary>
+              Invoked by the generation process to notify that the whole process has completed.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerationHook.NonProxyableMemberNotification(System.Type,System.Reflection.MemberInfo)">
+            <summary>
+              Invoked by the generation process to notify that a member was not marked as virtual.
+            </summary>
+            <param name = "type">The type which declares the non-virtual member.</param>
+            <param name = "memberInfo">The non-virtual member.</param>
+            <remarks>
+              This method gives an opportunity to inspect any non-proxyable member of a type that has 
+              been requested to be proxied, and if appropriate - throw an exception to notify the caller.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerationHook.ShouldInterceptMethod(System.Type,System.Reflection.MethodInfo)">
+            <summary>
+              Invoked by the generation process to determine if the specified method should be proxied.
+            </summary>
+            <param name = "type">The type which declares the given method.</param>
+            <param name = "methodInfo">The method to inspect.</param>
+            <returns>True if the given method should be proxied; false otherwise.</returns>
+        </member>
+        <member name="T:Castle.DynamicProxy.IProxyGenerator">
+            <summary>
+              Provides proxy objects for classes and interfaces.
+            </summary>
+        </member>
+        <member name="P:Castle.DynamicProxy.IProxyGenerator.Logger">
+            <summary>
+              Gets or sets the <see cref = "T:Castle.Core.Logging.ILogger" /> that this <see cref = "T:Castle.DynamicProxy.ProxyGenerator" /> log to.
+            </summary>
+        </member>
+        <member name="P:Castle.DynamicProxy.IProxyGenerator.ProxyBuilder">
+            <summary>
+              Gets the proxy builder instance used to generate proxy types.
+            </summary>
+            <value>The proxy builder.</value>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithTarget``1(``0,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <typeparamref name = "TInterface" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+            </summary>
+            <typeparam name = "TInterface">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</typeparam>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>Object proxying calls to members of <typeparamref name = "TInterface" /> on <paramref name = "target" /> object.</returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "target" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TInterface" />is not an interface type.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method generates new proxy type for each type of <paramref name = "target" />, which affects performance. If you don't want to proxy types differently depending on the type of the target
+              use <see cref = "M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithTargetInterface``1(``0,Castle.DynamicProxy.IInterceptor[])" /> method.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithTarget``1(``0,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <typeparamref name = "TInterface" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+            </summary>
+            <typeparam name = "TInterface">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</typeparam>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <typeparamref name = "TInterface" /> on <paramref name = "target" /> object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "target" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TInterface" />is not an interface type.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method generates new proxy type for each type of <paramref name = "target" />, which affects performance. If you don't want to proxy types differently depending on the type of the target
+              use <see
+               cref = "M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithTargetInterface``1(``0,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])" /> method.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithTarget(System.Type,System.Object,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> type on <paramref name = "target" /> object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "target" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "target" /> does not implement <paramref
+               name = "interfaceToProxy" /> interface.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method generates new proxy type for each type of <paramref name = "target" />, which affects performance. If you don't want to proxy types differently depending on the type of the target
+              use <see cref = "M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithTargetInterface(System.Type,System.Object,Castle.DynamicProxy.IInterceptor[])" /> method.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithTarget(System.Type,System.Object,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> type on <paramref name = "target" /> object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "target" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "target" /> does not implement <paramref
+               name = "interfaceToProxy" /> interface.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method generates new proxy type for each type of <paramref name = "target" />, which affects performance. If you don't want to proxy types differently depending on the type of the target
+              use <see cref = "M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithTargetInterface(System.Type,System.Object,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])" /> method.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithTarget(System.Type,System.Type[],System.Object,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> and <paramref
+               name = "additionalInterfacesToProxy" /> types  on <paramref name = "target" /> object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "target" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "target" /> does not implement <paramref
+               name = "interfaceToProxy" /> interface.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method generates new proxy type for each type of <paramref name = "target" />, which affects performance. If you don't want to proxy types differently depending on the type of the target
+              use <see cref = "M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithTargetInterface(System.Type,System.Type[],System.Object,Castle.DynamicProxy.IInterceptor[])" /> method.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithTarget(System.Type,System.Type[],System.Object,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> and <paramref
+               name = "additionalInterfacesToProxy" /> types on <paramref name = "target" /> object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "target" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "target" /> does not implement <paramref
+               name = "interfaceToProxy" /> interface.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method generates new proxy type for each type of <paramref name = "target" />, which affects performance. If you don't want to proxy types differently depending on the type of the target
+              use <see cref = "M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithTargetInterface(System.Type,System.Type[],System.Object,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])" /> method.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithTargetInterface(System.Type,System.Object,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+              Interceptors can use <see cref = "T:Castle.DynamicProxy.IChangeProxyTarget" /> interface to provide other target for method invocation than default <paramref
+               name = "target" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> type on <paramref name = "target" /> object or alternative implementation swapped at runtime by an interceptor.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "target" /> does not implement <paramref
+               name = "interfaceToProxy" /> interface.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithTargetInterface``1(``0,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <typeparamref name = "TInterface" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+              Interceptors can use <see cref = "T:Castle.DynamicProxy.IChangeProxyTarget" /> interface to provide other target for method invocation than default <paramref
+               name = "target" />.
+            </summary>
+            <typeparam name = "TInterface">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</typeparam>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <typeparamref name = "TInterface" /> type on <paramref name = "target" /> object or alternative implementation swapped at runtime by an interceptor.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TInterface" /> is not an interface type.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithTargetInterface``1(``0,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <typeparamref name = "TInterface" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+              Interceptors can use <see cref = "T:Castle.DynamicProxy.IChangeProxyTarget" /> interface to provide other target for method invocation than default <paramref
+               name = "target" />.
+            </summary>
+            <typeparam name = "TInterface">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</typeparam>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <typeparamref name = "TInterface" /> type on <paramref name = "target" /> object or alternative implementation swapped at runtime by an interceptor.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TInterface" /> is not an interface type.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithTargetInterface(System.Type,System.Type[],System.Object,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+              Interceptors can use <see cref = "T:Castle.DynamicProxy.IChangeProxyTarget" /> interface to provide other target for method invocation than default <paramref
+               name = "target" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> and <paramref
+               name = "additionalInterfacesToProxy" /> types on <paramref name = "target" /> object or alternative implementation swapped at runtime by an interceptor.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "target" /> does not implement <paramref
+               name = "interfaceToProxy" /> interface.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithTargetInterface(System.Type,System.Object,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+              Interceptors can use <see cref = "T:Castle.DynamicProxy.IChangeProxyTarget" /> interface to provide other target for method invocation than default <paramref
+               name = "target" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> type on <paramref name = "target" /> object or alternative implementation swapped at runtime by an interceptor.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "target" /> does not implement <paramref
+               name = "interfaceToProxy" /> interface.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithTargetInterface(System.Type,System.Type[],System.Object,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on <paramref name = "target" /> object with given <paramref name = "interceptors" />.
+              Interceptors can use <see cref = "T:Castle.DynamicProxy.IChangeProxyTarget" /> interface to provide other target for method invocation than default <paramref name = "target" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> and <paramref name = "additionalInterfacesToProxy" /> types on <paramref name = "target" /> object or alternative implementation swapped at runtime by an interceptor.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> or any of <paramref name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "target" /> does not implement <paramref name = "interfaceToProxy" /> interface.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithoutTarget``1(Castle.DynamicProxy.IInterceptor)">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <typeparamref name = "TInterface" /> on target object generated at runtime with given <paramref
+               name = "interceptor" />.
+            </summary>
+            <typeparam name = "TInterface">Type of the interface which will be proxied.</typeparam>
+            <param name = "interceptor">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <typeparamref name = "TInterface" /> types on generated target object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptor" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TInterface" /> is not an interface type.</exception>
+            <remarks>
+              Since this method uses an empty-shell implementation of interfaces to proxy generated at runtime, the actual implementation of proxied methods must be provided by given <see
+               cref = "T:Castle.DynamicProxy.IInterceptor" /> implementations.
+              They are responsible for setting return value (and out parameters) on proxied methods. It is also illegal for an interceptor to call <see
+               cref = "M:Castle.DynamicProxy.IInvocation.Proceed" />, since there's no actual implementation to proceed with.
+              As a result of that also at least one <see cref = "T:Castle.DynamicProxy.IInterceptor" /> implementation must be provided.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithoutTarget``1(Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <typeparamref name = "TInterface" /> on target object generated at runtime with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <typeparam name = "TInterface">Type of the interface which will be proxied.</typeparam>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <typeparamref name = "TInterface" /> types on generated target object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TInterface" /> is not an interface type.</exception>
+            <remarks>
+              Since this method uses an empty-shell implementation of interfaces to proxy generated at runtime, the actual implementation of proxied methods must be provided by given <see
+               cref = "T:Castle.DynamicProxy.IInterceptor" /> implementations.
+              They are responsible for setting return value (and out parameters) on proxied methods. It is also illegal for an interceptor to call <see
+               cref = "M:Castle.DynamicProxy.IInvocation.Proceed" />, since there's no actual implementation to proceed with.
+              As a result of that also at least one <see cref = "T:Castle.DynamicProxy.IInterceptor" /> implementation must be provided.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithoutTarget``1(Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <typeparamref name = "TInterface" /> on target object generated at runtime with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <typeparam name = "TInterface">Type of the interface which will be proxied.</typeparam>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <typeparamref name = "TInterface" /> types on generated target object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TInterface" /> is not an interface type.</exception>
+            <remarks>
+              Since this method uses an empty-shell implementation of interfaces to proxy generated at runtime, the actual implementation of proxied methods must be provided by given <see
+               cref = "T:Castle.DynamicProxy.IInterceptor" /> implementations.
+              They are responsible for setting return value (and out parameters) on proxied methods. It is also illegal for an interceptor to call <see
+               cref = "M:Castle.DynamicProxy.IInvocation.Proceed" />, since there's no actual implementation to proceed with.
+              As a result of that also at least one <see cref = "T:Castle.DynamicProxy.IInterceptor" /> implementation must be provided.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithoutTarget(System.Type,Castle.DynamicProxy.IInterceptor)">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on target object generated at runtime with given <paramref
+               name = "interceptor" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface which will be proxied.</param>
+            <param name = "interceptor">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> type on generated target object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptor" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <remarks>
+              Since this method uses an empty-shell implementation of interfaces to proxy generated at runtime, the actual implementation of proxied methods must be provided by given <see
+               cref = "T:Castle.DynamicProxy.IInterceptor" /> implementations.
+              They are responsible for setting return value (and out parameters) on proxied methods. It is also illegal for an interceptor to call <see
+               cref = "M:Castle.DynamicProxy.IInvocation.Proceed" />, since there's no actual implementation to proceed with.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithoutTarget(System.Type,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on target object generated at runtime with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface which will be proxied.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> type on generated target object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <remarks>
+              Since this method uses an empty-shell implementation of interfaces to proxy generated at runtime, the actual implementation of proxied methods must be provided by given <see
+               cref = "T:Castle.DynamicProxy.IInterceptor" /> implementations.
+              They are responsible for setting return value (and out parameters) on proxied methods. It is also illegal for an interceptor to call <see
+               cref = "M:Castle.DynamicProxy.IInvocation.Proceed" />, since there's no actual implementation to proceed with.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithoutTarget(System.Type,System.Type[],Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on target object generated at runtime with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface which will be proxied.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> and <paramref
+               name = "additionalInterfacesToProxy" /> types on generated target object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <remarks>
+              Since this method uses an empty-shell implementation of interfaces to proxy generated at runtime, the actual implementation of proxied methods must be provided by given <see
+               cref = "T:Castle.DynamicProxy.IInterceptor" /> implementations.
+              They are responsible for setting return value (and out parameters) on proxied methods. It is also illegal for an interceptor to call <see
+               cref = "M:Castle.DynamicProxy.IInvocation.Proceed" />, since there's no actual implementation to proceed with.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithoutTarget(System.Type,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on target object generated at runtime with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface which will be proxied.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> on generated target object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" />  is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <remarks>
+              They are responsible for setting return value (and out parameters) on proxied methods. It is also illegal for an interceptor to call <see
+               cref = "M:Castle.DynamicProxy.IInvocation.Proceed" />, since there's no actual implementation to proceed with.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateInterfaceProxyWithoutTarget(System.Type,System.Type[],Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on target object generated at runtime with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface which will be proxied.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> and <paramref
+               name = "additionalInterfacesToProxy" /> types on generated target object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <remarks>
+              Since this method uses an empty-shell implementation of <paramref name = "additionalInterfacesToProxy" /> to proxy generated at runtime, the actual implementation of proxied methods must be provided by given <see
+               cref = "T:Castle.DynamicProxy.IInterceptor" /> implementations.
+              They are responsible for setting return value (and out parameters) on proxied methods. It is also illegal for an interceptor to call <see
+               cref = "M:Castle.DynamicProxy.IInvocation.Proceed" />, since there's no actual implementation to proceed with.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateClassProxyWithTarget``1(``0,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <typeparamref name = "TClass" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <typeparam name = "TClass">Type of class which will be proxied.</typeparam>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <typeparamref name = "TClass" /> proxying calls to virtual members of <typeparamref
+               name = "TClass" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TClass" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no default constructor exists on type <typeparamref name = "TClass" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of type <typeparamref name = "TClass" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateClassProxyWithTarget``1(``0,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <typeparamref name = "TClass" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <typeparam name = "TClass">Type of class which will be proxied.</typeparam>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <typeparamref name = "TClass" /> proxying calls to virtual members of <typeparamref
+               name = "TClass" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TClass" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no default constructor exists on type <typeparamref name = "TClass" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of type <typeparamref name = "TClass" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateClassProxyWithTarget(System.Type,System.Type[],System.Object,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> and <paramref name = "additionalInterfacesToProxy" /> types.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no default constructor exists on type <paramref name = "classToProxy" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateClassProxyWithTarget(System.Type,System.Object,Castle.DynamicProxy.ProxyGenerationOptions,System.Object[],Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "constructorArguments">Arguments of constructor of type <paramref name = "classToProxy" /> which should be used to create a new instance of that type.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no constructor exists on type <paramref name = "classToProxy" /> with parameters matching <paramref
+               name = "constructorArguments" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateClassProxyWithTarget(System.Type,System.Object,System.Object[],Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "constructorArguments">Arguments of constructor of type <paramref name = "classToProxy" /> which should be used to create a new instance of that type.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no constructor exists on type <paramref name = "classToProxy" /> with parameters matching <paramref
+               name = "constructorArguments" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateClassProxyWithTarget(System.Type,System.Object,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no parameterless constructor exists on type <paramref
+               name = "classToProxy" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateClassProxyWithTarget(System.Type,System.Object,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "options" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no default constructor exists on type <paramref name = "classToProxy" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateClassProxyWithTarget(System.Type,System.Type[],System.Object,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> and <paramref name = "additionalInterfacesToProxy" /> types.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "options" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no default constructor exists on type <paramref name = "classToProxy" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateClassProxyWithTarget(System.Type,System.Type[],System.Object,Castle.DynamicProxy.ProxyGenerationOptions,System.Object[],Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "constructorArguments">Arguments of constructor of type <paramref name = "classToProxy" /> which should be used to create a new instance of that type.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> and <paramref name = "additionalInterfacesToProxy" /> types.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "options" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no constructor exists on type <paramref name = "classToProxy" /> with parameters matching <paramref
+               name = "constructorArguments" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateClassProxy``1(Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <typeparamref name = "TClass" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <typeparam name = "TClass">Type of class which will be proxied.</typeparam>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <typeparamref name = "TClass" /> proxying calls to virtual members of <typeparamref
+               name = "TClass" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TClass" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no default constructor exists on type <typeparamref name = "TClass" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of type <typeparamref name = "TClass" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateClassProxy``1(Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <typeparamref name = "TClass" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <typeparam name = "TClass">Type of class which will be proxied.</typeparam>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <typeparamref name = "TClass" /> proxying calls to virtual members of <typeparamref
+               name = "TClass" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TClass" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no default constructor exists on type <typeparamref name = "TClass" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of type <typeparamref name = "TClass" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateClassProxy(System.Type,System.Type[],Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> and <paramref name = "additionalInterfacesToProxy" /> types.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no default constructor exists on type <paramref name = "classToProxy" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateClassProxy(System.Type,Castle.DynamicProxy.ProxyGenerationOptions,System.Object[],Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "constructorArguments">Arguments of constructor of type <paramref name = "classToProxy" /> which should be used to create a new instance of that type.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no constructor exists on type <paramref name = "classToProxy" /> with parameters matching <paramref
+               name = "constructorArguments" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateClassProxy(System.Type,System.Object[],Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "constructorArguments">Arguments of constructor of type <paramref name = "classToProxy" /> which should be used to create a new instance of that type.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no constructor exists on type <paramref name = "classToProxy" /> with parameters matching <paramref
+               name = "constructorArguments" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateClassProxy(System.Type,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no parameterless constructor exists on type <paramref
+               name = "classToProxy" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateClassProxy(System.Type,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "options" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no default constructor exists on type <paramref name = "classToProxy" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateClassProxy(System.Type,System.Type[],Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> and <paramref name = "additionalInterfacesToProxy" /> types.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "options" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no default constructor exists on type <paramref name = "classToProxy" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateClassProxy(System.Type,System.Type[],Castle.DynamicProxy.ProxyGenerationOptions,System.Object[],Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "constructorArguments">Arguments of constructor of type <paramref name = "classToProxy" /> which should be used to create a new instance of that type.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> and <paramref name = "additionalInterfacesToProxy" /> types.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "options" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no constructor exists on type <paramref name = "classToProxy" /> with parameters matching <paramref
+               name = "constructorArguments" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateClassProxy``1(Castle.DynamicProxy.ProxyGenerationOptions,System.Object[],Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <typeparamref name = "TClass" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <typeparam name = "TClass">Type of class which will be proxied.</typeparam>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "constructorArguments">Arguments of constructor of type <typeparamref name = "TClass" /> which should be used to create a new instance of that type.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <typeparamref name = "TClass" /> proxying calls to virtual members of <typeparamref name = "TClass" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <typeparamref name = "TClass" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TClass" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TClass" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no constructor exists on type <typeparamref name = "TClass" /> with parameters matching <paramref
+               name = "constructorArguments" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when constructor of type <typeparamref name = "TClass" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyGenerator.CreateClassProxy``1(System.Object[],Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <typeparamref name = "TClass" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <typeparam name = "TClass">Type of class which will be proxied.</typeparam>
+            <param name = "constructorArguments">Arguments of constructor of type <typeparamref name = "TClass" /> which should be used to create a new instance of that type.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <typeparamref name = "TClass" /> proxying calls to virtual members of <typeparamref name = "TClass" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <typeparamref name = "TClass" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TClass" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TClass" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no constructor exists on type <typeparamref name = "TClass" /> with parameters matching <paramref
+               name = "constructorArguments" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when constructor of type <typeparamref name = "TClass" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="T:Castle.DynamicProxy.IProxyTargetAccessor">
+            <summary>
+              Exposes access to the target object and interceptors of proxy objects.
+              This is a DynamicProxy infrastructure interface and should not be implemented yourself.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyTargetAccessor.DynProxyGetTarget">
+            <summary>
+              Get the proxy target (note that null is a valid target!)
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyTargetAccessor.DynProxySetTarget(System.Object)">
+            <summary>
+              Set the proxy target.
+            </summary>
+            <param name="target">New proxy target.</param>
+        </member>
+        <member name="M:Castle.DynamicProxy.IProxyTargetAccessor.GetInterceptors">
+            <summary>
+              Gets the interceptors for the proxy
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.MixinData.#ctor(System.Collections.Generic.IEnumerable{System.Object})">
+            <summary>
+              Because we need to cache the types based on the mixed in mixins, we do the following here:
+              - Get all the mixin interfaces
+              - Sort them by full name
+              - Return them by position
+            
+            The idea is to have reproducible behavior for the case that mixins are registered in different orders.
+            This method is here because it is required 
+            </summary>
+        </member>
+        <member name="F:Castle.DynamicProxy.ModuleScope.DEFAULT_FILE_NAME">
+            <summary>
+              The default file name used when the assembly is saved using <see cref = "F:Castle.DynamicProxy.ModuleScope.DEFAULT_FILE_NAME" />.
+            </summary>
+        </member>
+        <member name="F:Castle.DynamicProxy.ModuleScope.DEFAULT_ASSEMBLY_NAME">
+            <summary>
+              The default assembly (simple) name used for the assemblies generated by a <see cref = "T:Castle.DynamicProxy.ModuleScope" /> instance.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.ModuleScope.#ctor">
+            <summary>
+              Initializes a new instance of the <see cref = "T:Castle.DynamicProxy.ModuleScope" /> class; assemblies created by this instance will not be saved.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.ModuleScope.#ctor(System.Boolean)">
+            <summary>
+              Initializes a new instance of the <see cref = "T:Castle.DynamicProxy.ModuleScope" /> class, allowing to specify whether the assemblies generated by this instance
+              should be saved.
+            </summary>
+            <param name = "savePhysicalAssembly">If set to <c>true</c> saves the generated module.</param>
+        </member>
+        <member name="M:Castle.DynamicProxy.ModuleScope.#ctor(System.Boolean,System.Boolean)">
+            <summary>
+              Initializes a new instance of the <see cref = "T:Castle.DynamicProxy.ModuleScope" /> class, allowing to specify whether the assemblies generated by this instance
+              should be saved.
+            </summary>
+            <param name = "savePhysicalAssembly">If set to <c>true</c> saves the generated module.</param>
+            <param name = "disableSignedModule">If set to <c>true</c> disables ability to generate signed module. This should be used in cases where ran under constrained permissions.</param>
+        </member>
+        <member name="M:Castle.DynamicProxy.ModuleScope.#ctor(System.Boolean,System.Boolean,System.String,System.String,System.String,System.String)">
+            <summary>
+              Initializes a new instance of the <see cref = "T:Castle.DynamicProxy.ModuleScope" /> class, allowing to specify whether the assemblies generated by this instance
+              should be saved and what simple names are to be assigned to them.
+            </summary>
+            <param name = "savePhysicalAssembly">If set to <c>true</c> saves the generated module.</param>
+            <param name = "disableSignedModule">If set to <c>true</c> disables ability to generate signed module. This should be used in cases where ran under constrained permissions.</param>
+            <param name = "strongAssemblyName">The simple name of the strong-named assembly generated by this <see
+               cref = "T:Castle.DynamicProxy.ModuleScope" />.</param>
+            <param name = "strongModulePath">The path and file name of the manifest module of the strong-named assembly generated by this <see
+               cref = "T:Castle.DynamicProxy.ModuleScope" />.</param>
+            <param name = "weakAssemblyName">The simple name of the weak-named assembly generated by this <see cref = "T:Castle.DynamicProxy.ModuleScope" />.</param>
+            <param name = "weakModulePath">The path and file name of the manifest module of the weak-named assembly generated by this <see
+               cref = "T:Castle.DynamicProxy.ModuleScope" />.</param>
+        </member>
+        <member name="M:Castle.DynamicProxy.ModuleScope.#ctor(System.Boolean,System.Boolean,Castle.DynamicProxy.Generators.INamingScope,System.String,System.String,System.String,System.String)">
+            <summary>
+              Initializes a new instance of the <see cref = "T:Castle.DynamicProxy.ModuleScope" /> class, allowing to specify whether the assemblies generated by this instance
+              should be saved and what simple names are to be assigned to them.
+            </summary>
+            <param name = "savePhysicalAssembly">If set to <c>true</c> saves the generated module.</param>
+            <param name = "disableSignedModule">If set to <c>true</c> disables ability to generate signed module. This should be used in cases where ran under constrained permissions.</param>
+            <param name = "namingScope">Naming scope used to provide unique names to generated types and their members (usually via sub-scopes).</param>
+            <param name = "strongAssemblyName">The simple name of the strong-named assembly generated by this <see
+               cref = "T:Castle.DynamicProxy.ModuleScope" />.</param>
+            <param name = "strongModulePath">The path and file name of the manifest module of the strong-named assembly generated by this <see
+               cref = "T:Castle.DynamicProxy.ModuleScope" />.</param>
+            <param name = "weakAssemblyName">The simple name of the weak-named assembly generated by this <see cref = "T:Castle.DynamicProxy.ModuleScope" />.</param>
+            <param name = "weakModulePath">The path and file name of the manifest module of the weak-named assembly generated by this <see
+               cref = "T:Castle.DynamicProxy.ModuleScope" />.</param>
+        </member>
+        <member name="M:Castle.DynamicProxy.ModuleScope.GetKeyPair">
+            <summary>
+              Gets the key pair used to sign the strong-named assembly generated by this <see cref = "T:Castle.DynamicProxy.ModuleScope" />.
+            </summary>
+        </member>
+        <member name="P:Castle.DynamicProxy.ModuleScope.StrongNamedModule">
+            <summary>
+              Gets the strong-named module generated by this scope, or <see langword = "null" /> if none has yet been generated.
+            </summary>
+            <value>The strong-named module generated by this scope, or <see langword = "null" /> if none has yet been generated.</value>
+        </member>
+        <member name="P:Castle.DynamicProxy.ModuleScope.StrongNamedModuleName">
+            <summary>
+              Gets the file name of the strongly named module generated by this scope.
+            </summary>
+            <value>The file name of the strongly named module generated by this scope.</value>
+        </member>
+        <member name="P:Castle.DynamicProxy.ModuleScope.WeakNamedModule">
+            <summary>
+              Gets the weak-named module generated by this scope, or <see langword = "null" /> if none has yet been generated.
+            </summary>
+            <value>The weak-named module generated by this scope, or <see langword = "null" /> if none has yet been generated.</value>
+        </member>
+        <member name="P:Castle.DynamicProxy.ModuleScope.WeakNamedModuleName">
+            <summary>
+              Gets the file name of the weakly named module generated by this scope.
+            </summary>
+            <value>The file name of the weakly named module generated by this scope.</value>
+        </member>
+        <member name="M:Castle.DynamicProxy.ModuleScope.ObtainDynamicModule(System.Boolean)">
+            <summary>
+              Gets the specified module generated by this scope, creating a new one if none has yet been generated.
+            </summary>
+            <param name = "isStrongNamed">If set to true, a strong-named module is returned; otherwise, a weak-named module is returned.</param>
+            <returns>A strong-named or weak-named module generated by this scope, as specified by the <paramref
+               name = "isStrongNamed" /> parameter.</returns>
+        </member>
+        <member name="M:Castle.DynamicProxy.ModuleScope.ObtainDynamicModuleWithStrongName">
+            <summary>
+              Gets the strong-named module generated by this scope, creating a new one if none has yet been generated.
+            </summary>
+            <returns>A strong-named module generated by this scope.</returns>
+        </member>
+        <member name="M:Castle.DynamicProxy.ModuleScope.ObtainDynamicModuleWithWeakName">
+            <summary>
+              Gets the weak-named module generated by this scope, creating a new one if none has yet been generated.
+            </summary>
+            <returns>A weak-named module generated by this scope.</returns>
+        </member>
+        <member name="T:Castle.DynamicProxy.ProxyGenerationOptions">
+            <summary>
+              <see cref="T:Castle.DynamicProxy.ProxyGenerationOptions"/> allows customization of the behavior of proxies created by
+              an <see cref="T:Castle.DynamicProxy.IProxyGenerator"/> (or proxy types generated by an <see cref="T:Castle.DynamicProxy.IProxyBuilder"/>).
+              <para>
+                You should not modify an instance of <see cref="T:Castle.DynamicProxy.ProxyGenerationOptions"/> once it has been
+                used to create a proxy (or proxy type).
+              </para>
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerationOptions.#ctor(Castle.DynamicProxy.IProxyGenerationHook)">
+            <summary>
+              Initializes a new instance of the <see cref = "T:Castle.DynamicProxy.ProxyGenerationOptions" /> class.
+            </summary>
+            <param name = "hook">The hook.</param>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerationOptions.#ctor">
+            <summary>
+              Initializes a new instance of the <see cref = "T:Castle.DynamicProxy.ProxyGenerationOptions" /> class.
+            </summary>
+        </member>
+        <member name="P:Castle.DynamicProxy.ProxyGenerationOptions.Hook">
+            <summary>
+              Gets or sets the <see cref="T:Castle.DynamicProxy.IProxyGenerationHook"/> that should be used during proxy type
+              generation. Defaults to an instance of <see cref="T:Castle.DynamicProxy.AllMethodsHook"/>.
+              <para>
+                You should not modify this property once this <see cref="T:Castle.DynamicProxy.ProxyGenerationOptions"/> instance
+                has been used to create a proxy.
+              </para>
+            </summary>
+        </member>
+        <member name="P:Castle.DynamicProxy.ProxyGenerationOptions.Selector">
+            <summary>
+              Gets or sets the <see cref="T:Castle.DynamicProxy.IInterceptorSelector"/> that should be used by created proxies
+              to determine which interceptors to use for an interception. If set to <see langword="null"/>
+              (which is the default), created proxies will not use any selector.
+              <para>
+                You should not modify this property once this <see cref="T:Castle.DynamicProxy.ProxyGenerationOptions"/> instance
+                has been used to create a proxy.
+              </para>
+            </summary>
+        </member>
+        <member name="P:Castle.DynamicProxy.ProxyGenerationOptions.BaseTypeForInterfaceProxy">
+            <summary>
+              Gets or sets the class type from which generated interface proxy types will be derived.
+              Defaults to <c><see langword="typeof"/>(<see langword="object"/>)</c>.
+              <para>
+                You should not modify this property once this <see cref="T:Castle.DynamicProxy.ProxyGenerationOptions"/> instance
+                has been used to create a proxy.
+              </para>
+            </summary>
+        </member>
+        <member name="P:Castle.DynamicProxy.ProxyGenerationOptions.AdditionalAttributes">
+            <summary>
+              Gets the collection of additional custom attributes that will be put on generated proxy types.
+              This collection is initially empty.
+              <para>
+                You should not modify this collection once this <see cref="T:Castle.DynamicProxy.ProxyGenerationOptions"/> instance
+                has been used to create a proxy.
+              </para>
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerationOptions.AddDelegateTypeMixin(System.Type)">
+            <summary>
+              Adds a delegate type to the list of mixins that will be added to generated proxies.
+              That is, generated proxies will have a `Invoke` method with a signature matching that
+              of the specified <paramref name="delegateType"/>.
+              <para>
+                You should not call this method once this <see cref="T:Castle.DynamicProxy.ProxyGenerationOptions"/> instance
+                has been used to create a proxy.
+              </para>
+            </summary>
+            <param name="delegateType">The delegate type whose `Invoke` method should be reproduced in generated proxies.</param>
+            <exception cref="T:System.ArgumentNullException"><paramref name="delegateType"/> is <see langword="null"/>.</exception>
+            <exception cref="T:System.ArgumentException"><paramref name="delegateType"/> is not a delegate type.</exception>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerationOptions.AddDelegateMixin(System.Delegate)">
+            <summary>
+              Adds a delegate to be mixed into generated proxies. The <paramref name="delegate"/>
+              will act as the target for calls to a `Invoke` method with a signature matching that
+              of the delegate.
+              <para>
+                You should not call this method once this <see cref="T:Castle.DynamicProxy.ProxyGenerationOptions"/> instance
+                has been used to create a proxy.
+              </para>
+            </summary>
+            <param name="delegate">The delegate that should act as the target for calls to `Invoke` methods with a matching signature.</param>
+            <exception cref="T:System.ArgumentNullException"><paramref name="delegate"/> is <see langword="null"/>.</exception>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerationOptions.AddMixinInstance(System.Object)">
+            <summary>
+              Mixes the interfaces implemented by the specified <paramref name="instance"/> object into
+              created proxies, and uses <paramref name="instance"/> as the target for these mixed-in interfaces.
+              <para>
+                You should not call this method once this <see cref="T:Castle.DynamicProxy.ProxyGenerationOptions"/> instance
+                has been used to create a proxy.
+              </para>
+            </summary>
+            <param name="instance">The object that should act as the target for all of its implemented interfaces' methods.</param>
+            <exception cref="T:System.ArgumentNullException"><paramref name="instance"/> is <see langword="null"/>.</exception>
+            <exception cref="T:System.ArgumentException"><paramref name="instance"/> is an instance of <see cref="T:System.Type"/>.</exception>
+        </member>
+        <member name="T:Castle.DynamicProxy.ProxyGenerator">
+            <summary>
+              Provides proxy objects for classes and interfaces.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.#ctor(Castle.DynamicProxy.IProxyBuilder)">
+            <summary>
+              Initializes a new instance of the <see cref = "T:Castle.DynamicProxy.ProxyGenerator" /> class.
+            </summary>
+            <param name = "builder">Proxy types builder.</param>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.#ctor">
+            <summary>
+              Initializes a new instance of the <see cref = "T:Castle.DynamicProxy.ProxyGenerator" /> class.
+            </summary>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.#ctor(System.Boolean)">
+            <summary>
+              Initializes a new instance of the <see cref = "T:Castle.DynamicProxy.ProxyGenerator" /> class.
+            </summary>
+            <param name="disableSignedModule">If <c>true</c> forces all types to be generated into an unsigned module.</param>
+        </member>
+        <member name="P:Castle.DynamicProxy.ProxyGenerator.Logger">
+            <summary>
+              Gets or sets the <see cref = "T:Castle.Core.Logging.ILogger" /> that this <see cref = "T:Castle.DynamicProxy.ProxyGenerator" /> log to.
+            </summary>
+        </member>
+        <member name="P:Castle.DynamicProxy.ProxyGenerator.ProxyBuilder">
+            <summary>
+              Gets the proxy builder instance used to generate proxy types.
+            </summary>
+            <value>The proxy builder.</value>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithTarget``1(``0,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <typeparamref name = "TInterface" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+            </summary>
+            <typeparam name = "TInterface">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</typeparam>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>Object proxying calls to members of <typeparamref name = "TInterface" /> on <paramref name = "target" /> object.</returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "target" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TInterface" />is not an interface type.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method generates new proxy type for each type of <paramref name = "target" />, which affects performance. If you don't want to proxy types differently depending on the type of the target
+              use <see cref = "M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithTargetInterface``1(``0,Castle.DynamicProxy.IInterceptor[])" /> method.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithTarget``1(``0,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <typeparamref name = "TInterface" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+            </summary>
+            <typeparam name = "TInterface">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</typeparam>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <typeparamref name = "TInterface" /> on <paramref name = "target" /> object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "target" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TInterface" />is not an interface type.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method generates new proxy type for each type of <paramref name = "target" />, which affects performance. If you don't want to proxy types differently depending on the type of the target
+              use <see
+               cref = "M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithTargetInterface``1(``0,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])" /> method.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithTarget(System.Type,System.Object,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> type on <paramref name = "target" /> object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "target" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "target" /> does not implement <paramref
+               name = "interfaceToProxy" /> interface.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method generates new proxy type for each type of <paramref name = "target" />, which affects performance. If you don't want to proxy types differently depending on the type of the target
+              use <see cref = "M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithTargetInterface(System.Type,System.Object,Castle.DynamicProxy.IInterceptor[])" /> method.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithTarget(System.Type,System.Object,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> type on <paramref name = "target" /> object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "target" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "target" /> does not implement <paramref
+               name = "interfaceToProxy" /> interface.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method generates new proxy type for each type of <paramref name = "target" />, which affects performance. If you don't want to proxy types differently depending on the type of the target
+              use <see cref = "M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithTargetInterface(System.Type,System.Object,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])" /> method.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithTarget(System.Type,System.Type[],System.Object,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> and <paramref
+               name = "additionalInterfacesToProxy" /> types  on <paramref name = "target" /> object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "target" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "target" /> does not implement <paramref
+               name = "interfaceToProxy" /> interface.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method generates new proxy type for each type of <paramref name = "target" />, which affects performance. If you don't want to proxy types differently depending on the type of the target
+              use <see cref = "M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithTargetInterface(System.Type,System.Type[],System.Object,Castle.DynamicProxy.IInterceptor[])" /> method.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithTarget(System.Type,System.Type[],System.Object,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> and <paramref
+               name = "additionalInterfacesToProxy" /> types on <paramref name = "target" /> object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "target" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "target" /> does not implement <paramref
+               name = "interfaceToProxy" /> interface.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method generates new proxy type for each type of <paramref name = "target" />, which affects performance. If you don't want to proxy types differently depending on the type of the target
+              use <see cref = "M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithTargetInterface(System.Type,System.Type[],System.Object,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])" /> method.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithTargetInterface(System.Type,System.Object,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+              Interceptors can use <see cref = "T:Castle.DynamicProxy.IChangeProxyTarget" /> interface to provide other target for method invocation than default <paramref
+               name = "target" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> type on <paramref name = "target" /> object or alternative implementation swapped at runtime by an interceptor.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "target" /> does not implement <paramref
+               name = "interfaceToProxy" /> interface.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithTargetInterface``1(``0,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <typeparamref name = "TInterface" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+              Interceptors can use <see cref = "T:Castle.DynamicProxy.IChangeProxyTarget" /> interface to provide other target for method invocation than default <paramref
+               name = "target" />.
+            </summary>
+            <typeparam name = "TInterface">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</typeparam>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <typeparamref name = "TInterface" /> type on <paramref name = "target" /> object or alternative implementation swapped at runtime by an interceptor.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TInterface" /> is not an interface type.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithTargetInterface``1(``0,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <typeparamref name = "TInterface" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+              Interceptors can use <see cref = "T:Castle.DynamicProxy.IChangeProxyTarget" /> interface to provide other target for method invocation than default <paramref
+               name = "target" />.
+            </summary>
+            <typeparam name = "TInterface">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</typeparam>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <typeparamref name = "TInterface" /> type on <paramref name = "target" /> object or alternative implementation swapped at runtime by an interceptor.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TInterface" /> is not an interface type.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithTargetInterface(System.Type,System.Type[],System.Object,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+              Interceptors can use <see cref = "T:Castle.DynamicProxy.IChangeProxyTarget" /> interface to provide other target for method invocation than default <paramref
+               name = "target" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> and <paramref
+               name = "additionalInterfacesToProxy" /> types on <paramref name = "target" /> object or alternative implementation swapped at runtime by an interceptor.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "target" /> does not implement <paramref
+               name = "interfaceToProxy" /> interface.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithTargetInterface(System.Type,System.Object,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on <paramref
+               name = "target" /> object with given <paramref name = "interceptors" />.
+              Interceptors can use <see cref = "T:Castle.DynamicProxy.IChangeProxyTarget" /> interface to provide other target for method invocation than default <paramref
+               name = "target" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> type on <paramref name = "target" /> object or alternative implementation swapped at runtime by an interceptor.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "target" /> does not implement <paramref
+               name = "interfaceToProxy" /> interface.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref
+               name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref
+               name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithTargetInterface(System.Type,System.Type[],System.Object,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on <paramref name = "target" /> object with given <paramref name = "interceptors" />.
+              Interceptors can use <see cref = "T:Castle.DynamicProxy.IChangeProxyTarget" /> interface to provide other target for method invocation than default <paramref name = "target" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface implemented by <paramref name = "target" /> which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> and <paramref name = "additionalInterfacesToProxy" /> types on <paramref name = "target" /> object or alternative implementation swapped at runtime by an interceptor.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> or any of <paramref name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "target" /> does not implement <paramref name = "interfaceToProxy" /> interface.</exception>
+            <exception cref = "T:System.MissingMethodException">Thrown when no default constructor exists on actual type of <paramref name = "target" /> object.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of actual type of <paramref name = "target" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithoutTarget``1(Castle.DynamicProxy.IInterceptor)">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <typeparamref name = "TInterface" /> on target object generated at runtime with given <paramref
+               name = "interceptor" />.
+            </summary>
+            <typeparam name = "TInterface">Type of the interface which will be proxied.</typeparam>
+            <param name = "interceptor">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <typeparamref name = "TInterface" /> types on generated target object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptor" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TInterface" /> is not an interface type.</exception>
+            <remarks>
+              Since this method uses an empty-shell implementation of interfaces to proxy generated at runtime, the actual implementation of proxied methods must be provided by given <see
+               cref = "T:Castle.DynamicProxy.IInterceptor" /> implementations.
+              They are responsible for setting return value (and out parameters) on proxied methods. It is also illegal for an interceptor to call <see
+               cref = "M:Castle.DynamicProxy.IInvocation.Proceed" />, since there's no actual implementation to proceed with.
+              As a result of that also at least one <see cref = "T:Castle.DynamicProxy.IInterceptor" /> implementation must be provided.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithoutTarget``1(Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <typeparamref name = "TInterface" /> on target object generated at runtime with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <typeparam name = "TInterface">Type of the interface which will be proxied.</typeparam>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <typeparamref name = "TInterface" /> types on generated target object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TInterface" /> is not an interface type.</exception>
+            <remarks>
+              Since this method uses an empty-shell implementation of interfaces to proxy generated at runtime, the actual implementation of proxied methods must be provided by given <see
+               cref = "T:Castle.DynamicProxy.IInterceptor" /> implementations.
+              They are responsible for setting return value (and out parameters) on proxied methods. It is also illegal for an interceptor to call <see
+               cref = "M:Castle.DynamicProxy.IInvocation.Proceed" />, since there's no actual implementation to proceed with.
+              As a result of that also at least one <see cref = "T:Castle.DynamicProxy.IInterceptor" /> implementation must be provided.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithoutTarget``1(Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <typeparamref name = "TInterface" /> on target object generated at runtime with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <typeparam name = "TInterface">Type of the interface which will be proxied.</typeparam>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <typeparamref name = "TInterface" /> types on generated target object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TInterface" /> is not an interface type.</exception>
+            <remarks>
+              Since this method uses an empty-shell implementation of interfaces to proxy generated at runtime, the actual implementation of proxied methods must be provided by given <see
+               cref = "T:Castle.DynamicProxy.IInterceptor" /> implementations.
+              They are responsible for setting return value (and out parameters) on proxied methods. It is also illegal for an interceptor to call <see
+               cref = "M:Castle.DynamicProxy.IInvocation.Proceed" />, since there's no actual implementation to proceed with.
+              As a result of that also at least one <see cref = "T:Castle.DynamicProxy.IInterceptor" /> implementation must be provided.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithoutTarget(System.Type,Castle.DynamicProxy.IInterceptor)">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on target object generated at runtime with given <paramref
+               name = "interceptor" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface which will be proxied.</param>
+            <param name = "interceptor">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> type on generated target object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptor" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <remarks>
+              Since this method uses an empty-shell implementation of interfaces to proxy generated at runtime, the actual implementation of proxied methods must be provided by given <see
+               cref = "T:Castle.DynamicProxy.IInterceptor" /> implementations.
+              They are responsible for setting return value (and out parameters) on proxied methods. It is also illegal for an interceptor to call <see
+               cref = "M:Castle.DynamicProxy.IInvocation.Proceed" />, since there's no actual implementation to proceed with.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithoutTarget(System.Type,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on target object generated at runtime with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface which will be proxied.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> type on generated target object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <remarks>
+              Since this method uses an empty-shell implementation of interfaces to proxy generated at runtime, the actual implementation of proxied methods must be provided by given <see
+               cref = "T:Castle.DynamicProxy.IInterceptor" /> implementations.
+              They are responsible for setting return value (and out parameters) on proxied methods. It is also illegal for an interceptor to call <see
+               cref = "M:Castle.DynamicProxy.IInvocation.Proceed" />, since there's no actual implementation to proceed with.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithoutTarget(System.Type,System.Type[],Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on target object generated at runtime with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface which will be proxied.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> and <paramref
+               name = "additionalInterfacesToProxy" /> types on generated target object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <remarks>
+              Since this method uses an empty-shell implementation of interfaces to proxy generated at runtime, the actual implementation of proxied methods must be provided by given <see
+               cref = "T:Castle.DynamicProxy.IInterceptor" /> implementations.
+              They are responsible for setting return value (and out parameters) on proxied methods. It is also illegal for an interceptor to call <see
+               cref = "M:Castle.DynamicProxy.IInvocation.Proceed" />, since there's no actual implementation to proceed with.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithoutTarget(System.Type,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on target object generated at runtime with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface which will be proxied.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> on generated target object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" />  is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <remarks>
+              They are responsible for setting return value (and out parameters) on proxied methods. It is also illegal for an interceptor to call <see
+               cref = "M:Castle.DynamicProxy.IInvocation.Proceed" />, since there's no actual implementation to proceed with.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyWithoutTarget(System.Type,System.Type[],Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to members of interface <paramref name = "interfaceToProxy" /> on target object generated at runtime with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "interfaceToProxy">Type of the interface which will be proxied.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              Object proxying calls to members of <paramref name = "interfaceToProxy" /> and <paramref
+               name = "additionalInterfacesToProxy" /> types on generated target object.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interfaceToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "interceptors" /> array is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "interfaceToProxy" /> is not an interface type.</exception>
+            <remarks>
+              Since this method uses an empty-shell implementation of <paramref name = "additionalInterfacesToProxy" /> to proxy generated at runtime, the actual implementation of proxied methods must be provided by given <see
+               cref = "T:Castle.DynamicProxy.IInterceptor" /> implementations.
+              They are responsible for setting return value (and out parameters) on proxied methods. It is also illegal for an interceptor to call <see
+               cref = "M:Castle.DynamicProxy.IInvocation.Proceed" />, since there's no actual implementation to proceed with.
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxyWithTarget``1(``0,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <typeparamref name = "TClass" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <typeparam name = "TClass">Type of class which will be proxied.</typeparam>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <typeparamref name = "TClass" /> proxying calls to virtual members of <typeparamref
+               name = "TClass" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TClass" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no default constructor exists on type <typeparamref name = "TClass" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of type <typeparamref name = "TClass" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxyWithTarget``1(``0,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <typeparamref name = "TClass" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <typeparam name = "TClass">Type of class which will be proxied.</typeparam>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <typeparamref name = "TClass" /> proxying calls to virtual members of <typeparamref
+               name = "TClass" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TClass" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no default constructor exists on type <typeparamref name = "TClass" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of type <typeparamref name = "TClass" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxyWithTarget(System.Type,System.Type[],System.Object,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> and <paramref name = "additionalInterfacesToProxy" /> types.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no default constructor exists on type <paramref name = "classToProxy" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxyWithTarget(System.Type,System.Object,Castle.DynamicProxy.ProxyGenerationOptions,System.Object[],Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "constructorArguments">Arguments of constructor of type <paramref name = "classToProxy" /> which should be used to create a new instance of that type.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no constructor exists on type <paramref name = "classToProxy" /> with parameters matching <paramref
+               name = "constructorArguments" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxyWithTarget(System.Type,System.Object,System.Object[],Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "constructorArguments">Arguments of constructor of type <paramref name = "classToProxy" /> which should be used to create a new instance of that type.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no constructor exists on type <paramref name = "classToProxy" /> with parameters matching <paramref
+               name = "constructorArguments" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxyWithTarget(System.Type,System.Object,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no parameterless constructor exists on type <paramref
+               name = "classToProxy" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxyWithTarget(System.Type,System.Object,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "options" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no default constructor exists on type <paramref name = "classToProxy" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxyWithTarget(System.Type,System.Type[],System.Object,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> and <paramref name = "additionalInterfacesToProxy" /> types.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "options" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no default constructor exists on type <paramref name = "classToProxy" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxyWithTarget(System.Type,System.Type[],System.Object,Castle.DynamicProxy.ProxyGenerationOptions,System.Object[],Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "target">The target object, calls to which will be intercepted.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "constructorArguments">Arguments of constructor of type <paramref name = "classToProxy" /> which should be used to create a new instance of that type.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> and <paramref name = "additionalInterfacesToProxy" /> types.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "options" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no constructor exists on type <paramref name = "classToProxy" /> with parameters matching <paramref
+               name = "constructorArguments" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxy``1(Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <typeparamref name = "TClass" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <typeparam name = "TClass">Type of class which will be proxied.</typeparam>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <typeparamref name = "TClass" /> proxying calls to virtual members of <typeparamref
+               name = "TClass" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TClass" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no default constructor exists on type <typeparamref name = "TClass" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of type <typeparamref name = "TClass" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxy``1(Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <typeparamref name = "TClass" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <typeparam name = "TClass">Type of class which will be proxied.</typeparam>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <typeparamref name = "TClass" /> proxying calls to virtual members of <typeparamref
+               name = "TClass" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TClass" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no default constructor exists on type <typeparamref name = "TClass" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of type <typeparamref name = "TClass" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxy``1(Castle.DynamicProxy.ProxyGenerationOptions,System.Object[],Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <typeparamref name = "TClass" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <typeparam name = "TClass">Type of class which will be proxied.</typeparam>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "constructorArguments">Arguments of constructor of type <typeparamref name = "TClass" /> which should be used to create a new instance of that type.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <typeparamref name = "TClass" /> proxying calls to virtual members of <typeparamref name = "TClass" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <typeparamref name = "TClass" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TClass" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TClass" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no constructor exists on type <typeparamref name = "TClass" /> with parameters matching <paramref
+               name = "constructorArguments" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when constructor of type <typeparamref name = "TClass" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxy``1(System.Object[],Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <typeparamref name = "TClass" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <typeparam name = "TClass">Type of class which will be proxied.</typeparam>
+            <param name = "constructorArguments">Arguments of constructor of type <typeparamref name = "TClass" /> which should be used to create a new instance of that type.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <typeparamref name = "TClass" /> proxying calls to virtual members of <typeparamref name = "TClass" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <typeparamref name = "TClass" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TClass" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <typeparamref name = "TClass" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no constructor exists on type <typeparamref name = "TClass" /> with parameters matching <paramref
+               name = "constructorArguments" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when constructor of type <typeparamref name = "TClass" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxy(System.Type,System.Type[],Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> and <paramref name = "additionalInterfacesToProxy" /> types.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no default constructor exists on type <paramref name = "classToProxy" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxy(System.Type,Castle.DynamicProxy.ProxyGenerationOptions,System.Object[],Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "constructorArguments">Arguments of constructor of type <paramref name = "classToProxy" /> which should be used to create a new instance of that type.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no constructor exists on type <paramref name = "classToProxy" /> with parameters matching <paramref
+               name = "constructorArguments" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxy(System.Type,System.Object[],Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "constructorArguments">Arguments of constructor of type <paramref name = "classToProxy" /> which should be used to create a new instance of that type.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no constructor exists on type <paramref name = "classToProxy" /> with parameters matching <paramref
+               name = "constructorArguments" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxy(System.Type,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no parameterless constructor exists on type <paramref
+               name = "classToProxy" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxy(System.Type,Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> type.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "options" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no default constructor exists on type <paramref name = "classToProxy" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxy(System.Type,System.Type[],Castle.DynamicProxy.ProxyGenerationOptions,Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> and <paramref name = "additionalInterfacesToProxy" /> types.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "options" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no default constructor exists on type <paramref name = "classToProxy" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when default constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxy(System.Type,System.Type[],Castle.DynamicProxy.ProxyGenerationOptions,System.Object[],Castle.DynamicProxy.IInterceptor[])">
+            <summary>
+              Creates proxy object intercepting calls to virtual members of type <paramref name = "classToProxy" /> on newly created instance of that type with given <paramref
+               name = "interceptors" />.
+            </summary>
+            <param name = "classToProxy">Type of class which will be proxied.</param>
+            <param name = "additionalInterfacesToProxy">Additional interface types. Calls to their members will be proxied as well.</param>
+            <param name = "options">The proxy generation options used to influence generated proxy type and object.</param>
+            <param name = "constructorArguments">Arguments of constructor of type <paramref name = "classToProxy" /> which should be used to create a new instance of that type.</param>
+            <param name = "interceptors">The interceptors called during the invocation of proxied methods.</param>
+            <returns>
+              New object of type <paramref name = "classToProxy" /> proxying calls to virtual members of <paramref
+               name = "classToProxy" /> and <paramref name = "additionalInterfacesToProxy" /> types.
+            </returns>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "classToProxy" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentNullException">Thrown when given <paramref name = "options" /> object is a null reference (Nothing in Visual Basic).</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> or any of <paramref
+               name = "additionalInterfacesToProxy" /> is a generic type definition.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when given <paramref name = "classToProxy" /> is not a class type.</exception>
+            <exception cref = "T:System.ArgumentException">Thrown when no constructor exists on type <paramref name = "classToProxy" /> with parameters matching <paramref
+               name = "constructorArguments" />.</exception>
+            <exception cref = "T:System.Reflection.TargetInvocationException">Thrown when constructor of type <paramref name = "classToProxy" /> throws an exception.</exception>
+            <remarks>
+              This method uses <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation to generate a proxy type.
+              As such caller should expect any type of exception that given <see cref = "T:Castle.DynamicProxy.IProxyBuilder" /> implementation may throw.
+            </remarks>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateClassProxyType(System.Type,System.Type[],Castle.DynamicProxy.ProxyGenerationOptions)">
+            <summary>
+              Creates the proxy type for class proxy with given <paramref name = "classToProxy" /> class, implementing given <paramref
+               name = "additionalInterfacesToProxy" /> and using provided <paramref name = "options" />.
+            </summary>
+            <param name = "classToProxy">The base class for proxy type.</param>
+            <param name = "additionalInterfacesToProxy">The interfaces that proxy type should implement.</param>
+            <param name = "options">The options for proxy generation process.</param>
+            <returns><see cref = "T:System.Type" /> of proxy.</returns>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyTypeWithTarget(System.Type,System.Type[],System.Type,Castle.DynamicProxy.ProxyGenerationOptions)">
+            <summary>
+              Creates the proxy type for interface proxy with target for given <paramref name = "interfaceToProxy" /> interface, implementing given <paramref
+               name = "additionalInterfacesToProxy" /> on given <paramref name = "targetType" /> and using provided <paramref
+               name = "options" />.
+            </summary>
+            <param name = "interfaceToProxy">The interface proxy type should implement.</param>
+            <param name = "additionalInterfacesToProxy">The additional interfaces proxy type should implement.</param>
+            <param name = "targetType">Actual type that the proxy type will encompass.</param>
+            <param name = "options">The options for proxy generation process.</param>
+            <returns><see cref = "T:System.Type" /> of proxy.</returns>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyTypeWithTargetInterface(System.Type,System.Type[],Castle.DynamicProxy.ProxyGenerationOptions)">
+            <summary>
+              Creates the proxy type for interface proxy with target interface for given <paramref name = "interfaceToProxy" /> interface, implementing given <paramref
+               name = "additionalInterfacesToProxy" /> on given <paramref name = "interfaceToProxy" /> and using provided <paramref
+               name = "options" />.
+            </summary>
+            <param name = "interfaceToProxy">The interface proxy type should implement.</param>
+            <param name = "additionalInterfacesToProxy">The additional interfaces proxy type should implement.</param>
+            <param name = "options">The options for proxy generation process.</param>
+            <returns><see cref = "T:System.Type" /> of proxy.</returns>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyGenerator.CreateInterfaceProxyTypeWithoutTarget(System.Type,System.Type[],Castle.DynamicProxy.ProxyGenerationOptions)">
+            <summary>
+              Creates the proxy type for interface proxy without target for given <paramref name = "interfaceToProxy" /> interface, implementing given <paramref
+               name = "additionalInterfacesToProxy" /> and using provided <paramref name = "options" />.
+            </summary>
+            <param name = "interfaceToProxy">The interface proxy type should implement.</param>
+            <param name = "additionalInterfacesToProxy">The additional interfaces proxy type should implement.</param>
+            <param name = "options">The options for proxy generation process.</param>
+            <returns><see cref = "T:System.Type" /> of proxy.</returns>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyUtil.CreateDelegateToMixin``1(System.Object)">
+            <summary>
+              Creates a delegate of the specified type to a suitable `Invoke` method
+              on the given <paramref name="proxy"/> instance.
+            </summary>
+            <param name="proxy">The proxy instance to which the delegate should be bound.</param>
+            <typeparam name="TDelegate">The type of delegate that should be created.</typeparam>
+            <exception cref="T:System.MissingMethodException">
+              The <paramref name="proxy"/> does not have an `Invoke` method that is compatible with
+              the requested <typeparamref name="TDelegate"/> type.
+            </exception>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyUtil.CreateDelegateToMixin(System.Object,System.Type)">
+            <summary>
+              Creates a delegate of the specified type to a suitable `Invoke` method
+              on the given <paramref name="proxy"/> instance.
+            </summary>
+            <param name="proxy">The proxy instance to which the delegate should be bound.</param>
+            <param name="delegateType">The type of delegate that should be created.</param>
+            <exception cref="T:System.MissingMethodException">
+              The <paramref name="proxy"/> does not have an `Invoke` method that is compatible with
+              the requested <paramref name="delegateType"/>.
+            </exception>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyUtil.IsAccessible(System.Reflection.MethodBase)">
+            <summary>
+            Checks whether the specified method is accessible to DynamicProxy.</summary>
+            <param name="method">The method to check.</param>
+            <returns><c>true</c> if the method is accessible to DynamicProxy, <c>false</c> otherwise.</returns>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyUtil.IsAccessible(System.Reflection.MethodBase,System.String@)">
+            <summary>
+            Checks whether the specified method is accessible to DynamicProxy.</summary>
+            <param name="method">The method to check.</param>
+            <param name="message">If the method is accessible to DynamicProxy, <c>null</c>; otherwise, an explanation of why the method is not accessible.</param>
+            <returns><c>true</c> if the method is accessible to DynamicProxy, <c>false</c> otherwise.</returns>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyUtil.IsAccessible(System.Type)">
+            <summary>
+            Checks whether the specified type is accessible to DynamicProxy.</summary>
+            <param name="type">The type to check.</param>
+            <returns><c>true</c> if the type is accessible to DynamicProxy, <c>false</c> otherwise.</returns>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyUtil.AreInternalsVisibleToDynamicProxy(System.Reflection.Assembly)">
+            <summary>
+              Determines whether this assembly has internals visible to DynamicProxy.
+            </summary>
+            <param name="asm">The assembly to inspect.</param>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyUtil.IsAccessibleMethod(System.Reflection.MethodBase)">
+            <summary>
+              Checks whether the specified method is accessible to DynamicProxy.
+              Unlike with <see cref="M:Castle.DynamicProxy.ProxyUtil.IsAccessible(System.Reflection.MethodBase)"/>, the declaring type's accessibility is ignored.
+            </summary>
+            <param name = "method">The method to check.</param>
+            <returns><c>true</c> if the method is accessible to DynamicProxy, <c>false</c> otherwise.</returns>
+        </member>
+        <member name="M:Castle.DynamicProxy.ProxyUtil.IsInternal(System.Reflection.MethodBase)">
+            <summary>
+              Determines whether the specified method is internal.
+            </summary>
+            <param name = "method">The method.</param>
+            <returns>
+              <c>true</c> if the specified method is internal; otherwise, <c>false</c>.
+            </returns>
+        </member>
+        <member name="T:Castle.DynamicProxy.Tokens.InvocationMethods">
+            <summary>
+              Holds <see cref = "T:System.Reflection.MethodInfo" /> objects representing methods of <see cref = "T:Castle.DynamicProxy.AbstractInvocation" /> class.
+            </summary>
+        </member>
+    </members>
+</doc>

--- a/Tests/Plugins/castle.core.5.2.1/Castle.Core.xml.meta
+++ b/Tests/Plugins/castle.core.5.2.1/Castle.Core.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ed3198134b4ba3e468fc2d55703c5938
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Plugins/nsubstitute.5.3.0.meta
+++ b/Tests/Plugins/nsubstitute.5.3.0.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0e656186e2acacd4289e218a79f219f1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Plugins/nsubstitute.5.3.0/NSubstitute.dll
+++ b/Tests/Plugins/nsubstitute.5.3.0/NSubstitute.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f2ff179ad67cc4e6a48566578cf2d8efd604d0c99e3ff35920f4ddd4278675c
+size 165888

--- a/Tests/Plugins/nsubstitute.5.3.0/NSubstitute.dll.meta
+++ b/Tests/Plugins/nsubstitute.5.3.0/NSubstitute.dll.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 08dc9844c4bd83048b3dddc7862d0fa1

--- a/Tests/Plugins/nsubstitute.5.3.0/NSubstitute.xml
+++ b/Tests/Plugins/nsubstitute.5.3.0/NSubstitute.xml
@@ -1,0 +1,1479 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>NSubstitute</name>
+    </assembly>
+    <members>
+        <member name="T:NSubstitute.Arg">
+            <summary>
+            Argument matchers used for specifying calls to substitutes.
+            </summary>
+        </member>
+        <member name="T:NSubstitute.Arg.AnyType">
+            <summary>
+            This type can be used with any matcher to match a generic type parameter.
+            </summary>
+            <remarks>
+            If the generic type parameter has constraints, you will have to create a derived class/struct that
+            implements those constraints.
+            </remarks>
+        </member>
+        <member name="M:NSubstitute.Arg.Any``1">
+            <summary>
+            Match any argument value compatible with type <typeparamref name="T"/>.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.Is``1(``0)">
+            <summary>
+            Match argument that is equal to <paramref name="value"/>.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.Is``1(System.Linq.Expressions.Expression{System.Predicate{``0}})">
+            <summary>
+            Match argument that satisfies <paramref name="predicate"/>.
+            If the <paramref name="predicate"/> throws an exception for an argument it will be treated as non-matching.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.Is``1(System.Linq.Expressions.Expression{System.Predicate{System.Object}})">
+            <summary>
+            Match argument that satisfies <paramref name="predicate"/>.
+            If the <paramref name="predicate"/> throws an exception for an argument it will be treated as non-matching.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.Invoke">
+            <summary>
+            Invoke any <see cref="T:System.Action"/> argument whenever a matching call is made to the substitute.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.Invoke``1(``0)">
+            <summary>
+            Invoke any <see cref="T:System.Action`1"/> argument with specified argument whenever a matching call is made to the substitute.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.Invoke``2(``0,``1)">
+            <summary>
+            Invoke any <see cref="T:System.Action`2"/> argument with specified arguments whenever a matching call is made to the substitute.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.Invoke``3(``0,``1,``2)">
+            <summary>
+            Invoke any <see cref="T:System.Action`3"/> argument with specified arguments whenever a matching call is made to the substitute.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.Invoke``4(``0,``1,``2,``3)">
+            <summary>
+            Invoke any <see cref="T:System.Action`4"/> argument with specified arguments whenever a matching call is made to the substitute.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.InvokeDelegate``1(System.Object[])">
+            <summary>
+            Invoke any <typeparamref name="TDelegate"/> argument with specified arguments whenever a matching call is made to the substitute.
+            </summary>
+            <param name="arguments">Arguments to pass to delegate.</param>
+        </member>
+        <member name="M:NSubstitute.Arg.Do``1(System.Action{``0})">
+            <summary>
+            Capture any argument compatible with type <typeparamref name="T"/> and use it to call the <paramref name="useArgument"/> function
+            whenever a matching call is made to the substitute.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.Do``1(System.Action{System.Object})">
+            <summary>
+            Capture any argument compatible with type <typeparamref name="T"/> and use it to call the <paramref name="useArgument"/> function
+            whenever a matching call is made to the substitute.
+            </summary>
+        </member>
+        <member name="T:NSubstitute.Arg.Compat">
+             <summary>
+             Alternate version of <see cref="T:NSubstitute.Arg"/> matchers for compatibility with pre-C#7 compilers
+             which do not support <c>ref</c> return types. Do not use unless you are unable to use <see cref="T:NSubstitute.Arg"/>.
+            
+             For more information see <see href="https://nsubstitute.github.io/help/compat-args">Compatibility Argument
+             Matchers</see> in the NSubstitute documentation.
+             </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.Compat.Any``1">
+            <summary>
+            Match any argument value compatible with type <typeparamref name="T"/>.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.Any``1" /> instead.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.Compat.Is``1(``0)">
+            <summary>
+            Match argument that is equal to <paramref name="value"/>.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.Is``1(``0)" /> instead.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.Compat.Is``1(System.Linq.Expressions.Expression{System.Predicate{``0}})">
+            <summary>
+            Match argument that satisfies <paramref name="predicate"/>.
+            If the <paramref name="predicate"/> throws an exception for an argument it will be treated as non-matching.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.Is``1(System.Linq.Expressions.Expression{System.Predicate{``0}})" /> instead.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.Compat.Is``1(System.Linq.Expressions.Expression{System.Predicate{System.Object}})">
+            <summary>
+            Match argument that satisfies <paramref name="predicate"/>.
+            If the <paramref name="predicate"/> throws an exception for an argument it will be treated as non-matching.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.Is``1(System.Linq.Expressions.Expression{System.Predicate{``0}})" /> instead.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.Compat.Invoke">
+            <summary>
+            Invoke any <see cref="T:System.Action"/> argument whenever a matching call is made to the substitute.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.Invoke" /> instead.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.Compat.Invoke``1(``0)">
+            <summary>
+            Invoke any <see cref="T:System.Action`1"/> argument with specified argument whenever a matching call is made to the substitute.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.Invoke``1(``0)" /> instead.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.Compat.Invoke``2(``0,``1)">
+            <summary>
+            Invoke any <see cref="T:System.Action`2"/> argument with specified arguments whenever a matching call is made to the substitute.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.Invoke``2(``0,``1)" /> instead.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.Compat.Invoke``3(``0,``1,``2)">
+            <summary>
+            Invoke any <see cref="T:System.Action`3"/> argument with specified arguments whenever a matching call is made to the substitute.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.Invoke``3(``0,``1,``2)" /> instead.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.Compat.Invoke``4(``0,``1,``2,``3)">
+            <summary>
+            Invoke any <see cref="T:System.Action`4"/> argument with specified arguments whenever a matching call is made to the substitute.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.Invoke``4(``0,``1,``2,``3)" /> instead.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.Compat.InvokeDelegate``1(System.Object[])">
+            <summary>
+            Invoke any <typeparamref name="TDelegate"/> argument with specified arguments whenever a matching call is made to the substitute.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.InvokeDelegate``1(System.Object[])" /> instead.
+            </summary>
+            <param name="arguments">Arguments to pass to delegate.</param>
+        </member>
+        <member name="M:NSubstitute.Arg.Compat.Do``1(System.Action{``0})">
+            <summary>
+            Capture any argument compatible with type <typeparamref name="T"/> and use it to call the <paramref name="useArgument"/> function
+            whenever a matching call is made to the substitute.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.Do``1(System.Action{``0})" /> instead.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Arg.Compat.Do``1(System.Action{System.Object})">
+            <summary>
+            Capture any argument compatible with type <typeparamref name="T"/> and use it to call the <paramref name="useArgument"/> function
+            whenever a matching call is made to the substitute.
+            </summary>
+        </member>
+        <member name="T:NSubstitute.Callback">
+            <summary>
+            Perform this chain of callbacks and/or always callback when called.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Callback.First(System.Action{NSubstitute.Core.CallInfo})">
+            <summary>
+            Perform as first in chain of callback when called.
+            </summary>
+            <param name="doThis"></param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.Callback.Always(System.Action{NSubstitute.Core.CallInfo})">
+            <summary>
+            Perform this action always when callback is called.
+            </summary>
+            <param name="doThis"></param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.Callback.FirstThrow``1(System.Func{NSubstitute.Core.CallInfo,``0})">
+            <summary>
+            Throw exception returned by function as first callback in chain of callback when called.
+            </summary>
+            <param name="throwThis"></param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.Callback.FirstThrow``1(``0)">
+            <summary>
+            Throw this exception as first callback in chain of callback when called.
+            </summary>
+            <param name="exception"></param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.Callback.AlwaysThrow``1(System.Func{NSubstitute.Core.CallInfo,``0})">
+            <summary>
+            Throw exception returned by function always when callback is called.
+            </summary>
+            <typeparam name="TException">The type of the exception.</typeparam>
+            <param name="throwThis">The throw this.</param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.Callback.AlwaysThrow``1(``0)">
+            <summary>
+            Throw this exception always when callback is called.
+            </summary>
+            <typeparam name="TException">The type of the exception.</typeparam>
+            <param name="exception">The exception.</param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.Callbacks.ConfiguredCallback.Then(System.Action{NSubstitute.Core.CallInfo})">
+            <summary>
+            Perform this action once in chain of called callbacks.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Callbacks.ConfiguredCallback.ThenKeepDoing(System.Action{NSubstitute.Core.CallInfo})">
+            <summary>
+            Keep doing this action after the other callbacks have run.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Callbacks.ConfiguredCallback.ThenKeepThrowing``1(System.Func{NSubstitute.Core.CallInfo,``0})">
+            <summary>
+            Keep throwing this exception after the other callbacks have run.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Callbacks.ConfiguredCallback.ThenKeepThrowing``1(``0)">
+            <summary>
+            Keep throwing this exception after the other callbacks have run.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Callbacks.ConfiguredCallback.ThenThrow``1(System.Func{NSubstitute.Core.CallInfo,``0})">
+            <summary>
+            Throw exception returned by function once when called in a chain of callbacks.
+            </summary>
+            <typeparam name="TException">The type of the exception</typeparam>
+            <param name="throwThis">Produce the exception to throw for a CallInfo</param>
+        </member>
+        <member name="M:NSubstitute.Callbacks.ConfiguredCallback.ThenThrow``1(``0)">
+            <summary>
+            Throw this exception once when called in a chain of callbacks.
+            </summary>
+            <typeparam name="TException">The type of the exception</typeparam>
+            <param name="exception">The exception to throw</param>
+        </member>
+        <member name="M:NSubstitute.Callbacks.EndCallbackChain.AndAlways(System.Action{NSubstitute.Core.CallInfo})">
+            <summary>
+            Perform the given action for every call.
+            </summary>
+            <param name="doThis">The action to perform for every call</param>
+        </member>
+        <member name="F:NSubstitute.ClearOptions.ReceivedCalls">
+            <summary>
+            Clear all the received calls
+            </summary>
+        </member>
+        <member name="F:NSubstitute.ClearOptions.ReturnValues">
+            <summary>
+            Clear all configured return results (including auto-substituted values).
+            </summary>
+        </member>
+        <member name="F:NSubstitute.ClearOptions.CallActions">
+            <summary>
+            Clear all call actions configured for this substitute (via When..Do, Arg.Invoke, and Arg.Do)
+            </summary>
+        </member>
+        <member name="F:NSubstitute.ClearOptions.All">
+            <summary>
+            Clears all received calls and configured return values and callbacks.
+            </summary>
+        </member>
+        <member name="T:NSubstitute.Compatibility.CompatArg">
+             <summary>
+             Alternate version of <see cref="T:NSubstitute.Arg"/> matchers for compatibility with pre-C#7 compilers
+             which do not support <c>ref</c> return types. Do not use unless you are unable to use <see cref="T:NSubstitute.Arg"/>.
+            
+             <see cref="T:NSubstitute.Compatibility.CompatArg"/> provides a non-static version of <see cref="T:NSubstitute.Arg.Compat"/>, which can make it easier
+             to use from an abstract base class. You can get a reference to this instance using the static
+             <see cref="F:NSubstitute.Compatibility.CompatArg.Instance" /> field.
+            
+             For more information see <see href="https://nsubstitute.github.io/help/compat-args">Compatibility Argument
+             Matchers</see> in the NSubstitute documentation.
+             </summary>
+        </member>
+        <member name="F:NSubstitute.Compatibility.CompatArg.Instance">
+            <summary>
+            Get the CompatArg instance.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Compatibility.CompatArg.Any``1">
+            <summary>
+            Match any argument value compatible with type <typeparamref name="T"/>.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.Any``1" /> instead.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Compatibility.CompatArg.Is``1(``0)">
+            <summary>
+            Match argument that is equal to <paramref name="value"/>.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.Is``1(``0)" /> instead.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Compatibility.CompatArg.Is``1(System.Linq.Expressions.Expression{System.Predicate{``0}})">
+            <summary>
+            Match argument that satisfies <paramref name="predicate"/>.
+            If the <paramref name="predicate"/> throws an exception for an argument it will be treated as non-matching.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.Is``1(System.Linq.Expressions.Expression{System.Predicate{``0}})" /> instead.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Compatibility.CompatArg.Is``1(System.Linq.Expressions.Expression{System.Predicate{System.Object}})">
+            <summary>
+            Match argument that satisfies <paramref name="predicate"/>.
+            If the <paramref name="predicate"/> throws an exception for an argument it will be treated as non-matching.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.Is``1(System.Linq.Expressions.Expression{System.Predicate{System.Object}})" /> instead.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Compatibility.CompatArg.Invoke">
+            <summary>
+            Invoke any <see cref="T:System.Action"/> argument whenever a matching call is made to the substitute.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.Invoke" /> instead.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Compatibility.CompatArg.Invoke``1(``0)">
+            <summary>
+            Invoke any <see cref="T:System.Action`1"/> argument with specified argument whenever a matching call is made to the substitute.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.Invoke``1(``0)" /> instead.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Compatibility.CompatArg.Invoke``2(``0,``1)">
+            <summary>
+            Invoke any <see cref="T:System.Action`2"/> argument with specified arguments whenever a matching call is made to the substitute.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.Invoke``2(``0,``1)" /> instead.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Compatibility.CompatArg.Invoke``3(``0,``1,``2)">
+            <summary>
+            Invoke any <see cref="T:System.Action`3"/> argument with specified arguments whenever a matching call is made to the substitute.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.Invoke``3(``0,``1,``2)" /> instead.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Compatibility.CompatArg.Invoke``4(``0,``1,``2,``3)">
+            <summary>
+            Invoke any <see cref="T:System.Action`4"/> argument with specified arguments whenever a matching call is made to the substitute.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.Invoke``4(``0,``1,``2,``3)" /> instead.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Compatibility.CompatArg.InvokeDelegate``1(System.Object[])">
+            <summary>
+            Invoke any <typeparamref name="TDelegate"/> argument with specified arguments whenever a matching call is made to the substitute.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.InvokeDelegate``1(System.Object[])" /> instead.
+            </summary>
+            <param name="arguments">Arguments to pass to delegate.</param>
+        </member>
+        <member name="M:NSubstitute.Compatibility.CompatArg.Do``1(System.Action{``0})">
+            <summary>
+            Capture any argument compatible with type <typeparamref name="T"/> and use it to call the <paramref name="useArgument"/> function
+            whenever a matching call is made to the substitute.
+            This is provided for compatibility with older compilers --
+            if possible use <see cref="M:NSubstitute.Arg.Do``1(System.Action{``0})" /> instead.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Compatibility.CompatArg.Do``1(System.Action{System.Object})">
+            <summary>
+            Capture any argument compatible with type <typeparamref name="T"/> and use it to call the <paramref name="useArgument"/> function
+            whenever a matching call is made to the substitute.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.Arguments.ArgumentMatcher.Enqueue``1(NSubstitute.Core.Arguments.IArgumentMatcher{``0})">
+            <summary>
+            Enqueues a matcher for the method argument in current position and returns the value which should be
+            passed back to the method you invoke.
+            </summary>
+        </member>
+        <member name="T:NSubstitute.Core.Arguments.IArgumentMatcher">
+            <summary>
+            Provides a specification for arguments for use with <see ctype="Arg.Matches (IArgumentMatcher)" />.
+            Can additionally implement <see cref="T:NSubstitute.Core.IDescribeNonMatches" /> to give descriptions when arguments do not match.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.Arguments.IArgumentMatcher.IsSatisfiedBy(System.Object)">
+            <summary>
+            Checks whether the <paramref name="argument"/> satisfies the condition of the matcher.
+            If this throws an exception the argument will be treated as non-matching.
+            </summary>
+        </member>
+        <member name="T:NSubstitute.Core.Arguments.IArgumentMatcher`1">
+            <summary>
+            Provides a specification for arguments for use with <see ctype="Arg.Matches &lt; T &gt;(IArgumentMatcher)" />.
+            Can additionally implement <see ctype="IDescribeNonMatches" /> to give descriptions when arguments do not match.
+            </summary>
+            <typeparam name="T">Matches arguments of type <typeparamref name="T"/> or compatible type.</typeparam>
+        </member>
+        <member name="M:NSubstitute.Core.Arguments.IArgumentMatcher`1.IsSatisfiedBy(`0)">
+            <summary>
+            Checks whether the <paramref name="argument"/> satisfies the condition of the matcher.
+            If this throws an exception the argument will be treated as non-matching.
+            </summary>
+        </member>
+        <member name="P:NSubstitute.Core.CallBaseConfiguration.CallBaseByDefault">
+            <inheritdoc />
+        </member>
+        <member name="M:NSubstitute.Core.CallBaseConfiguration.Exclude(NSubstitute.Core.ICallSpecification)">
+            <inheritdoc />
+        </member>
+        <member name="M:NSubstitute.Core.CallBaseConfiguration.Include(NSubstitute.Core.ICallSpecification)">
+            <inheritdoc />
+        </member>
+        <member name="M:NSubstitute.Core.CallBaseConfiguration.ShouldCallBase(NSubstitute.Core.ICall)">
+            <inheritdoc />
+        </member>
+        <member name="T:NSubstitute.Core.CallCollection.IReceivedCallEntry">
+            <summary>
+            Performance optimization. Allows to mark call as deleted without allocating extra wrapper.
+            To play safely, we track ownership, so object can be re-used only once.
+            </summary>
+        </member>
+        <member name="T:NSubstitute.Core.CallCollection.ReceivedCallEntry">
+            <summary>
+            Wrapper to track that particular entry was deleted.
+            That is needed because concurrent collections don't have a Delete method.
+            Notice, in most cases the original <see cref="P:NSubstitute.Core.CallCollection.ReceivedCallEntry.Call"/> instance will be used as a wrapper itself.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.CallCollection.ReceivedCallEntry.#ctor(NSubstitute.Core.ICall)">
+            <summary>
+            Wrapper to track that particular entry was deleted.
+            That is needed because concurrent collections don't have a Delete method.
+            Notice, in most cases the original <see cref="P:NSubstitute.Core.CallCollection.ReceivedCallEntry.Call"/> instance will be used as a wrapper itself.
+            </summary>
+        </member>
+        <member name="P:NSubstitute.Core.CallInfo.Item(System.Int32)">
+            <summary>
+            Gets the nth argument to this call.
+            </summary>
+            <param name="index">Index of argument</param>
+            <returns>The value of the argument at the given index</returns>
+        </member>
+        <member name="M:NSubstitute.Core.CallInfo.Args">
+            <summary>
+            Get the arguments passed to this call.
+            </summary>
+            <returns>Array of all arguments passed to this call</returns>
+        </member>
+        <member name="M:NSubstitute.Core.CallInfo.ArgTypes">
+            <summary>
+            Gets the types of all the arguments passed to this call.
+            </summary>
+            <returns>Array of types of all arguments passed to this call</returns>
+        </member>
+        <member name="M:NSubstitute.Core.CallInfo.Arg``1">
+            <summary>
+            Gets the argument of type `T` passed to this call. This will throw if there are no arguments
+            of this type, or if there is more than one matching argument.
+            </summary>
+            <typeparam name="T">The type of the argument to retrieve</typeparam>
+            <returns>The argument passed to the call, or throws if there is not exactly one argument of this type</returns>
+        </member>
+        <member name="M:NSubstitute.Core.CallInfo.ArgAt``1(System.Int32)">
+            <summary>
+            Gets the argument passed to this call at the specified zero-based position, converted to type `T`.
+            This will throw if there are no arguments, if the argument is out of range or if it
+            cannot be converted to the specified type.
+            </summary>
+            <typeparam name="T">The type of the argument to retrieve</typeparam>
+            <param name="position">The zero-based position of the argument to retrieve</param>
+            <returns>The argument passed to the call, or throws if there is not exactly one argument of this type</returns>
+        </member>
+        <member name="M:NSubstitute.Core.ConfiguredCall.AndDoes(System.Action{NSubstitute.Core.CallInfo})">
+            <summary>
+            Adds a callback to execute for matching calls.
+            </summary>
+            <param name="action">an action to call</param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.Core.DependencyInjection.INSubContainer.Customize">
+            <summary>
+            Creates a new container based on the current one,
+            which can be configured to override the existing registrations without affecting the existing container.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.DependencyInjection.INSubContainer.CreateScope">
+            <summary>
+            Create an explicit scope, so all dependencies with the <see cref="F:NSubstitute.Core.DependencyInjection.NSubLifetime.PerScope"/> lifetime
+            are preserved for multiple resolve requests.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.DependencyInjection.IConfigurableNSubContainer.Decorate``1(System.Func{``0,NSubstitute.Core.DependencyInjection.INSubResolver,``0})">
+            <summary>
+            Decorates the original implementation with a custom decorator.
+            The factory method is provided with an original implementation instance.
+            The lifetime of decorated implementation is used.
+            </summary>
+        </member>
+        <member name="T:NSubstitute.Core.DependencyInjection.NSubContainer">
+            <summary>
+            Tiny and very limited implementation of the DI services.
+            Container supports the following features required by NSubstitute:
+                - Registration by type with automatic constructor injection
+                - Registration of factory methods for the complex objects
+                - Support of the most required lifetimes:
+                    - <see cref="F:NSubstitute.Core.DependencyInjection.NSubLifetime.Transient" />
+                    - <see cref="F:NSubstitute.Core.DependencyInjection.NSubLifetime.PerScope" />
+                    - <see cref="F:NSubstitute.Core.DependencyInjection.NSubLifetime.Singleton" />
+                - Immutability (via interfaces) and customization by creating a nested container
+            </summary>
+        </member>
+        <member name="F:NSubstitute.Core.DependencyInjection.NSubLifetime.Singleton">
+            <summary>
+            Value is created only once.
+            </summary>
+        </member>
+        <member name="F:NSubstitute.Core.DependencyInjection.NSubLifetime.PerScope">
+            <summary>
+            Value is created only once per scope. Allows to share the same instance across the objects in the same graph.
+            If no explicit scope is created, an implicit scope is created per single resolve request.
+            </summary>
+        </member>
+        <member name="F:NSubstitute.Core.DependencyInjection.NSubLifetime.Transient">
+            <summary>
+            New value is created for each time.
+            </summary>
+        </member>
+        <member name="P:NSubstitute.Core.DependencyInjection.NSubstituteDefaultFactory.DefaultContainer">
+            <summary>
+            The default NSubstitute registrations. Feel free to configure the existing container to customize
+            and override NSubstitute parts.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.Extensions.IsCompatibleWith(System.Object,System.Type)">
+            <summary>
+            Checks if the instance can be used when a <paramref name="type"/> is expected.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.Extensions.Join(System.Collections.Generic.IEnumerable{System.String},System.String)">
+            <summary>
+            Join the <paramref name="strings"/> using <paramref name="separator"/>.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.Extensions.AsArray``1(System.Collections.Generic.IEnumerable{``0})">
+            <summary>
+            Tries to cast sequence to array first before making a new array sequence.
+            </summary>
+        </member>
+        <member name="P:NSubstitute.Core.ICallBaseConfiguration.CallBaseByDefault">
+            <summary>
+            Gets or sets whether base method should be called by default.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.ICallBaseConfiguration.Exclude(NSubstitute.Core.ICallSpecification)">
+            <summary>
+            Specifies whether base method should be always ignored for the matching call.
+            If method is both explicitly excluded and included, base method is _not_ called.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.ICallBaseConfiguration.Include(NSubstitute.Core.ICallSpecification)">
+            <summary>
+            Specifies whether base method should be called for the matching call.
+            If method is both explicitly excluded and included, base method is _not_ called.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.ICallBaseConfiguration.ShouldCallBase(NSubstitute.Core.ICall)">
+            <summary>
+            Tests whether base method should be called for the call given the existing configuration.
+            </summary>
+        </member>
+        <member name="P:NSubstitute.Core.ICallRouter.CallBaseByDefault">
+            <summary>
+            Specifies whether base method should be called by default.
+            </summary>
+            <remarks>
+            This configuration is considered only when base method exists (e.g. you created a substitute for
+            the AbstractType with method implementation).
+            </remarks>
+        </member>
+        <member name="T:NSubstitute.Core.CallHandlerFactory">
+            <summary>
+                Factory method which creates <see cref="T:NSubstitute.Core.ICallHandler" /> from the <see cref="T:NSubstitute.Core.ISubstituteState" />.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.IDescribeNonMatches.DescribeFor(System.Object)">
+            <summary>
+            Describes how the <paramref name="argument" /> does not match the condition specified by this class, or <see cref="F:System.String.Empty"/>
+            if a detailed description can not be provided for the argument.
+            </summary>
+            <param name="argument"></param>
+            <returns>Description of the non-match, or <see cref="F:System.String.Empty" /> if no description can be provided.</returns>
+        </member>
+        <member name="T:NSubstitute.Core.ICallIndependentReturn">
+            <summary>
+            Performance optimization. Allows to not construct <see cref="T:NSubstitute.Core.CallInfo"/> if configured result doesn't depend on it.
+            </summary>
+        </member>
+        <member name="P:NSubstitute.Core.ISubstitutionContext.ThreadContext">
+            <summary>
+            A thread bound state of the NSubstitute context. Usually this API is used to provide the fluent
+            features of the NSubstitute.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.IThreadLocalContext.SetNextRoute(NSubstitute.Core.ICallRouter,System.Func{NSubstitute.Core.ISubstituteState,NSubstitute.Routing.IRoute})">
+            <summary>
+            Sets the route to use for the next call dispatch on the current thread for the specified <paramref name="callRouter"/>.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.IThreadLocalContext.UseNextRoute(NSubstitute.Core.ICallRouter)">
+            <summary>
+            Returns the previously configured next route and resets the stored value.
+            If route was configured for the different router, returns <see langword="null"/> and persist the route info.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.IThreadLocalContext.UsePendingRaisingEventArgumentsFactory">
+            <summary>
+            Returns the previously set arguments factory and resets the stored value.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.IThreadLocalContext.RunInQueryContext(System.Action,NSubstitute.Core.IQuery)">
+            <summary>
+            Invokes the passed callback in a context of the specified query.
+            </summary>
+        </member>
+        <member name="T:NSubstitute.Core.Maybe`1">
+            <summary>
+            Particularly poor implementation of Maybe/Option type.
+            This is just filling an immediate need; use FSharpOption or XSharpx or similar for a
+            real implementation.
+            </summary>
+            <typeparam name="T"></typeparam>
+        </member>
+        <member name="T:NSubstitute.Core.RobustThreadLocal`1">
+            <summary>
+            Delegates to ThreadLocal&lt;T&gt;, but wraps Value property access in try/catch to swallow ObjectDisposedExceptions.
+            These can occur if the Value property is accessed from the finalizer thread. Because we can't detect this, we'll
+            just swallow the exception (the finalizer thread won't be using any of the values from thread local storage anyway).
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.SubstituteFactory.Create(System.Type[],System.Object[])">
+            <summary>
+            Create a substitute for the given types.
+            </summary>
+            <param name="typesToProxy"></param>
+            <param name="constructorArguments"></param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.Core.SubstituteFactory.CreatePartial(System.Type[],System.Object[])">
+            <summary>
+            Create an instance of the given types, with calls configured to call the base implementation
+            where possible. Parts of the instance can be substituted using
+            <see cref="M:NSubstitute.SubstituteExtensions.Returns``1(``0,``0,``0[])">Returns()</see>.
+            </summary>
+            <param name="typesToProxy"></param>
+            <param name="constructorArguments"></param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.Core.WhenCalled`1.Do(System.Action{NSubstitute.Core.CallInfo})">
+            <summary>
+            Perform this action when called.
+            </summary>
+            <param name="callbackWithArguments"></param>
+        </member>
+        <member name="M:NSubstitute.Core.WhenCalled`1.Do(NSubstitute.Callback)">
+            <summary>
+            Perform this configured callback when called.
+            </summary>
+            <param name="callback"></param>
+        </member>
+        <member name="M:NSubstitute.Core.WhenCalled`1.DoNotCallBase">
+            <summary>
+            Do not call the base implementation on future calls. For use with partial substitutes.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.WhenCalled`1.CallBase">
+            <summary>
+            Call the base implementation of future calls. For use with non-partial class substitutes.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.WhenCalled`1.Throw(System.Exception)">
+            <summary>
+            Throw the specified exception when called.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.WhenCalled`1.Throw``1">
+            <summary>
+            Throw an exception of the given type when called.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.WhenCalled`1.Throw(System.Func{NSubstitute.Core.CallInfo,System.Exception})">
+            <summary>
+            Throw an exception generated by the specified function when called.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Core.WhenCalled`1.Throws(System.Exception)">
+            <summary>
+            Throws the specified exception when called.
+            </summary>
+            Prefer <see cref="M:NSubstitute.Core.WhenCalled`1.Throw(System.Exception)" /> for readability.
+        </member>
+        <member name="M:NSubstitute.Core.WhenCalled`1.Throws``1">
+            <summary>
+            Throws an exception of the given type when called.
+            </summary>
+            Prefer <see cref="M:NSubstitute.Core.WhenCalled`1.Throw``1" /> for readability.
+        </member>
+        <member name="M:NSubstitute.Core.WhenCalled`1.Throws(System.Func{NSubstitute.Core.CallInfo,System.Exception})">
+            <summary>
+            Throws an exception generated by the specified function when called.
+            </summary>
+            Prefer <see cref="M:NSubstitute.Core.WhenCalled`1.Throw(System.Func{NSubstitute.Core.CallInfo,System.Exception})" /> for readability.
+        </member>
+        <member name="M:NSubstitute.ClearExtensions.ClearExtensions.ClearSubstitute``1(``0,NSubstitute.ClearOptions)">
+            <summary>
+            Clears received calls, configured return values and/or call actions for this substitute.
+            </summary>
+            <typeparam name="T"></typeparam>
+            <param name="substitute"></param>
+            <param name="options">Specifies what to clear on the substitute. Can be combined with <code>|</code> to 
+            clear multiple aspects at once.</param>
+            <remarks>
+            </remarks>
+        </member>
+        <member name="M:NSubstitute.Extensions.ConfigurationExtensions.Configure``1(``0)">
+            <summary>
+            A hint for the NSubstitute that the subsequent method/property call is about to be configured.
+            For example: substitute.Configure().GetValue().Returns(1,2,3);
+            <para>
+            NOTICE, you _don't need_ to invoke this method for the basic configuration scenarios.
+            Ensure you don't overuse this method and it is applied only if strictly required.
+            </para>
+            <remarks>
+            Due to the NSubstitute configuration syntax it is often impossible to recognise during the method call
+            dispatch whether this is a setup phase or a regular method call.
+            Usually it doesn't matter, however sometimes method invocation could lead to undesired side effects
+            (e.g. the previously configured value is returned, base method is invoked). In that case you might want to
+            provide NSubstitute with a hint that you are configuring a method, so it handles the call in configuration mode.
+            </remarks>
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Extensions.ReturnsForAllExtensions.ReturnsForAll``1(System.Object,``0)">
+            <summary>
+            Configure default return value for all methods that return the specified type
+            </summary>
+            <typeparam name="T"></typeparam>
+            <param name = "substitute"></param>
+            <param name="returnThis"></param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.Extensions.ReturnsForAllExtensions.ReturnsForAll``1(System.Object,System.Func{NSubstitute.Core.CallInfo,``0})">
+            <summary>
+            Configure default return value for all methods that return the specified type, calculated by a function
+            </summary>
+            <typeparam name="T"></typeparam>
+            <param name="substitute"></param>
+            <param name="returnThis"></param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.ExceptionExtensions.ExceptionExtensions.Throws(System.Object,System.Exception)">
+            <summary>
+            Throw an exception for this call.
+            </summary>
+            <param name="value"></param>
+            <param name="ex">Exception to throw</param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.ExceptionExtensions.ExceptionExtensions.Throws``1(System.Object)">
+            <summary>
+            Throw an exception of the given type for this call.
+            </summary>
+            <typeparam name="TException">Type of exception to throw</typeparam>
+            <param name="value"></param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.ExceptionExtensions.ExceptionExtensions.Throws(System.Object,System.Func{NSubstitute.Core.CallInfo,System.Exception})">
+            <summary>
+            Throw an exception for this call, as generated by the specified function.
+            </summary>
+            <param name="value"></param>
+            <param name="createException">Func creating exception object</param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.ExceptionExtensions.ExceptionExtensions.ThrowsForAnyArgs(System.Object,System.Exception)">
+            <summary>
+            Throw an exception for this call made with any arguments.
+            </summary>
+            <param name="value"></param>
+            <param name="ex">Exception to throw</param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.ExceptionExtensions.ExceptionExtensions.ThrowsForAnyArgs``1(System.Object)">
+            <summary>
+            Throws an exception of the given type for this call made with any arguments.
+            </summary>
+            <typeparam name="TException">Type of exception to throw</typeparam>
+            <param name="value"></param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.ExceptionExtensions.ExceptionExtensions.ThrowsForAnyArgs(System.Object,System.Func{NSubstitute.Core.CallInfo,System.Exception})">
+            <summary>
+            Throws an exception for this call made with any arguments, as generated by the specified function.
+            </summary>
+            <param name="value"></param>
+            <param name="createException">Func creating exception object</param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.ExceptionExtensions.ExceptionExtensions.ThrowsAsync(System.Threading.Tasks.Task,System.Exception)">
+            <summary>
+            Throw an exception for this call.
+            </summary>
+            <param name="value"></param>
+            <param name="ex">Exception to throw</param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.ExceptionExtensions.ExceptionExtensions.ThrowsAsync``1(System.Threading.Tasks.Task{``0},System.Exception)">
+            <summary>
+            Throw an exception for this call.
+            </summary>
+            <param name="value"></param>
+            <param name="ex">Exception to throw</param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.ExceptionExtensions.ExceptionExtensions.ThrowsAsync``1(System.Threading.Tasks.Task)">
+            <summary>
+            Throw an exception of the given type for this call.
+            </summary>
+            <typeparam name="TException">Type of exception to throw</typeparam>
+            <param name="value"></param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.ExceptionExtensions.ExceptionExtensions.ThrowsAsync(System.Threading.Tasks.Task,System.Func{NSubstitute.Core.CallInfo,System.Exception})">
+            <summary>
+            Throw an exception for this call, as generated by the specified function.
+            </summary>
+            <param name="value"></param>
+            <param name="createException">Func creating exception object</param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.ExceptionExtensions.ExceptionExtensions.ThrowsAsync``1(System.Threading.Tasks.Task{``0},System.Func{NSubstitute.Core.CallInfo,System.Exception})">
+            <summary>
+            Throw an exception for this call, as generated by the specified function.
+            </summary>
+            <param name="value"></param>
+            <param name="createException">Func creating exception object</param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.ExceptionExtensions.ExceptionExtensions.ThrowsAsyncForAnyArgs(System.Threading.Tasks.Task,System.Exception)">
+            <summary>
+            Throw an exception for this call made with any arguments.
+            </summary>
+            <param name="value"></param>
+            <param name="ex">Exception to throw</param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.ExceptionExtensions.ExceptionExtensions.ThrowsAsyncForAnyArgs``1(System.Threading.Tasks.Task{``0},System.Exception)">
+            <summary>
+            Throw an exception for this call made with any arguments.
+            </summary>
+            <param name="value"></param>
+            <param name="ex">Exception to throw</param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.ExceptionExtensions.ExceptionExtensions.ThrowsAsyncForAnyArgs``1(System.Threading.Tasks.Task)">
+            <summary>
+            Throws an exception of the given type for this call made with any arguments.
+            </summary>
+            <typeparam name="TException">Type of exception to throw</typeparam>
+            <param name="value"></param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.ExceptionExtensions.ExceptionExtensions.ThrowsAsyncForAnyArgs(System.Threading.Tasks.Task,System.Func{NSubstitute.Core.CallInfo,System.Exception})">
+            <summary>
+            Throws an exception for this call made with any arguments, as generated by the specified function.
+            </summary>
+            <param name="value"></param>
+            <param name="createException">Func creating exception object</param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.ExceptionExtensions.ExceptionExtensions.ThrowsAsyncForAnyArgs``1(System.Threading.Tasks.Task{``0},System.Func{NSubstitute.Core.CallInfo,System.Exception})">
+            <summary>
+            Throws an exception for this call made with any arguments, as generated by the specified function.
+            </summary>
+            <param name="value"></param>
+            <param name="createException">Func creating exception object</param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.ReceivedExtensions.ReceivedExtensions.Received``1(``0,NSubstitute.ReceivedExtensions.Quantity)">
+            <summary>
+            Checks this substitute has received the following call the required number of times.
+            </summary>
+            <typeparam name="T"></typeparam>
+            <param name="substitute"></param>
+            <param name="requiredQuantity"></param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.ReceivedExtensions.ReceivedExtensions.ReceivedWithAnyArgs``1(``0,NSubstitute.ReceivedExtensions.Quantity)">
+            <summary>
+            Checks this substitute has received the following call with any arguments the required number of times.
+            </summary>
+            <typeparam name="T"></typeparam>
+            <param name="substitute"></param>
+            <param name="requiredQuantity"></param>
+            <returns></returns>
+        </member>
+        <member name="T:NSubstitute.ReceivedExtensions.Quantity">
+            <summary>
+            Represents a quantity. Primarily used for specifying a required amount of calls to a member.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.ReceivedExtensions.Quantity.Within(System.Int32,System.Int32)">
+            <summary>
+            A non-zero quantity between the given minimum and maximum numbers (inclusive).
+            </summary>
+            <param name="minInclusive">Minimum quantity (inclusive). Must be greater than or equal to 0.</param>
+            <param name="maxInclusive">Maximum quantity (inclusive). Must be greater than minInclusive.</param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.ReceivedExtensions.Quantity.Matches``1(System.Collections.Generic.IEnumerable{``0})">
+            <summary>
+            Returns whether the given collection contains the required quantity of items.
+            </summary>
+            <typeparam name="T"></typeparam>
+            <param name="items"></param>
+            <returns>true if the collection has the required quantity; otherwise false.</returns>
+        </member>
+        <member name="M:NSubstitute.ReceivedExtensions.Quantity.RequiresMoreThan``1(System.Collections.Generic.IEnumerable{``0})">
+            <summary>
+            Returns whether the given collections needs more items to satisfy the required quantity.
+            </summary>
+            <typeparam name="T"></typeparam>
+            <param name="items"></param>
+            <returns>true if the collection needs more items to match this quantity; otherwise false.</returns>
+        </member>
+        <member name="M:NSubstitute.ReceivedExtensions.Quantity.Describe(System.String,System.String)">
+            <summary>
+            Describe this quantity using the given noun variants.
+            For example, `Describe("item", "items")` could return the description:
+            "more than 1 item, but less than 10 items".
+            </summary>
+            <param name="singularNoun"></param>
+            <param name="pluralNoun"></param>
+            <returns>A string describing the required quantity of items identified by the provided noun forms.</returns>
+        </member>
+        <member name="M:NSubstitute.ReturnsExtensions.ReturnsExtensions.ReturnsNull``1(``0)">
+            <summary>
+            Set null as returned value for this call.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.ReturnsExtensions.ReturnsExtensions.ReturnsNullForAnyArgs``1(``0)">
+            <summary>
+            Set null as returned value for this call made with any arguments.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.ReturnsExtensions.ReturnsExtensions.ReturnsNull``1(System.Nullable{``0})">
+            <summary>
+            Set null as returned value for this call.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.ReturnsExtensions.ReturnsExtensions.ReturnsNullForAnyArgs``1(System.Nullable{``0})">
+            <summary>
+            Set null as returned value for this call made with any arguments.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.ReturnsExtensions.ReturnsExtensions.ReturnsNull``1(System.Threading.Tasks.Task{``0})">
+            <summary>
+            Set null as returned value for this call.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.ReturnsExtensions.ReturnsExtensions.ReturnsNull``1(System.Threading.Tasks.ValueTask{``0})">
+            <summary>
+            Set null as returned value for this call.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.ReturnsExtensions.ReturnsExtensions.ReturnsNullForAnyArgs``1(System.Threading.Tasks.Task{``0})">
+            <summary>
+            Set null as returned value for this call made with any arguments.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.ReturnsExtensions.ReturnsExtensions.ReturnsNullForAnyArgs``1(System.Threading.Tasks.ValueTask{``0})">
+            <summary>
+            Set null as returned value for this call made with any arguments.
+            </summary>
+            <typeparam name="T"></typeparam>
+            <param name="value"></param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.ReturnsExtensions.ReturnsExtensions.ReturnsNull``1(System.Threading.Tasks.Task{System.Nullable{``0}})">
+            <summary>
+            Set null as returned value for this call.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.ReturnsExtensions.ReturnsExtensions.ReturnsNullForAnyArgs``1(System.Threading.Tasks.Task{System.Nullable{``0}})">
+            <summary>
+            Set null as returned value for this call made with any arguments.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.ReturnsExtensions.ReturnsExtensions.ReturnsNull``1(System.Threading.Tasks.ValueTask{System.Nullable{``0}})">
+            <summary>
+            Set null as returned value for this call.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.ReturnsExtensions.ReturnsExtensions.ReturnsNullForAnyArgs``1(System.Threading.Tasks.ValueTask{System.Nullable{``0}})">
+            <summary>
+            Set null as returned value for this call made with any arguments.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Proxies.CastleDynamicProxy.CastleForwardingInterceptor.SwitchToFullDispatchMode">
+            <summary>
+            Switches interceptor to dispatch calls via the full pipeline.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Raise.EventWith``1(System.Object,``0)">
+            <summary>
+            Raise an event for an <c>EventHandler&lt;TEventArgs&gt;</c> event with the provided <paramref name="sender"/> and <paramref name="eventArgs"/>.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Raise.EventWith``1(``0)">
+            <summary>
+            Raise an event for an <c>EventHandler&lt;TEventArgs&gt;</c> event with the substitute as the sender and the provided <paramref name="eventArgs" />.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Raise.EventWith``1">
+            <summary>
+            Raise an event for an <c>EventHandler&lt;EventArgsT&gt;</c> event with the substitute as the sender
+            and with a default instance of <typeparamref name="TEventArgs" />.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Raise.Event">
+            <summary>
+            Raise an event for an <c>EventHandler</c> or <c>EventHandler&lt;EventArgs&gt;</c> event with the substitute
+            as the sender and with empty <c>EventArgs</c>.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Raise.Event``1(System.Object[])">
+            <summary>
+            Raise an event of type <typeparamref name="THandler" /> with the provided arguments. If no arguments are provided
+            NSubstitute will try to provide reasonable defaults.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Raise.FixParamsArrayAmbiguity(System.Object[],System.Type)">
+            <summary>
+            If delegate takes single parameter of array type, it's impossible to distinguish
+            whether input array represents all arguments, or the first argument only.
+            If we find that ambiguity might happen, we wrap user input in an extra array.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Received.InOrder(System.Action)">
+            <summary>
+            Asserts the calls to the substitutes contained in the given Action were
+            received by these substitutes in the same order. Calls to property getters are not included
+            in the assertion.
+            </summary>
+            <param name="calls">Action containing calls to substitutes in the expected order</param>
+        </member>
+        <member name="T:NSubstitute.Routing.Handlers.ClearLastCallRouterHandler">
+            <summary>
+            Clears last call router on SubstitutionContext for routes that do not require it.
+            </summary>
+            <remarks>
+            This is to help prevent static state bleeding over into future calls.
+            </remarks>
+        </member>
+        <member name="M:NSubstitute.Routing.Handlers.ClearLastCallRouterHandler.#ctor(NSubstitute.Core.IThreadLocalContext)">
+            <summary>
+            Clears last call router on SubstitutionContext for routes that do not require it.
+            </summary>
+            <remarks>
+            This is to help prevent static state bleeding over into future calls.
+            </remarks>
+        </member>
+        <member name="T:NSubstitute.Substitute">
+            <summary>
+            Create a substitute for one or more types. For example: <c>Substitute.For&lt;ISomeType&gt;()</c> 
+            </summary>
+        </member>
+        <member name="M:NSubstitute.Substitute.For``1(System.Object[])">
+            <summary>
+            Substitute for an interface or class.
+            <para>Be careful when specifying a class, as all non-virtual members will actually be executed. Only virtual members 
+            can be recorded or have return values specified.</para>
+            </summary>
+            <typeparam name="T">The type of interface or class to substitute.</typeparam>
+            <param name="constructorArguments">Arguments required to construct a class being substituted. Not required for interfaces or classes with default constructors.</param>
+            <returns>A substitute for the interface or class.</returns>
+        </member>
+        <member name="M:NSubstitute.Substitute.For``2(System.Object[])">
+            <summary>
+            <para>Substitute for multiple interfaces or a class that implements an interface. At most one class can be specified.</para>
+            <para>Be careful when specifying a class, as all non-virtual members will actually be executed. Only virtual members 
+            can be recorded or have return values specified.</para>
+            </summary>
+            <typeparam name="T1">The type of interface or class to substitute.</typeparam>
+            <typeparam name="T2">An additional interface or class (maximum of one class) the substitute should implement.</typeparam>
+            <param name="constructorArguments">Arguments required to construct a class being substituted. Not required for interfaces or classes with default constructors.</param>
+            <returns>A substitute of type T1, that also implements T2.</returns>
+        </member>
+        <member name="M:NSubstitute.Substitute.For``3(System.Object[])">
+            <summary>
+            <para>Substitute for multiple interfaces or a class that implements multiple interfaces. At most one class can be specified.</para>
+            If additional interfaces are required use the <see cref="M:NSubstitute.Substitute.For(System.Type[],System.Object[])" /> overload.
+            <para>Be careful when specifying a class, as all non-virtual members will actually be executed. Only virtual members 
+            can be recorded or have return values specified.</para>
+            </summary>
+            <typeparam name="T1">The type of interface or class to substitute.</typeparam>
+            <typeparam name="T2">An additional interface or class (maximum of one class) the substitute should implement.</typeparam>
+            <typeparam name="T3">An additional interface or class (maximum of one class) the substitute should implement.</typeparam>
+            <param name="constructorArguments">Arguments required to construct a class being substituted. Not required for interfaces or classes with default constructors.</param>
+            <returns>A substitute of type T1, that also implements T2 and T3.</returns>
+        </member>
+        <member name="M:NSubstitute.Substitute.For(System.Type[],System.Object[])">
+            <summary>
+            <para>Substitute for multiple interfaces or a class that implements multiple interfaces. At most one class can be specified.</para>
+            <para>Be careful when specifying a class, as all non-virtual members will actually be executed. Only virtual members 
+            can be recorded or have return values specified.</para>
+            </summary>
+            <param name="typesToProxy">The types of interfaces or a type of class and multiple interfaces the substitute should implement.</param>
+            <param name="constructorArguments">Arguments required to construct a class being substituted. Not required for interfaces or classes with default constructors.</param>
+            <returns>A substitute implementing the specified types.</returns>
+        </member>
+        <member name="M:NSubstitute.Substitute.ForPartsOf``1(System.Object[])">
+            <summary>
+            Create a substitute for a class that behaves just like a real instance of the class, but also
+            records calls made to its virtual members and allows for specific members to be substituted
+            by using <see cref="M:NSubstitute.Core.WhenCalled`1.DoNotCallBase">When(() => call).DoNotCallBase()</see> or by
+            <see cref="M:NSubstitute.SubstituteExtensions.Returns``1(``0,``0,``0[])">setting a value to return value</see> for that member.
+            </summary>
+            <typeparam name="T">The type to substitute for parts of. Must be a class; not a delegate or interface.</typeparam>
+            <param name="constructorArguments"></param>
+            <returns>An instance of the class that will execute real methods when called, but allows parts to be selectively 
+            overridden via `Returns` and `When..DoNotCallBase`.</returns>
+        </member>
+        <member name="M:NSubstitute.Substitute.ForTypeForwardingTo``2(System.Object[])">
+            <summary>
+            Creates a proxy for a class that implements an interface, forwarding methods and properties to an instance of the class, effectively mimicking a real instance.
+            Both the interface and the class must be provided as parameters.
+            The proxy will log calls made to the interface members and delegate them to an instance of the class. Specific members can be substituted 
+            by using <see cref="M:NSubstitute.Core.WhenCalled`1.DoNotCallBase">When(() => call).DoNotCallBase()</see> or by
+            <see cref="M:NSubstitute.SubstituteExtensions.Returns``1(``0,``0,``0[])">setting a value to return value</see> for that member.
+            This extension supports sealed classes and non-virtual members, with some limitations. Since the substituted method is non-virtual, internal calls within the object will invoke the original implementation and will not be logged.
+            </summary>
+            <typeparam name="TInterface">The interface the substitute will implement.</typeparam>
+            <typeparam name="TClass">The class type implementing the interface. Must be a class; not a delegate or interface. </typeparam>
+            <param name="constructorArguments"></param>
+            <returns>An object implementing the selected interface. Calls will be forwarded to the actuall methods, but allows parts to be selectively 
+            overridden via `Returns` and `When..DoNotCallBase`.</returns>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.Received``1(``0)">
+            <summary>
+            Checks this substitute has received the following call.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.Received``1(``0,System.Int32)">
+            <summary>
+            Checks this substitute has received the following call the required number of times.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.DidNotReceive``1(``0)">
+            <summary>
+            Checks this substitute has not received the following call.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.ReceivedWithAnyArgs``1(``0)">
+            <summary>
+            Checks this substitute has received the following call with any arguments.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.ReceivedWithAnyArgs``1(``0,System.Int32)">
+            <summary>
+            Checks this substitute has received the following call with any arguments the required number of times.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.DidNotReceiveWithAnyArgs``1(``0)">
+            <summary>
+            Checks this substitute has not received the following call with any arguments.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.ReceivedCalls``1(``0)">
+            <summary>
+            Returns the calls received by this substitute.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.ClearReceivedCalls``1(``0)">
+            <summary>
+            Forget all the calls this substitute has received.
+            </summary>
+            <remarks>
+            Note that this will not clear any results set up for the substitute using Returns().
+            See <see cref="M:NSubstitute.ClearExtensions.ClearExtensions.ClearSubstitute``1(``0,NSubstitute.ClearOptions)"/> for more options with resetting
+            a substitute.
+            </remarks>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.Returns``1(``0,``0,``0[])">
+            <summary>
+            Set a return value for this call.
+            </summary>
+            <param name="value"></param>
+            <param name="returnThis">Value to return</param>
+            <param name="returnThese">Optionally return these values next</param>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.Returns``1(``0,System.Func{NSubstitute.Core.CallInfo,``0},System.Func{NSubstitute.Core.CallInfo,``0}[])">
+            <summary>
+            Set a return value for this call, calculated by the provided function.
+            </summary>
+            <param name="value"></param>
+            <param name="returnThis">Function to calculate the return value</param>
+            <param name="returnThese">Optionally use these functions next</param>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.ReturnsForAnyArgs``1(``0,``0,``0[])">
+            <summary>
+            Set a return value for this call made with any arguments.
+            </summary>
+            <param name="value"></param>
+            <param name="returnThis">Value to return</param>
+            <param name="returnThese">Optionally return these values next</param>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.ReturnsForAnyArgs``1(``0,System.Func{NSubstitute.Core.CallInfo,``0},System.Func{NSubstitute.Core.CallInfo,``0}[])">
+            <summary>
+            Set a return value for this call made with any arguments, calculated by the provided function.
+            </summary>
+            <param name="value"></param>
+            <param name="returnThis">Function to calculate the return value</param>
+            <param name="returnThese">Optionally use these functions next</param>
+            <returns></returns>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.Returns``1(System.Threading.Tasks.Task{``0},``0,``0[])">
+            <summary>
+            Set a return value for this call. The value(s) to be returned will be wrapped in Tasks.
+            </summary>
+            <param name="value"></param>
+            <param name="returnThis">Value to return. Will be wrapped in a Task</param>
+            <param name="returnThese">Optionally use these values next</param>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.Returns``1(System.Threading.Tasks.Task{``0},System.Func{NSubstitute.Core.CallInfo,``0},System.Func{NSubstitute.Core.CallInfo,``0}[])">
+            <summary>
+            Set a return value for this call, calculated by the provided function. The value(s) to be returned will be wrapped in Tasks.
+            </summary>
+            <param name="value"></param>
+            <param name="returnThis">Function to calculate the return value</param>
+            <param name="returnThese">Optionally use these functions next</param>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.ReturnsForAnyArgs``1(System.Threading.Tasks.Task{``0},``0,``0[])">
+            <summary>
+            Set a return value for this call made with any arguments. The value(s) to be returned will be wrapped in Tasks.
+            </summary>
+            <param name="value"></param>
+            <param name="returnThis">Value to return</param>
+            <param name="returnThese">Optionally return these values next</param>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.ReturnsForAnyArgs``1(System.Threading.Tasks.Task{``0},System.Func{NSubstitute.Core.CallInfo,``0},System.Func{NSubstitute.Core.CallInfo,``0}[])">
+            <summary>
+            Set a return value for this call made with any arguments, calculated by the provided function. The value(s) to be returned will be wrapped in Tasks.
+            </summary>
+            <param name="value"></param>
+            <param name="returnThis">Function to calculate the return value</param>
+            <param name="returnThese">Optionally use these functions next</param>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.Returns``1(System.Threading.Tasks.ValueTask{``0},``0,``0[])">
+            <summary>
+            Set a return value for this call. The value(s) to be returned will be wrapped in ValueTasks.
+            </summary>
+            <param name="value"></param>
+            <param name="returnThis">Value to return. Will be wrapped in a ValueTask</param>
+            <param name="returnThese">Optionally use these values next</param>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.Returns``1(System.Threading.Tasks.ValueTask{``0},System.Func{NSubstitute.Core.CallInfo,``0},System.Func{NSubstitute.Core.CallInfo,``0}[])">
+            <summary>
+            Set a return value for this call, calculated by the provided function. The value(s) to be returned will be wrapped in ValueTasks.
+            </summary>
+            <param name="value"></param>
+            <param name="returnThis">Function to calculate the return value</param>
+            <param name="returnThese">Optionally use these functions next</param>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.ReturnsForAnyArgs``1(System.Threading.Tasks.ValueTask{``0},``0,``0[])">
+            <summary>
+            Set a return value for this call made with any arguments. The value(s) to be returned will be wrapped in ValueTasks.
+            </summary>
+            <param name="value"></param>
+            <param name="returnThis">Value to return</param>
+            <param name="returnThese">Optionally return these values next</param>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.ReturnsForAnyArgs``1(System.Threading.Tasks.ValueTask{``0},System.Func{NSubstitute.Core.CallInfo,``0},System.Func{NSubstitute.Core.CallInfo,``0}[])">
+            <summary>
+            Set a return value for this call made with any arguments, calculated by the provided function. The value(s) to be returned will be wrapped in ValueTasks.
+            </summary>
+            <param name="value"></param>
+            <param name="returnThis">Function to calculate the return value</param>
+            <param name="returnThese">Optionally use these functions next</param>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.When``1(``0,System.Action{``0})">
+            <summary>
+            Perform an action when this member is called.
+            Must be followed by <see cref="M:NSubstitute.Core.WhenCalled`1.Do(System.Action{NSubstitute.Core.CallInfo})"/> to provide the callback.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.WhenForAnyArgs``1(``0,System.Action{``0})">
+            <summary>
+            Perform an action when this member is called with any arguments.
+            Must be followed by <see cref="M:NSubstitute.Core.WhenCalled`1.Do(System.Action{NSubstitute.Core.CallInfo})"/> to provide the callback.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.When``1(``0,System.Func{``0,System.Threading.Tasks.Task})">
+            <summary>
+            Perform an action when this member is called.
+            Must be followed by <see cref="M:NSubstitute.Core.WhenCalled`1.Do(System.Action{NSubstitute.Core.CallInfo})"/> to provide the callback.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.WhenForAnyArgs``1(``0,System.Func{``0,System.Threading.Tasks.Task})">
+            <summary>
+            Perform an action when this member is called with any arguments.
+            Must be followed by <see cref="M:NSubstitute.Core.WhenCalled`1.Do(System.Action{NSubstitute.Core.CallInfo})"/> to provide the callback.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.When``2(``0,System.Func{``0,System.Threading.Tasks.ValueTask{``1}})">
+            <summary>
+            Perform an action when this member is called.
+            Must be followed by <see cref="M:NSubstitute.Core.WhenCalled`1.Do(System.Action{NSubstitute.Core.CallInfo})"/> to provide the callback.
+            </summary>
+        </member>
+        <member name="M:NSubstitute.SubstituteExtensions.WhenForAnyArgs``2(``0,System.Func{``0,System.Threading.Tasks.ValueTask{``1}})">
+            <summary>
+            Perform an action when this member is called with any arguments.
+            Must be followed by <see cref="M:NSubstitute.Core.WhenCalled`1.Do(System.Action{NSubstitute.Core.CallInfo})"/> to provide the callback.
+            </summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.AllowNullAttribute">
+            <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.DisallowNullAttribute">
+            <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.MaybeNullAttribute">
+            <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.NotNullAttribute">
+            <summary>Specifies that an output will not be null even if the corresponding type allows it.</summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute">
+            <summary>Specifies that when a method returns <see cref="P:System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute.ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
+            <remarks>Initializes the attribute with the specified return value condition.</remarks>
+            <param name="returnValue">
+            The return value condition. If the method returns this value, the associated parameter may be null.
+            </param>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute.#ctor(System.Boolean)">
+            <summary>Specifies that when a method returns <see cref="P:System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute.ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
+            <remarks>Initializes the attribute with the specified return value condition.</remarks>
+            <param name="returnValue">
+            The return value condition. If the method returns this value, the associated parameter may be null.
+            </param>
+        </member>
+        <member name="P:System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute.ReturnValue">
+            <summary>Gets the return value condition.</summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute">
+            <summary>Specifies that when a method returns <see cref="P:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute.ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+            <remarks>Initializes the attribute with the specified return value condition.</remarks>
+            <param name="returnValue">
+            The return value condition. If the method returns this value, the associated parameter will not be null.
+            </param>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute.#ctor(System.Boolean)">
+            <summary>Specifies that when a method returns <see cref="P:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute.ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+            <remarks>Initializes the attribute with the specified return value condition.</remarks>
+            <param name="returnValue">
+            The return value condition. If the method returns this value, the associated parameter will not be null.
+            </param>
+        </member>
+        <member name="P:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute.ReturnValue">
+            <summary>Gets the return value condition.</summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute">
+            <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+            <remarks>Initializes the attribute with the associated parameter name.</remarks>
+            <param name="parameterName">
+            The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+            </param>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute.#ctor(System.String)">
+            <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+            <remarks>Initializes the attribute with the associated parameter name.</remarks>
+            <param name="parameterName">
+            The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+            </param>
+        </member>
+        <member name="P:System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute.ParameterName">
+            <summary>Gets the associated parameter name.</summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute">
+            <summary>Applied to a method that will never return under any circumstance.</summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute">
+            <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
+            <remarks>Initializes the attribute with the specified parameter value.</remarks>
+            <param name="parameterValue">
+            The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+            the associated parameter matches this value.
+            </param>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute.#ctor(System.Boolean)">
+            <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
+            <remarks>Initializes the attribute with the specified parameter value.</remarks>
+            <param name="parameterValue">
+            The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+            the associated parameter matches this value.
+            </param>
+        </member>
+        <member name="P:System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute.ParameterValue">
+            <summary>Gets the condition parameter value.</summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.MemberNotNullAttribute">
+            <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.MemberNotNullAttribute.#ctor(System.String)">
+            <summary>Initializes the attribute with a field or property member.</summary>
+            <param name="member">
+            The field or property member that is promised to be not-null.
+            </param>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.MemberNotNullAttribute.#ctor(System.String[])">
+            <summary>Initializes the attribute with the list of field and property members.</summary>
+            <param name="members">
+            The list of field and property members that are promised to be not-null.
+            </param>
+        </member>
+        <member name="P:System.Diagnostics.CodeAnalysis.MemberNotNullAttribute.Members">
+            <summary>Gets field or property member names.</summary>
+        </member>
+        <member name="T:System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute">
+            <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute.#ctor(System.Boolean,System.String)">
+            <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
+            <param name="returnValue">
+            The return value condition. If the method returns this value, the associated parameter will not be null.
+            </param>
+            <param name="member">
+            The field or property member that is promised to be not-null.
+            </param>
+        </member>
+        <member name="M:System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute.#ctor(System.Boolean,System.String[])">
+            <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
+            <param name="returnValue">
+            The return value condition. If the method returns this value, the associated parameter will not be null.
+            </param>
+            <param name="members">
+            The list of field and property members that are promised to be not-null.
+            </param>
+        </member>
+        <member name="P:System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute.ReturnValue">
+            <summary>Gets the return value condition.</summary>
+        </member>
+        <member name="P:System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute.Members">
+            <summary>Gets field or property member names.</summary>
+        </member>
+    </members>
+</doc>

--- a/Tests/Plugins/nsubstitute.5.3.0/NSubstitute.xml.meta
+++ b/Tests/Plugins/nsubstitute.5.3.0/NSubstitute.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d551d5eb905dcb14aa594a06eab20a61
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Plugins/system.diagnostics.eventlog.9.0.5.meta
+++ b/Tests/Plugins/system.diagnostics.eventlog.9.0.5.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 88cfdec5938fd974cbf18d086bab627a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Plugins/system.diagnostics.eventlog.9.0.5/System.Diagnostics.EventLog.dll
+++ b/Tests/Plugins/system.diagnostics.eventlog.9.0.5/System.Diagnostics.EventLog.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46992d8d399468d26c5a6544511cb75a7ee1427beff3bcd6734c0bdb05136306
+size 56072

--- a/Tests/Plugins/system.diagnostics.eventlog.9.0.5/System.Diagnostics.EventLog.dll.meta
+++ b/Tests/Plugins/system.diagnostics.eventlog.9.0.5/System.Diagnostics.EventLog.dll.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 148ba77873cf4cb49b03989f4270a1a3

--- a/Tests/Plugins/system.diagnostics.eventlog.9.0.5/System.Diagnostics.EventLog.xml
+++ b/Tests/Plugins/system.diagnostics.eventlog.9.0.5/System.Diagnostics.EventLog.xml
@@ -1,0 +1,2249 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<doc>
+  <assembly>
+    <name>System.Diagnostics.EventLog</name>
+  </assembly>
+  <members>
+    <member name="T:System.Diagnostics.EntryWrittenEventArgs">
+      <summary>Provides data for the <see cref="E:System.Diagnostics.EventLog.EntryWritten" /> event.</summary>
+    </member>
+    <member name="M:System.Diagnostics.EntryWrittenEventArgs.#ctor">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.EntryWrittenEventArgs" /> class.</summary>
+    </member>
+    <member name="M:System.Diagnostics.EntryWrittenEventArgs.#ctor(System.Diagnostics.EventLogEntry)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.EntryWrittenEventArgs" /> class with the specified event log entry.</summary>
+      <param name="entry">An <see cref="T:System.Diagnostics.EventLogEntry" /> that represents the entry that was written.</param>
+    </member>
+    <member name="P:System.Diagnostics.EntryWrittenEventArgs.Entry">
+      <summary>Gets the event log entry that was written to the log.</summary>
+      <returns>An <see cref="T:System.Diagnostics.EventLogEntry" /> that represents the entry that was written to the event log.</returns>
+    </member>
+    <member name="T:System.Diagnostics.EntryWrittenEventHandler">
+      <summary>Represents the method that will handle the <see cref="E:System.Diagnostics.EventLog.EntryWritten" /> event of an <see cref="T:System.Diagnostics.EventLog" />.</summary>
+      <param name="sender">The source of the event.</param>
+      <param name="e">An <see cref="T:System.Diagnostics.EntryWrittenEventArgs" /> that contains the event data.</param>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventBookmark">
+      <summary>Represents a placeholder (bookmark) within an event stream. You can use the placeholder to mark a position and return to this position in a stream of events. An instance of this object can be obtained from an <see cref="T:System.Diagnostics.Eventing.Reader.EventRecord" /> object, in which case it corresponds to the position of that event record.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventBookmark.#ctor(System.String)">
+      <summary>Creates a bookmark that identifies an event in a channel.</summary>
+      <param name="bookmarkXml">An XML string that represents the bookmark.</param>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventBookmark.BookmarkXml">
+      <summary>Gets the XML string that represents the bookmark.</summary>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventKeyword">
+      <summary>Represents a keyword for an event. Keywords are defined in an event provider and are used to group the event with other similar events (based on the usage of the events).</summary>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventKeyword.DisplayName">
+      <summary>Gets the localized name of the keyword.</summary>
+      <returns>A string that contains a localized name for this keyword.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventKeyword.Name">
+      <summary>Gets the non-localized name of the keyword.</summary>
+      <returns>A string that contains the non-localized name of this keyword.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventKeyword.Value">
+      <summary>Gets the numeric value associated with the keyword.</summary>
+      <returns>The numeric value associated with the keyword.</returns>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventLevel">
+      <summary>Contains an event level that is defined in an event provider. The level signifies the severity of the event.</summary>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLevel.DisplayName">
+      <summary>Gets the localized name for the event level. The name describes what severity level of events this level is used for.</summary>
+      <returns>A string that contains the localized name for the event level.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLevel.Name">
+      <summary>Gets the non-localized name of the event level.</summary>
+      <returns>A string that contains the non-localized name of the event level.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLevel.Value">
+      <summary>Gets the numeric value of the event level.</summary>
+      <returns>The numeric value of the event level.</returns>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventLogConfiguration">
+      <summary>Contains static information and configuration settings for an event log. Many of the configurations settings were defined by the event provider that created the log.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogConfiguration.#ctor(System.String,System.Diagnostics.Eventing.Reader.EventLogSession)">
+      <summary>Initializes a new <see cref="T:System.Diagnostics.Eventing.Reader.EventLogConfiguration" /> object by specifying the name of the log for which to get information and configuration settings. The log can be on the local computer or a remote computer, based on the event log session specified.</summary>
+      <param name="logName">The name of the event log for which to get information and configuration settings.</param>
+      <param name="session">The event log session used to determine the event log service that the specified log belongs to. The session is either connected to the event log service on the local computer or a remote computer.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogConfiguration.#ctor(System.String)">
+      <summary>Initializes a new <see cref="T:System.Diagnostics.Eventing.Reader.EventLogConfiguration" /> object by specifying the local event log for which to get information and configuration settings.</summary>
+      <param name="logName">The name of the local event log for which to get information and configuration settings.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogConfiguration.Dispose">
+      <summary>Releases all the resources used by this object.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogConfiguration.Dispose(System.Boolean)">
+      <summary>Releases the unmanaged resources used by this object, and optionally releases the managed resources.</summary>
+      <param name="disposing">
+        <see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogConfiguration.SaveChanges">
+      <summary>Saves the configuration settings that.</summary>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogConfiguration.IsClassicLog">
+      <summary>Gets a value that indicates whether the event log is a classic event log. A classic event log is one that has its events defined in an .mc file instead of a manifest (.xml file) used by the event provider.</summary>
+      <returns>
+        <see langword="true" /> if the event log is a classic log; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogConfiguration.IsEnabled">
+      <summary>Gets or sets a value that indicates whether the event log is enabled or disabled. An enabled log is one in which events can be logged, and a disabled log is one in which events cannot be logged.</summary>
+      <returns>
+        <see langword="true" /> if the log is enabled; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogConfiguration.LogFilePath">
+      <summary>Gets or sets the file directory path to the location of the file where the events are stored for the log.</summary>
+      <returns>A string that contains the path to the event log file.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogConfiguration.LogIsolation">
+      <summary>Gets an <see cref="T:System.Diagnostics.Eventing.Reader.EventLogIsolation" /> value that specifies whether the event log is an application, system, or custom event log.</summary>
+      <returns>One of the enumeration values.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogConfiguration.LogMode">
+      <summary>Gets or sets an <see cref="T:System.Diagnostics.Eventing.Reader.EventLogMode" /> value that determines how events are handled when the event log becomes full.</summary>
+      <returns>One of the enumeration values.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogConfiguration.LogName">
+      <summary>Gets the name of the event log.</summary>
+      <returns>The name of the event log.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogConfiguration.LogType">
+      <summary>Gets an <see cref="T:System.Diagnostics.Eventing.Reader.EventLogType" /> value that determines the type of the event log.</summary>
+      <returns>One of the enumeration values.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogConfiguration.MaximumSizeInBytes">
+      <summary>Gets or sets the maximum size, in bytes, that the event log file is allowed to be. When the file reaches this maximum size, it is considered full.</summary>
+      <returns>The maximum size, in bytes, that the event log file is allowed to be.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogConfiguration.OwningProviderName">
+      <summary>Gets the name of the event provider that created this event log.</summary>
+      <returns>The name of the event provider that created this event log.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogConfiguration.ProviderBufferSize">
+      <summary>Gets the size of the buffer that the event provider uses for publishing events to the log.</summary>
+      <returns>The size of the buffer that the event provider uses for publishing events to the log. It can be <see langword="null" />.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogConfiguration.ProviderControlGuid">
+      <summary>Gets the control globally unique identifier (GUID) for the event log if the log is a debug log. If this log is not a debug log, this value is <see langword="null" />.</summary>
+      <returns>A GUID value, or <see langword="null" /> if the log is not a debug log.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogConfiguration.ProviderKeywords">
+      <summary>Gets or sets the keyword mask used by the event provider.</summary>
+      <returns>The keyword mask used by the event provider, or <see langword="null" /> if the event provider did not define any keywords.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogConfiguration.ProviderLatency">
+      <summary>Gets the maximum latency time used by the event provider when publishing events to the log.</summary>
+      <returns>The maximum latency time used by the event provider when publishing events to the log, or <see langword="null" /> if no latency time was specified by the event provider.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogConfiguration.ProviderLevel">
+      <summary>Gets or sets the maximum event level (which defines the severity of the event) that is allowed to be logged in the event log. This value is defined by the event provider.</summary>
+      <returns>The maximum event level that is allowed to be logged in the event log, or <see langword="null" /> if the maximum event level was not defined in the event provider.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogConfiguration.ProviderMaximumNumberOfBuffers">
+      <summary>Gets the maximum number of buffers used by the event provider to publish events to the event log.</summary>
+      <returns>The maximum number of buffers used by the event provider to publish events to the event log. This value can be <see langword="null" />.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogConfiguration.ProviderMinimumNumberOfBuffers">
+      <summary>Gets the minimum number of buffers used by the event provider to publish events to the event log.</summary>
+      <returns>The minimum number of buffers used by the event provider to publish events to the event log. This value can be <see langword="null" />.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogConfiguration.ProviderNames">
+      <summary>Gets an enumerable collection of the names of all the event providers that can publish events to this event log.</summary>
+      <returns>An enumerable collection of strings that contain the event provider names.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogConfiguration.SecurityDescriptor">
+      <summary>Gets or sets the security descriptor of the event log. The security descriptor defines the users and groups of users that can read and write to the event log.</summary>
+      <returns>A string that contains the security descriptor for the event log.</returns>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventLogException">
+      <summary>Represents the base class for all the exceptions that are thrown when an error occurs while reading event log related information.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogException.#ctor">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogException" /> class.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogException.#ctor(System.Int32)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogException" /> class with the error code for the exception.</summary>
+      <param name="errorCode">The error code for the error that occurred while reading or configuring event log related information.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogException" /> class with serialized data.</summary>
+      <param name="serializationInfo">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object that holds the serialized object data about the exception being thrown.</param>
+      <param name="streamingContext">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> object that contains contextual information about the source or destination.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogException.#ctor(System.String,System.Exception)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogException" /> class with an error message and inner exception.</summary>
+      <param name="message">The error message that describes the current exception.</param>
+      <param name="innerException">The Exception instance that caused the current exception.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogException.#ctor(System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogException" /> class by specifying the error message that describes the current exception.</summary>
+      <param name="message">The error message that describes the current exception.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogException.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)">
+      <summary>Sets the SerializationInfo object with information about the exception.</summary>
+      <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object that holds the serialized object data about the exception thrown.</param>
+      <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> object that contains contextual information about the source or destination.</param>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogException.Message">
+      <summary>Gets the error message that describes the current exception.</summary>
+      <returns>Returns a string that contains the error message that describes the current exception.</returns>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventLogInformation">
+      <summary>Allows you to access the run-time properties of active event logs and event log files. These properties include the number of events in the log, the size of the log, a value that determines whether the log is full, and the last time the log was written to or accessed.</summary>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogInformation.Attributes">
+      <summary>Gets the file attributes of the log file associated with the log.</summary>
+      <returns>Returns an integer value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogInformation.CreationTime">
+      <summary>Gets the time that the log file associated with the event log was created.</summary>
+      <returns>Returns a <see cref="T:System.DateTime" /> object. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogInformation.FileSize">
+      <summary>Gets the size of the file, in bytes, associated with the event log.</summary>
+      <returns>Returns a long value.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogInformation.IsLogFull">
+      <summary>Gets a Boolean value that determines whether the log file has reached its maximum size (the log is full).</summary>
+      <returns>Returns <see langword="true" /> if the log is full, and returns <see langword="false" /> if the log is not full.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogInformation.LastAccessTime">
+      <summary>Gets the last time the log file associated with the event log was accessed.</summary>
+      <returns>Returns a <see cref="T:System.DateTime" /> object. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogInformation.LastWriteTime">
+      <summary>Gets the last time data was written to the log file associated with the event log.</summary>
+      <returns>Returns a <see cref="T:System.DateTime" /> object. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogInformation.OldestRecordNumber">
+      <summary>Gets the number of the oldest event record in the event log.</summary>
+      <returns>Returns a long value that represents the number of the oldest event record in the event log. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogInformation.RecordCount">
+      <summary>Gets the number of event records in the event log.</summary>
+      <returns>Returns a long value that represents the number of event records in the event log. This value can be null.</returns>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventLogInvalidDataException">
+      <summary>Represents the exception thrown when an event provider publishes invalid data in an event.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogInvalidDataException.#ctor">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogInvalidDataException" /> class.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogInvalidDataException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogInvalidDataException" /> class with serialized data.</summary>
+      <param name="serializationInfo">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object that holds the serialized object data about the exception thrown.</param>
+      <param name="streamingContext">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> object that contains contextual information about the source or destination.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogInvalidDataException.#ctor(System.String,System.Exception)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogInvalidDataException" /> class with an error message and inner exception.</summary>
+      <param name="message">The error message that describes the current exception.</param>
+      <param name="innerException">The Exception instance that caused the current exception.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogInvalidDataException.#ctor(System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogInvalidDataException" /> class by specifying the error message that describes the current exception.</summary>
+      <param name="message">The error message that describes the current exception.</param>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventLogIsolation">
+      <summary>Defines the default access permissions for the event log. The Application and System values indicate that the log shares the access control list (ACL) with the appropriate Windows log (the Application or System event logs) and share the Event Tracing for Windows (ETW) session with other logs of the same isolation. All channels with Custom isolation use a private ETW session.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.EventLogIsolation.Application">
+      <summary>The log shares the access control list with the Application event log and shares the ETW session with other logs that have Application isolation.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.EventLogIsolation.Custom">
+      <summary>The event log is a custom event log that uses its own private ETW session.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.EventLogIsolation.System">
+      <summary>The log shares the access control list with the System event log and shares the ETW session with other logs that have System isolation.</summary>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventLogLink">
+      <summary>Represents a link between an event provider and an event log that the provider publishes events into. This object cannot be instantiated.</summary>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogLink.DisplayName">
+      <summary>Gets the localized name of the event log.</summary>
+      <returns>Returns a string that contains the localized name of the event log.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogLink.IsImported">
+      <summary>Gets a Boolean value that determines whether the event log is imported, rather than defined in the event provider. An imported event log is defined in a different provider.</summary>
+      <returns>Returns <see langword="true" /> if the event log is imported by the event provider, and returns <see langword="false" /> if the event log is not imported by the event provider.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogLink.LogName">
+      <summary>Gets the non-localized name of the event log associated with this object.</summary>
+      <returns>Returns a string that contains the non-localized name of the event log associated with this object.</returns>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventLogMode">
+      <summary>Determines the behavior for the event log service handles an event log when the log reaches its maximum allowed size (when the event log is full).</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.EventLogMode.AutoBackup">
+      <summary>Archive the log when full, do not overwrite events. The log is automatically archived when necessary. No events are overwritten.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.EventLogMode.Circular">
+      <summary>New events continue to be stored when the log file is full. Each new incoming event replaces the oldest event in the log.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.EventLogMode.Retain">
+      <summary>Do not overwrite events. Clear the log manually rather than automatically.</summary>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventLogNotFoundException">
+      <summary>Represents the exception that is thrown when a requested event log (usually specified by the name of the event log or the path to the event log file) does not exist.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogNotFoundException.#ctor">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogNotFoundException" /> class.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogNotFoundException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogNotFoundException" /> class with serialized data.</summary>
+      <param name="serializationInfo">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object that holds the serialized object data about the exception thrown.</param>
+      <param name="streamingContext">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> object that contains contextual information about the source or destination.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogNotFoundException.#ctor(System.String,System.Exception)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogNotFoundException" /> class with an error message and inner exception.</summary>
+      <param name="message">The error message that describes the current exception.</param>
+      <param name="innerException">The Exception instance that caused the current exception.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogNotFoundException.#ctor(System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogNotFoundException" /> class by specifying the error message that describes the current exception.</summary>
+      <param name="message">The error message that describes the current exception.</param>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventLogPropertySelector">
+      <summary>Contains an array of strings that represent XPath queries for elements in the XML representation of an event, which is based on the Event Schema. The queries in this object are used to extract values from the event.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogPropertySelector.#ctor(System.Collections.Generic.IEnumerable{System.String})">
+      <summary>Initializes a new <see cref="T:System.Diagnostics.Eventing.Reader.EventLogPropertySelector" /> class instance.</summary>
+      <param name="propertyQueries">XPath queries used to extract values from the XML representation of the event.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogPropertySelector.Dispose">
+      <summary>Releases all the resources used by this object.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogPropertySelector.Dispose(System.Boolean)">
+      <summary>Releases the unmanaged resources used by this object, and optionally releases the managed resources.</summary>
+      <param name="disposing">
+        <see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventLogProviderDisabledException">
+      <summary>Represents the exception that is thrown when a specified event provider name references a disabled event provider. A disabled event provider cannot publish events.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogProviderDisabledException.#ctor">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogProviderDisabledException" /> class.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogProviderDisabledException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogProviderDisabledException" /> class with serialized data.</summary>
+      <param name="serializationInfo">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object that holds the serialized object data about the exception thrown.</param>
+      <param name="streamingContext">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> object that contains contextual information about the source or destination.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogProviderDisabledException.#ctor(System.String,System.Exception)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogProviderDisabledException" /> class with an error message and inner exception.</summary>
+      <param name="message">The error message that describes the current exception.</param>
+      <param name="innerException">The Exception instance that caused the current exception.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogProviderDisabledException.#ctor(System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogProviderDisabledException" /> class by specifying the error message that describes the current exception.</summary>
+      <param name="message">The error message that describes the current exception.</param>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventLogQuery">
+      <summary>Represents a query for events in an event log and the settings that define how the query is executed and on what computer the query is executed on.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogQuery.#ctor(System.String,System.Diagnostics.Eventing.Reader.PathType,System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogQuery" /> class by specifying the target of the query and the event query. The target can be an active event log or a log file.</summary>
+      <param name="path">The name of the event log to query, or the path to the event log file to query.</param>
+      <param name="pathType">Specifies whether the string used in the path parameter specifies the name of an event log, or the path to an event log file.</param>
+      <param name="query">The event query used to retrieve events that match the query conditions.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogQuery.#ctor(System.String,System.Diagnostics.Eventing.Reader.PathType)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogQuery" /> class by specifying the target of the query. The target can be an active event log or a log file.</summary>
+      <param name="path">The name of the event log to query, or the path to the event log file to query.</param>
+      <param name="pathType">Specifies whether the string used in the path parameter specifies the name of an event log, or the path to an event log file.</param>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogQuery.ReverseDirection">
+      <summary>Gets or sets the Boolean value that determines whether to read events from the newest event in an event log to the oldest event in the log.</summary>
+      <returns>Returns <see langword="true" /> if events are read from the newest event in the log to the oldest event, and returns <see langword="false" /> if events are read from the oldest event in the log to the newest event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogQuery.Session">
+      <summary>Gets or sets the session that access the Event Log service on the local computer or a remote computer. This object can be set to access a remote event log by creating a <see cref="T:System.Diagnostics.Eventing.Reader.EventLogReader" /> object or an <see cref="T:System.Diagnostics.Eventing.Reader.EventLogWatcher" /> object with this <see cref="T:System.Diagnostics.Eventing.Reader.EventLogQuery" /> object.</summary>
+      <returns>Returns an <see cref="T:System.Diagnostics.Eventing.Reader.EventLogSession" /> object.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogQuery.TolerateQueryErrors">
+      <summary>Gets or sets a Boolean value that determines whether this query will continue to retrieve events when the query has an error.</summary>
+      <returns>
+        <see langword="true" /> indicates that the query will continue to retrieve events even if the query fails for some logs, and <see langword="false" /> indicates that this query will not continue to retrieve events when the query fails.</returns>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventLogReader">
+      <summary>Enables you to read events from an event log based on an event query. The events that are read by this object are returned as <see cref="T:System.Diagnostics.Eventing.Reader.EventRecord" /> objects.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogReader.#ctor(System.Diagnostics.Eventing.Reader.EventLogQuery,System.Diagnostics.Eventing.Reader.EventBookmark)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogReader" /> class by specifying an event query and a bookmark that is used as starting position for the query.</summary>
+      <param name="eventQuery">The event query used to retrieve events.</param>
+      <param name="bookmark">The bookmark (placeholder) used as a starting position in the event log or stream of events. Only events logged after the bookmark event will be returned by the query.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogReader.#ctor(System.Diagnostics.Eventing.Reader.EventLogQuery)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogReader" /> class by specifying an event query.</summary>
+      <param name="eventQuery">The event query used to retrieve events.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogReader.#ctor(System.String,System.Diagnostics.Eventing.Reader.PathType)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogReader" /> class by specifying the name of an event log to retrieve events from or the path to a log file to retrieve events from.</summary>
+      <param name="path">The name of the event log to retrieve events from, or the path to the event log file to retrieve events from.</param>
+      <param name="pathType">Specifies whether the string used in the path parameter specifies the name of an event log, or the path to an event log file.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogReader.#ctor(System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogReader" /> class by specifying an active event log to retrieve events from.</summary>
+      <param name="path">The name of the event log to retrieve events from.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogReader.CancelReading">
+      <summary>Cancels the current query operation.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogReader.Dispose">
+      <summary>Releases all the resources used by this object.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogReader.Dispose(System.Boolean)">
+      <summary>Releases the unmanaged resources used by this object, and optionally releases the managed resources.</summary>
+      <param name="disposing">
+        <see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogReader.ReadEvent">
+      <summary>Reads the next event that is returned from the event query in this object.</summary>
+      <returns>Returns an <see cref="T:System.Diagnostics.Eventing.Reader.EventRecord" /> object.</returns>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogReader.ReadEvent(System.TimeSpan)">
+      <summary>Reads the next event that is returned from the event query in this object.</summary>
+      <param name="timeout">The maximum time to allow the read operation to run before canceling the operation.</param>
+      <returns>Returns an <see cref="T:System.Diagnostics.Eventing.Reader.EventRecord" /> object.</returns>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogReader.Seek(System.Diagnostics.Eventing.Reader.EventBookmark,System.Int64)">
+      <summary>Changes the position in the event stream where the next event that is read will come from by specifying a bookmark event and an offset number of events from the bookmark. No events logged before the bookmark plus the offset will be retrieved.</summary>
+      <param name="bookmark">The bookmark (placeholder) used as a starting position in the event log or stream of events. Only events that have been logged after the bookmark event will be returned by the query.</param>
+      <param name="offset">The offset number of events to change the position of the bookmark.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogReader.Seek(System.Diagnostics.Eventing.Reader.EventBookmark)">
+      <summary>Changes the position in the event stream where the next event that is read will come from by specifying a bookmark event. No events logged before the bookmark event will be retrieved.</summary>
+      <param name="bookmark">The bookmark (placeholder) used as a starting position in the event log or stream of events. Only events that have been logged after the bookmark event will be returned by the query.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogReader.Seek(System.IO.SeekOrigin,System.Int64)">
+      <summary>Changes the position in the event stream where the next event that is read will come from by specifying a starting position and an offset from the starting position. No events logged before the starting position plus the offset will be retrieved.</summary>
+      <param name="origin">A value from the <see cref="T:System.IO.SeekOrigin" /> enumeration defines where in the stream of events to start querying for events.</param>
+      <param name="offset">The offset number of events to add to the origin.</param>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogReader.BatchSize">
+      <summary>Gets or sets the number of events retrieved from the stream of events on every read operation.</summary>
+      <returns>Returns an integer value.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogReader.LogStatus">
+      <summary>Gets the status of each event log or log file associated with the event query in this object.</summary>
+      <returns>Returns a list of <see cref="T:System.Diagnostics.Eventing.Reader.EventLogStatus" /> objects that each contain status information about an event log associated with the event query in this object.</returns>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventLogReadingException">
+      <summary>Represents an exception that is thrown when an error occurred while reading, querying, or subscribing to the events in an event log.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogReadingException.#ctor">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogReadingException" /> class.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogReadingException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogReadingException" /> class with serialized data.</summary>
+      <param name="serializationInfo">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object that holds the serialized object data about the exception thrown.</param>
+      <param name="streamingContext">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> object that contains contextual information about the source or destination.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogReadingException.#ctor(System.String,System.Exception)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogReadingException" /> class with an error message and inner exception.</summary>
+      <param name="message">The error message that describes the current exception.</param>
+      <param name="innerException">The Exception instance that caused the current exception.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogReadingException.#ctor(System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogReadingException" /> class by specifying the error message that describes the current exception.</summary>
+      <param name="message">The error message that describes the current exception.</param>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventLogRecord">
+      <summary>Contains the properties of an event instance for an event that is received from an <see cref="T:System.Diagnostics.Eventing.Reader.EventLogReader" /> object. The event properties provide information about the event such as the name of the computer where the event was logged and the time that the event was created.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogRecord.Dispose(System.Boolean)">
+      <summary>Releases the unmanaged resources used by this object, and optionally releases the managed resources.</summary>
+      <param name="disposing">
+        <see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogRecord.FormatDescription">
+      <summary>Gets the event message in the current locale.</summary>
+      <returns>Returns a string that contains the event message in the current locale.</returns>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogRecord.FormatDescription(System.Collections.Generic.IEnumerable{System.Object})">
+      <summary>Gets the event message, replacing variables in the message with the specified values.</summary>
+      <param name="values">The values used to replace variables in the event message. Variables are represented by %n, where n is a number.</param>
+      <returns>Returns a string that contains the event message in the current locale.</returns>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogRecord.GetPropertyValues(System.Diagnostics.Eventing.Reader.EventLogPropertySelector)">
+      <summary>Gets the enumeration of the values of the user-supplied event properties, or the results of XPath-based data if the event has XML representation.</summary>
+      <param name="propertySelector">Selects the property values to return.</param>
+      <returns>Returns a list of objects.</returns>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogRecord.ToXml">
+      <summary>Gets the XML representation of the event. All of the event properties are represented in the event's XML. The XML conforms to the event schema.</summary>
+      <returns>Returns a string that contains the XML representation of the event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.ActivityId">
+      <summary>Gets the globally unique identifier (GUID) for the activity in process for which the event is involved. This allows consumers to group related activities.</summary>
+      <returns>Returns a GUID value.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.Bookmark">
+      <summary>Gets a placeholder (bookmark) that corresponds to this event. This can be used as a placeholder in a stream of events.</summary>
+      <returns>Returns a <see cref="T:System.Diagnostics.Eventing.Reader.EventBookmark" /> object.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.ContainerLog">
+      <summary>Gets the name of the event log or the event log file in which the event is stored.</summary>
+      <returns>Returns a string that contains the name of the event log or the event log file in which the event is stored.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.Id">
+      <summary>Gets the identifier for this event. All events with this identifier value represent the same type of event.</summary>
+      <returns>Returns an integer value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.Keywords">
+      <summary>Gets the keyword mask of the event. Get the value of the <see cref="P:System.Diagnostics.Eventing.Reader.EventLogRecord.KeywordsDisplayNames" /> property to get the name of the keywords used in this mask.</summary>
+      <returns>Returns a long value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.KeywordsDisplayNames">
+      <summary>Gets the display names of the keywords used in the keyword mask for this event.</summary>
+      <returns>Returns an enumerable collection of strings that contain the display names of the keywords used in the keyword mask for this event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.Level">
+      <summary>Gets the level of the event. The level signifies the severity of the event. For the name of the level, get the value of the <see cref="P:System.Diagnostics.Eventing.Reader.EventLogRecord.LevelDisplayName" /> property.</summary>
+      <returns>Returns a byte value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.LevelDisplayName">
+      <summary>Gets the display name of the level for this event.</summary>
+      <returns>Returns a string that contains the display name of the level for this event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.LogName">
+      <summary>Gets the name of the event log where this event is logged.</summary>
+      <returns>Returns a string that contains a name of the event log that contains this event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.MachineName">
+      <summary>Gets the name of the computer on which this event was logged.</summary>
+      <returns>Returns a string that contains the name of the computer on which this event was logged.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.MatchedQueryIds">
+      <summary>Gets a list of query identifiers that this event matches. This event matches a query if the query would return this event.</summary>
+      <returns>Returns an enumerable collection of integer values.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.Opcode">
+      <summary>Gets the opcode of the event. The opcode defines a numeric value that identifies the activity or a point within an activity that the application was performing when it raised the event. For the name of the opcode, get the value of the <see cref="P:System.Diagnostics.Eventing.Reader.EventLogRecord.OpcodeDisplayName" /> property.</summary>
+      <returns>Returns a short value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.OpcodeDisplayName">
+      <summary>Gets the display name of the opcode for this event.</summary>
+      <returns>Returns a string that contains the display name of the opcode for this event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.ProcessId">
+      <summary>Gets the process identifier for the event provider that logged this event.</summary>
+      <returns>Returns an integer value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.Properties">
+      <summary>Gets the user-supplied properties of the event.</summary>
+      <returns>Returns a list of <see cref="T:System.Diagnostics.Eventing.Reader.EventProperty" /> objects.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.ProviderId">
+      <summary>Gets the globally unique identifier (GUID) of the event provider that published this event.</summary>
+      <returns>Returns a GUID value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.ProviderName">
+      <summary>Gets the name of the event provider that published this event.</summary>
+      <returns>Returns a string that contains the name of the event provider that published this event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.Qualifiers">
+      <summary>Gets qualifier numbers that are used for event identification.</summary>
+      <returns>Returns an integer value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.RecordId">
+      <summary>Gets the event record identifier of the event in the log.</summary>
+      <returns>Returns a long value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.RelatedActivityId">
+      <summary>Gets a globally unique identifier (GUID) for a related activity in a process for which an event is involved.</summary>
+      <returns>Returns a GUID value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.Task">
+      <summary>Gets a task identifier for a portion of an application or a component that publishes an event. A task is a 16-bit value with 16 top values reserved. This type allows any value between 0x0000 and 0xffef to be used. For the name of the task, get the value of the <see cref="P:System.Diagnostics.Eventing.Reader.EventLogRecord.TaskDisplayName" /> property.</summary>
+      <returns>Returns an integer value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.TaskDisplayName">
+      <summary>Gets the display name of the task for the event.</summary>
+      <returns>Returns a string that contains the display name of the task for the event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.ThreadId">
+      <summary>Gets the thread identifier for the thread that the event provider is running in.</summary>
+      <returns>Returns an integer value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.TimeCreated">
+      <summary>Gets the time, in <see cref="T:System.DateTime" /> format, that the event was created.</summary>
+      <returns>Returns a <see cref="T:System.DateTime" /> value. The value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.UserId">
+      <summary>Gets the security descriptor of the user whose context is used to publish the event.</summary>
+      <returns>Returns a <see cref="T:System.Security.Principal.SecurityIdentifier" /> value.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogRecord.Version">
+      <summary>Gets the version number for the event.</summary>
+      <returns>Returns a byte value. This value can be null.</returns>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventLogSession">
+      <summary>Used to access the Event Log service on the local computer or a remote computer so you can manage and gather information about the event logs and event providers on the computer.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogSession.#ctor">
+      <summary>Initializes a new <see cref="T:System.Diagnostics.Eventing.Reader.EventLogSession" /> object, establishes a connection with the local Event Log service.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogSession.#ctor(System.String,System.String,System.String,System.Security.SecureString,System.Diagnostics.Eventing.Reader.SessionAuthentication)">
+      <summary>Initializes a new <see cref="T:System.Diagnostics.Eventing.Reader.EventLogSession" /> object, and establishes a connection with the Event Log service on the specified computer. The specified credentials (user name and password) are used for the credentials to access the remote computer.</summary>
+      <param name="server">The name of the computer on which to connect to the Event Log service.</param>
+      <param name="domain">The domain of the specified user.</param>
+      <param name="user">The user name used to connect to the remote computer.</param>
+      <param name="password">The password used to connect to the remote computer.</param>
+      <param name="logOnType">The type of connection to use for the connection to the remote computer.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogSession.#ctor(System.String)">
+      <summary>Initializes a new <see cref="T:System.Diagnostics.Eventing.Reader.EventLogSession" /> object, and establishes a connection with the Event Log service on the specified computer. The credentials (user name and password) of the user who calls the method is used for the credentials to access the remote computer.</summary>
+      <param name="server">The name of the computer on which to connect to the Event Log service.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogSession.CancelCurrentOperations">
+      <summary>Cancels any operations (such as reading an event log or subscribing to an event log) that are currently active for the Event Log service that this session object is connected to.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogSession.ClearLog(System.String,System.String)">
+      <summary>Clears events from the specified event log, and saves the cleared events to the specified file.</summary>
+      <param name="logName">The name of the event log to clear all the events from.</param>
+      <param name="backupPath">The path to the file in which the cleared events will be saved. The file should end in .evtx.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogSession.ClearLog(System.String)">
+      <summary>Clears events from the specified event log.</summary>
+      <param name="logName">The name of the event log to clear all the events from.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogSession.Dispose">
+      <summary>Releases all the resources used by this object.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogSession.Dispose(System.Boolean)">
+      <summary>Releases the unmanaged resources used by this object, and optionally releases the managed resources.</summary>
+      <param name="disposing">
+        <see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogSession.ExportLog(System.String,System.Diagnostics.Eventing.Reader.PathType,System.String,System.String,System.Boolean)">
+      <summary>Exports events into an external log file. A flag can be set to indicate that the method will continue exporting events even if the specified query fails for some logs. The events are stored without the event messages.</summary>
+      <param name="path">The name of the event log to export events from, or the path to the event log file to export events from.</param>
+      <param name="pathType">Specifies whether the string used in the path parameter specifies the name of an event log, or the path to an event log file.</param>
+      <param name="query">The query used to select the events to export. Only the events returned from the query will be exported.</param>
+      <param name="targetFilePath">The path to the log file (ends in .evtx) in which the exported events will be stored after this method is executed.</param>
+      <param name="tolerateQueryErrors">
+        <see langword="true" /> indicates that the method will continue exporting events even if the specified query fails for some logs, and <see langword="false" /> indicates that this method will not continue to export events when the specified query fails.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogSession.ExportLog(System.String,System.Diagnostics.Eventing.Reader.PathType,System.String,System.String)">
+      <summary>Exports events into an external log file. The events are stored without the event messages.</summary>
+      <param name="path">The name of the event log to export events from, or the path to the event log file to export events from.</param>
+      <param name="pathType">Specifies whether the string used in the path parameter specifies the name of an event log, or the path to an event log file.</param>
+      <param name="query">The query used to select the events to export.  Only the events returned from the query will be exported.</param>
+      <param name="targetFilePath">The path to the log file (ends in .evtx) in which the exported events will be stored after this method is executed.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogSession.ExportLogAndMessages(System.String,System.Diagnostics.Eventing.Reader.PathType,System.String,System.String,System.Boolean,System.Globalization.CultureInfo)">
+      <summary>Exports events and their messages into an external log file. A flag can be set to indicate that the method will continue exporting events even if the specified query fails for some logs. The event messages are exported in the specified language.</summary>
+      <param name="path">The name of the event log to export events from, or the path to the event log file to export events from.</param>
+      <param name="pathType">Specifies whether the string used in the path parameter specifies the name of an event log, or the path to an event log file.</param>
+      <param name="query">The query used to select the events to export.  Only the events returned from the query will be exported.</param>
+      <param name="targetFilePath">The path to the log file (ends in .evtx) in which the exported events will be stored after this method is executed.</param>
+      <param name="tolerateQueryErrors">
+        <see langword="true" /> indicates that the method will continue exporting events even if the specified query fails for some logs, and <see langword="false" /> indicates that this method will not continue to export events when the specified query fails.</param>
+      <param name="targetCultureInfo">The culture that specifies which language that the exported event messages will be in.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogSession.ExportLogAndMessages(System.String,System.Diagnostics.Eventing.Reader.PathType,System.String,System.String)">
+      <summary>Exports events and their messages into an external log file.</summary>
+      <param name="path">The name of the event log to export events from, or the path to the event log file to export events from.</param>
+      <param name="pathType">Specifies whether the string used in the path parameter specifies the name of an event log, or the path to an event log file.</param>
+      <param name="query">The query used to select the events to export.  Only the events returned from the query will be exported.</param>
+      <param name="targetFilePath">The path to the log file (ends in .evtx) in which the exported events will be stored after this method is executed.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogSession.GetLogInformation(System.String,System.Diagnostics.Eventing.Reader.PathType)">
+      <summary>Gets an object that contains runtime information for the specified event log.</summary>
+      <param name="logName">The name of the event log to get information about, or the path to the event log file to get information about.</param>
+      <param name="pathType">Specifies whether the string used in the path parameter specifies the name of an event log, or the path to an event log file.</param>
+      <returns>An object that contains information about the specified log.</returns>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogSession.GetLogNames">
+      <summary>Gets an enumerable collection of all the event log names that are registered with the Event Log service.</summary>
+      <returns>An enumerable collection of strings that contain the event log names.</returns>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogSession.GetProviderNames">
+      <summary>Gets an enumerable collection of all the event provider names that are registered with the Event Log service. An event provider is an application that publishes events to an event log.</summary>
+      <returns>An enumerable collection of strings that contain the event provider names.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogSession.GlobalSession">
+      <summary>Gets a static predefined session object that is connected to the Event Log service on the local computer.</summary>
+      <returns>A predefined session object that is connected to the Event Log service on the local computer.</returns>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventLogStatus">
+      <summary>Contains the status code or error code for a specific event log. This status can be used to determine if the event log is available for an operation.</summary>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogStatus.LogName">
+      <summary>Gets the name of the event log for which the status code is obtained.</summary>
+      <returns>The name of the event log for which the status code is obtained.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogStatus.StatusCode">
+      <summary>Gets the status code or error code for the event log. This status or error is the result of a read or subscription operation on the event log.</summary>
+      <returns>The status code or error code for the event log.</returns>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventLogType">
+      <summary>Defines the type of events that are logged in an event log. Each log can only contain one type of event.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.EventLogType.Administrative">
+      <summary>These events are primarily for end users, administrators, and support. The events that are found in the Administrative type logs indicate a problem and a well-defined solution that an administrator can act on. An example of an administrative event is an event that occurs when an application fails to connect to a printer.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.EventLogType.Analytical">
+      <summary>Events in an analytic event log are published in high volume. They describe program operation and indicate problems that cannot be handled by user intervention.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.EventLogType.Debug">
+      <summary>Events in a debug type event log are used solely by developers to diagnose a problem for debugging.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.EventLogType.Operational">
+      <summary>Events in an operational type event log are used for analyzing and diagnosing a problem or occurrence. They can be used to trigger tools or tasks based on the problem or occurrence. An example of an operational event is an event that occurs when a printer is added or removed from a system.</summary>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventLogWatcher">
+      <summary>Allows you to subscribe to incoming events. Each time a desired event is published to an event log, the <see cref="E:System.Diagnostics.Eventing.Reader.EventLogWatcher.EventRecordWritten" /> event is raised, and the method that handles this event will be executed.</summary>
+    </member>
+    <member name="E:System.Diagnostics.Eventing.Reader.EventLogWatcher.EventRecordWritten">
+      <summary>Allows setting a delegate (event handler method) that gets called every time an event is published that matches the criteria specified in the event query for this object.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogWatcher.#ctor(System.Diagnostics.Eventing.Reader.EventLogQuery,System.Diagnostics.Eventing.Reader.EventBookmark,System.Boolean)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogWatcher" /> class by specifying an event query, a bookmark that is used as starting position for the query, and a Boolean value that determines whether to read the events that already exist in the event log.</summary>
+      <param name="eventQuery">Specifies a query for the event subscription. When an event is logged that matches the criteria expressed in the query, then the <see cref="E:System.Diagnostics.Eventing.Reader.EventLogWatcher.EventRecordWritten" /> event is raised.</param>
+      <param name="bookmark">The bookmark (placeholder) used as a starting position in the event log or stream of events. Only events that have been logged after the bookmark event will be returned by the query.</param>
+      <param name="readExistingEvents">A Boolean value that determines whether to read the events that already exist in the event log. If this value is <see langword="true" />, then the existing events are read and if this value is <see langword="false" />, then the existing events are not read.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogWatcher.#ctor(System.Diagnostics.Eventing.Reader.EventLogQuery,System.Diagnostics.Eventing.Reader.EventBookmark)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogWatcher" /> class by specifying an event query and a bookmark that is used as starting position for the query.</summary>
+      <param name="eventQuery">Specifies a query for the event subscription. When an event is logged that matches the criteria expressed in the query, then the <see cref="E:System.Diagnostics.Eventing.Reader.EventLogWatcher.EventRecordWritten" /> event is raised.</param>
+      <param name="bookmark">The bookmark (placeholder) used as a starting position in the event log or stream of events. Only events that have been logged after the bookmark event will be returned by the query.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogWatcher.#ctor(System.Diagnostics.Eventing.Reader.EventLogQuery)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogWatcher" /> class by specifying an event query.</summary>
+      <param name="eventQuery">Specifies a query for the event subscription. When an event is logged that matches the criteria expressed in the query, then the <see cref="E:System.Diagnostics.Eventing.Reader.EventLogWatcher.EventRecordWritten" /> event is raised.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogWatcher.#ctor(System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventLogWatcher" /> class by specifying the name or path to an event log.</summary>
+      <param name="path">The path or name of the event log monitor for events. If any event is logged in this event log, then the <see cref="E:System.Diagnostics.Eventing.Reader.EventLogWatcher.EventRecordWritten" /> event is raised.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogWatcher.Dispose">
+      <summary>Releases all the resources used by this object.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventLogWatcher.Dispose(System.Boolean)">
+      <summary>Releases the unmanaged resources used by this object, and optionally releases the managed resources.</summary>
+      <param name="disposing">
+        <see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventLogWatcher.Enabled">
+      <summary>Gets or sets a value that indicates whether this object starts delivering events to the event delegate.</summary>
+      <returns>
+        <see langword="true" /> when this object can deliver events to the event delegate; <see langword="false" /> when this object has stopped delivery.</returns>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventMetadata">
+      <summary>Contains the metadata (properties and settings) for an event that is defined in an event provider.</summary>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventMetadata.Description">
+      <summary>Gets the description template associated with the event using the current thread locale for the description language.</summary>
+      <returns>A string that contains the description template associated with the event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventMetadata.Id">
+      <summary>Gets the identifier of the event that is defined in the event provider.</summary>
+      <returns>The event identifier.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventMetadata.Keywords">
+      <summary>Gets the keywords associated with the event that is defined in the event provider.</summary>
+      <returns>An enumerable collection of the keywords associated with the event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventMetadata.Level">
+      <summary>Gets the level associated with the event that is defined in the event provider. The level defines the severity of the event.</summary>
+      <returns>The level associated with the event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventMetadata.LogLink">
+      <summary>Gets a link to the event log that receives this event when the provider publishes this event.</summary>
+      <returns>A link to the event log.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventMetadata.Opcode">
+      <summary>Gets the opcode associated with this event that is defined by an event provider. The opcode defines a numeric value that identifies the activity or a point within an activity that the application was performing when it raised the event.</summary>
+      <returns>The opcode associated with this event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventMetadata.Task">
+      <summary>Gets the task associated with the event. A task identifies a portion of an application or a component that publishes an event.</summary>
+      <returns>The task associated with the event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventMetadata.Template">
+      <summary>Gets the template string for the event. Templates are used to describe data that is used by a provider when an event is published. Templates optionally specify XML that provides the structure of an event. The XML allows values that the event publisher provides to be inserted during the rendering of an event.</summary>
+      <returns>A string that contains the template for the event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventMetadata.Version">
+      <summary>Gets the version of the event that qualifies the event identifier.</summary>
+      <returns>A byte value that contains the version of the event.</returns>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventOpcode">
+      <summary>Contains an event opcode that is defined in an event provider. An opcode defines a numeric value that identifies the activity or a point within an activity that the application was performing when it raised the event.</summary>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventOpcode.DisplayName">
+      <summary>Gets the localized name for an event opcode.</summary>
+      <returns>The localized name for an event opcode.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventOpcode.Name">
+      <summary>Gets the non-localized name for an event opcode.</summary>
+      <returns>The non-localized name for an event opcode.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventOpcode.Value">
+      <summary>Gets the numeric value associated with the event opcode.</summary>
+      <returns>The numeric value associated with the event opcode.</returns>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventProperty">
+      <summary>Contains the value of an event property that is specified by the event provider when the event is published.</summary>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventProperty.Value">
+      <summary>Gets the value of the event property that is specified by the event provider when the event is published.</summary>
+      <returns>The value of the event property.</returns>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventRecord">
+      <summary>Defines the properties of an event instance for an event that is received from an <see cref="T:System.Diagnostics.Eventing.Reader.EventLogReader" /> object. The event properties provide information about the event such as the name of the computer where the event was logged and the time the event was created. This class is an abstract class. The <see cref="T:System.Diagnostics.Eventing.Reader.EventLogRecord" /> class implements this class.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventRecord.#ctor">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.EventRecord" /> class.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventRecord.Dispose">
+      <summary>Releases all the resources used by this object.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventRecord.Dispose(System.Boolean)">
+      <summary>Releases the unmanaged resources used by this object, and optionally releases the managed resources.</summary>
+      <param name="disposing">
+        <see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventRecord.FormatDescription">
+      <summary>Gets the event message in the current locale.</summary>
+      <returns>Returns a string that contains the event message in the current locale.</returns>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventRecord.FormatDescription(System.Collections.Generic.IEnumerable{System.Object})">
+      <summary>Gets the event message, replacing variables in the message with the specified values.</summary>
+      <param name="values">The values used to replace variables in the event message. Variables are represented by %n, where n is a number.</param>
+      <returns>Returns a string that contains the event message in the current locale.</returns>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.EventRecord.ToXml">
+      <summary>Gets the XML representation of the event. All of the event properties are represented in the event XML. The XML conforms to the event schema.</summary>
+      <returns>Returns a string that contains the XML representation of the event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.ActivityId">
+      <summary>Gets the globally unique identifier (GUID) for the activity in process for which the event is involved. This allows consumers to group related activities.</summary>
+      <returns>Returns a GUID value.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.Bookmark">
+      <summary>Gets a placeholder (bookmark) that corresponds to this event. This can be used as a placeholder in a stream of events.</summary>
+      <returns>Returns a <see cref="T:System.Diagnostics.Eventing.Reader.EventBookmark" /> object.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.Id">
+      <summary>Gets the identifier for this event. All events with this identifier value represent the same type of event.</summary>
+      <returns>Returns an integer value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.Keywords">
+      <summary>Gets the keyword mask of the event. Get the value of the <see cref="P:System.Diagnostics.Eventing.Reader.EventRecord.KeywordsDisplayNames" /> property to get the name of the keywords used in this mask.</summary>
+      <returns>Returns a long value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.KeywordsDisplayNames">
+      <summary>Gets the display names of the keywords used in the keyword mask for this event.</summary>
+      <returns>Returns an enumerable collection of strings that contain the display names of the keywords used in the keyword mask for this event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.Level">
+      <summary>Gets the level of the event. The level signifies the severity of the event. For the name of the level, get the value of the <see cref="P:System.Diagnostics.Eventing.Reader.EventRecord.LevelDisplayName" /> property.</summary>
+      <returns>Returns a byte value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.LevelDisplayName">
+      <summary>Gets the display name of the level for this event.</summary>
+      <returns>Returns a string that contains the display name of the level for this event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.LogName">
+      <summary>Gets the name of the event log where this event is logged.</summary>
+      <returns>Returns a string that contains a name of the event log that contains this event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.MachineName">
+      <summary>Gets the name of the computer on which this event was logged.</summary>
+      <returns>Returns a string that contains the name of the computer on which this event was logged.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.Opcode">
+      <summary>Gets the opcode of the event. The opcode defines a numeric value that identifies the activity or a point within an activity that the application was performing when it raised the event. For the name of the opcode, get the value of the <see cref="P:System.Diagnostics.Eventing.Reader.EventRecord.OpcodeDisplayName" /> property.</summary>
+      <returns>Returns a short value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.OpcodeDisplayName">
+      <summary>Gets the display name of the opcode for this event.</summary>
+      <returns>Returns a string that contains the display name of the opcode for this event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.ProcessId">
+      <summary>Gets the process identifier for the event provider that logged this event.</summary>
+      <returns>Returns an integer value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.Properties">
+      <summary>Gets the user-supplied properties of the event.</summary>
+      <returns>Returns a list of <see cref="T:System.Diagnostics.Eventing.Reader.EventProperty" /> objects.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.ProviderId">
+      <summary>Gets the globally unique identifier (GUID) of the event provider that published this event.</summary>
+      <returns>Returns a GUID value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.ProviderName">
+      <summary>Gets the name of the event provider that published this event.</summary>
+      <returns>Returns a string that contains the name of the event provider that published this event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.Qualifiers">
+      <summary>Gets qualifier numbers that are used for event identification.</summary>
+      <returns>Returns an integer value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.RecordId">
+      <summary>Gets the event record identifier of the event in the log.</summary>
+      <returns>Returns a long value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.RelatedActivityId">
+      <summary>Gets a globally unique identifier (GUID) for a related activity in a process for which an event is involved.</summary>
+      <returns>Returns a GUID value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.Task">
+      <summary>Gets a task identifier for a portion of an application or a component that publishes an event. A task is a 16-bit value with 16 top values reserved. This type allows any value between 0x0000 and 0xffef to be used. To obtain the task name, get the value of the <see cref="P:System.Diagnostics.Eventing.Reader.EventRecord.TaskDisplayName" /> property.</summary>
+      <returns>Returns an integer value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.TaskDisplayName">
+      <summary>Gets the display name of the task for the event.</summary>
+      <returns>Returns a string that contains the display name of the task for the event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.ThreadId">
+      <summary>Gets the thread identifier for the thread that the event provider is running in.</summary>
+      <returns>Returns an integer value. This value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.TimeCreated">
+      <summary>Gets the time, in <see cref="T:System.DateTime" /> format, that the event was created.</summary>
+      <returns>Returns a <see cref="T:System.DateTime" /> value. The value can be null.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.UserId">
+      <summary>Gets the security descriptor of the user whose context is used to publish the event.</summary>
+      <returns>Returns a <see cref="T:System.Security.Principal.SecurityIdentifier" /> value.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecord.Version">
+      <summary>Gets the version number for the event.</summary>
+      <returns>Returns a byte value. This value can be null.</returns>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventRecordWrittenEventArgs">
+      <summary>When the <see cref="E:System.Diagnostics.Eventing.Reader.EventLogWatcher.EventRecordWritten" /> event is raised, an instance of this object is passed to the delegate method that handles the event. This object contains the event that was published to the event log or the exception that occurred when the event subscription failed.</summary>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecordWrittenEventArgs.EventException">
+      <summary>Gets the exception that occurred when the event subscription failed. The exception has a description of why the subscription failed.</summary>
+      <returns>The exception that occurred when the event subscription failed.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventRecordWrittenEventArgs.EventRecord">
+      <summary>Gets the event record that is published to the event log. This event matches the criteria from the query specified in the event subscription.</summary>
+      <returns>The event record.</returns>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.EventTask">
+      <summary>Contains an event task that is defined in an event provider. The task identifies a portion of an application or a component that publishes an event. A task is a 16-bit value with 16 top values reserved.</summary>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventTask.DisplayName">
+      <summary>Gets the localized name for the event task.</summary>
+      <returns>The localized name for the event task.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventTask.EventGuid">
+      <summary>Gets the event globally unique identifier (GUID) associated with the task.</summary>
+      <returns>The event GUID associated with the task.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventTask.Name">
+      <summary>Gets the non-localized name of the event task.</summary>
+      <returns>The non-localized name of the event task.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.EventTask.Value">
+      <summary>Gets the numeric value associated with the task.</summary>
+      <returns>The numeric value associated with the task.</returns>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.PathType">
+      <summary>Specifies that a string contains a name of an event log or the file system path to an event log file.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.PathType.FilePath">
+      <summary>A path parameter contains the file system path to an event log file.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.PathType.LogName">
+      <summary>A path parameter contains the name of the event log.</summary>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.ProviderMetadata">
+      <summary>Contains static information about an event provider, such as the name and id of the provider, and the collection of events defined in the provider.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.ProviderMetadata.#ctor(System.String,System.Diagnostics.Eventing.Reader.EventLogSession,System.Globalization.CultureInfo)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.ProviderMetadata" /> class by specifying the name of the provider that you want to retrieve information about, the event log service that the provider is registered with, and the language that you want to return the information in.</summary>
+      <param name="providerName">The name of the event provider that you want to retrieve information about.</param>
+      <param name="session">The <see cref="T:System.Diagnostics.Eventing.Reader.EventLogSession" /> object that specifies whether to get the provider information from a provider on the local computer or a provider on a remote computer.</param>
+      <param name="targetCultureInfo">The culture that specifies the language that the information should be returned in.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.ProviderMetadata.#ctor(System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.Eventing.Reader.ProviderMetadata" /> class by specifying the name of the provider that you want to retrieve information about.</summary>
+      <param name="providerName">The name of the event provider that you want to retrieve information about.</param>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.ProviderMetadata.Dispose">
+      <summary>Releases all the resources used by this object.</summary>
+    </member>
+    <member name="M:System.Diagnostics.Eventing.Reader.ProviderMetadata.Dispose(System.Boolean)">
+      <summary>Releases the unmanaged resources used by this object, and optionally releases the managed resources.</summary>
+      <param name="disposing">
+        <see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.ProviderMetadata.DisplayName">
+      <summary>Gets the localized name of the event provider.</summary>
+      <returns>Returns a string that contains the localized name of the event provider.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.ProviderMetadata.Events">
+      <summary>Gets an enumerable collection of <see cref="T:System.Diagnostics.Eventing.Reader.EventMetadata" /> objects, each of which represents an event that is defined in the provider.</summary>
+      <returns>Returns an enumerable collection of <see cref="T:System.Diagnostics.Eventing.Reader.EventMetadata" /> objects.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.ProviderMetadata.HelpLink">
+      <summary>Gets the base of the URL used to form help requests for the events in this event provider.</summary>
+      <returns>Returns a <see cref="T:System.Uri" /> value.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.ProviderMetadata.Id">
+      <summary>Gets the globally unique identifier (GUID) for the event provider.</summary>
+      <returns>Returns the GUID value for the event provider.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.ProviderMetadata.Keywords">
+      <summary>Gets an enumerable collection of <see cref="T:System.Diagnostics.Eventing.Reader.EventKeyword" /> objects, each of which represent an event keyword that is defined in the event provider.</summary>
+      <returns>Returns an enumerable collection of <see cref="T:System.Diagnostics.Eventing.Reader.EventKeyword" /> objects.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.ProviderMetadata.Levels">
+      <summary>Gets an enumerable collection of <see cref="T:System.Diagnostics.Eventing.Reader.EventLevel" /> objects, each of which represent a level that is defined in the event provider.</summary>
+      <returns>Returns an enumerable collection of <see cref="T:System.Diagnostics.Eventing.Reader.EventLevel" /> objects.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.ProviderMetadata.LogLinks">
+      <summary>Gets an enumerable collection of <see cref="T:System.Diagnostics.Eventing.Reader.EventLogLink" /> objects, each of which represent a link to an event log that is used by the event provider.</summary>
+      <returns>Returns an enumerable collection of <see cref="T:System.Diagnostics.Eventing.Reader.EventLogLink" /> objects.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.ProviderMetadata.MessageFilePath">
+      <summary>Gets the path of the file that contains the message table resource that has the strings associated with the provider metadata.</summary>
+      <returns>Returns a string that contains the path of the provider message file.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.ProviderMetadata.Name">
+      <summary>Gets the unique name of the event provider.</summary>
+      <returns>Returns a string that contains the unique name of the event provider.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.ProviderMetadata.Opcodes">
+      <summary>Gets an enumerable collection of <see cref="T:System.Diagnostics.Eventing.Reader.EventOpcode" /> objects, each of which represent an opcode that is defined in the event provider.</summary>
+      <returns>Returns an enumerable collection of <see cref="T:System.Diagnostics.Eventing.Reader.EventOpcode" /> objects.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.ProviderMetadata.ParameterFilePath">
+      <summary>Gets the path of the file that contains the message table resource that has the strings used for parameter substitutions in event descriptions.</summary>
+      <returns>Returns a string that contains the path of the file that contains the message table resource that has the strings used for parameter substitutions in event descriptions.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.ProviderMetadata.ResourceFilePath">
+      <summary>Gets the path to the file that contains the metadata associated with the provider.</summary>
+      <returns>Returns a string that contains the path to the file that contains the metadata associated with the provider.</returns>
+    </member>
+    <member name="P:System.Diagnostics.Eventing.Reader.ProviderMetadata.Tasks">
+      <summary>Gets an enumerable collection of <see cref="T:System.Diagnostics.Eventing.Reader.EventTask" /> objects, each of which represent a task that is defined in the event provider.</summary>
+      <returns>Returns an enumerable collection of <see cref="T:System.Diagnostics.Eventing.Reader.EventTask" /> objects.</returns>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.SessionAuthentication">
+      <summary>Defines values for the type of authentication used during a Remote Procedure Call (RPC) login to a server. This login occurs when you create a <see cref="T:System.Diagnostics.Eventing.Reader.EventLogSession" /> object that specifies a connection to a remote computer.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.SessionAuthentication.Default">
+      <summary>Use the default authentication method during RPC login. The default authentication is equivalent to Negotiate.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.SessionAuthentication.Kerberos">
+      <summary>Use Kerberos authentication during RPC login.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.SessionAuthentication.Negotiate">
+      <summary>Use the Negotiate authentication method during RPC login. This allows the client application to select the most appropriate authentication method (NTLM or Kerberos) for the situation.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.SessionAuthentication.Ntlm">
+      <summary>Use Windows NT LAN Manager (NTLM) authentication during RPC login.</summary>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.StandardEventKeywords">
+      <summary>Defines the standard keywords that are attached to events by the event provider. For more information about keywords, see <see cref="T:System.Diagnostics.Eventing.Reader.EventKeyword" />.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventKeywords.AuditFailure">
+      <summary>Attached to all failed security audit events. This keyword should only be used for events in the Security log.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventKeywords.AuditSuccess">
+      <summary>Attached to all successful security audit events. This keyword should only be used for events in the Security log.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventKeywords.CorrelationHint">
+      <summary>Attached to transfer events where the related Activity ID (Correlation ID) is a computed value and is not guaranteed to be unique (not a real GUID).</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventKeywords.CorrelationHint2">
+      <summary>Attached to transfer events where the related Activity ID (Correlation ID) is a computed value and is not guaranteed to be unique (not a real GUID).</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventKeywords.EventLogClassic">
+      <summary>Attached to events which are raised using the RaiseEvent function.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventKeywords.None">
+      <summary>This value indicates that no filtering on keyword is performed when the event is published.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventKeywords.ResponseTime">
+      <summary>Attached to all response time events.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventKeywords.Sqm">
+      <summary>Attached to all Service Quality Mechanism (SQM) events.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventKeywords.WdiContext">
+      <summary>Attached to all Windows Diagnostic Infrastructure (WDI) context events.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventKeywords.WdiDiagnostic">
+      <summary>Attached to all Windows Diagnostic Infrastructure (WDI) diagnostic events.</summary>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.StandardEventLevel">
+      <summary>Defines the standard event levels that are used in the Event Log service. The level defines the severity of the event. Custom event levels can be defined beyond these standard levels. For more information about levels, see <see cref="T:System.Diagnostics.Eventing.Reader.EventLevel" />.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventLevel.Critical">
+      <summary>This level corresponds to critical errors, which is a serious error that has caused a major failure.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventLevel.Error">
+      <summary>This level corresponds to normal errors that signify a problem.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventLevel.Informational">
+      <summary>This level corresponds to informational events or messages that are not errors. These events can help trace the progress or state of an application.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventLevel.LogAlways">
+      <summary>This value indicates that not filtering on the level is done during the event publishing.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventLevel.Verbose">
+      <summary>This level corresponds to lengthy events or messages.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventLevel.Warning">
+      <summary>This level corresponds to warning events. For example, an event that gets published because a disk is nearing full capacity is a warning event.</summary>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.StandardEventOpcode">
+      <summary>Defines the standard opcodes that are attached to events by the event provider. For more information about opcodes, see <see cref="T:System.Diagnostics.Eventing.Reader.EventOpcode" />.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventOpcode.DataCollectionStart">
+      <summary>An event with this opcode is a trace collection start event.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventOpcode.DataCollectionStop">
+      <summary>An event with this opcode is a trace collection stop event.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventOpcode.Extension">
+      <summary>An event with this opcode is an extension event.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventOpcode.Info">
+      <summary>An event with this opcode is an informational event.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventOpcode.Receive">
+      <summary>An event with this opcode is published when one activity in an application receives data.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventOpcode.Reply">
+      <summary>An event with this opcode is published after an activity in an application replies to an event.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventOpcode.Resume">
+      <summary>An event with this opcode is published after an activity in an application resumes from a suspended state. The event should follow an event with the Suspend opcode.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventOpcode.Send">
+      <summary>An event with this opcode is published when one activity in an application transfers data or system resources to another activity.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventOpcode.Start">
+      <summary>An event with this opcode is published when an application starts a new transaction or activity. This can be embedded into another transaction or activity when multiple events with the Start opcode follow each other without an event with a Stop opcode.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventOpcode.Stop">
+      <summary>An event with this opcode is published when an activity or a transaction in an application ends. The event corresponds to the last unpaired event with a Start opcode.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventOpcode.Suspend">
+      <summary>An event with this opcode is published when an activity in an application is suspended.</summary>
+    </member>
+    <member name="T:System.Diagnostics.Eventing.Reader.StandardEventTask">
+      <summary>Defines the standard tasks that are attached to events by the event provider. For more information about tasks, see <see cref="T:System.Diagnostics.Eventing.Reader.EventTask" />.</summary>
+    </member>
+    <member name="F:System.Diagnostics.Eventing.Reader.StandardEventTask.None">
+      <summary>No task is used to identify a portion of an application that publishes an event.</summary>
+    </member>
+    <member name="T:System.Diagnostics.EventInstance">
+      <summary>Represents language-neutral information for an event log entry.</summary>
+    </member>
+    <member name="M:System.Diagnostics.EventInstance.#ctor(System.Int64,System.Int32,System.Diagnostics.EventLogEntryType)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.EventInstance" /> class using the specified resource identifiers for the localized message and category text of the event entry and the specified event log entry type.</summary>
+      <param name="instanceId">A resource identifier that corresponds to a string defined in the message resource file of the event source.</param>
+      <param name="categoryId">A resource identifier that corresponds to a string defined in the category resource file of the event source, or zero to specify no category for the event.</param>
+      <param name="entryType">An <see cref="T:System.Diagnostics.EventLogEntryType" /> value that indicates the event type.</param>
+      <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">
+        <paramref name="entryType" /> is not a valid <see cref="T:System.Diagnostics.EventLogEntryType" /> value.</exception>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        <paramref name="instanceId" /> is a negative value or a value larger than <see cref="F:System.UInt32.MaxValue">UInt32.MaxValue</see>.  
+  
+ -or-  
+  
+ <paramref name="categoryId" /> is a negative value or a value larger than <see cref="F:System.UInt16.MaxValue">UInt16.MaxValue</see>.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventInstance.#ctor(System.Int64,System.Int32)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.EventInstance" /> class using the specified resource identifiers for the localized message and category text of the event entry.</summary>
+      <param name="instanceId">A resource identifier that corresponds to a string defined in the message resource file of the event source.</param>
+      <param name="categoryId">A resource identifier that corresponds to a string defined in the category resource file of the event source, or zero to specify no category for the event.</param>
+      <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="instanceId" /> parameter is a negative value or a value larger than <see cref="F:System.UInt32.MaxValue">UInt32.MaxValue</see>.  
+  
+ -or-  
+  
+ The <paramref name="categoryId" /> parameter is a negative value or a value larger than <see cref="F:System.UInt16.MaxValue">UInt16.MaxValue</see>.</exception>
+    </member>
+    <member name="P:System.Diagnostics.EventInstance.CategoryId">
+      <summary>Gets or sets the resource identifier that specifies the application-defined category of the event entry.</summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">The property is set to a negative value or to a value larger than <see cref="F:System.UInt16.MaxValue">UInt16.MaxValue</see>.</exception>
+      <returns>A numeric category value or resource identifier that corresponds to a string defined in the category resource file of the event source. The default is zero, which signifies that no category will be displayed for the event entry.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventInstance.EntryType">
+      <summary>Gets or sets the event type of the event log entry.</summary>
+      <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">The property is not set to a valid <see cref="T:System.Diagnostics.EventLogEntryType" /> value.</exception>
+      <returns>An <see cref="T:System.Diagnostics.EventLogEntryType" /> value that indicates the event entry type. The default value is <see cref="F:System.Diagnostics.EventLogEntryType.Information" />.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventInstance.InstanceId">
+      <summary>Gets or sets the resource identifier that designates the message text of the event entry.</summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">The property is set to a negative value or to a value larger than <see cref="F:System.UInt32.MaxValue">UInt32.MaxValue</see>.</exception>
+      <returns>A resource identifier that corresponds to a string defined in the message resource file of the event source.</returns>
+    </member>
+    <member name="T:System.Diagnostics.EventLog">
+      <summary>Provides interaction with Windows event logs.</summary>
+    </member>
+    <member name="E:System.Diagnostics.EventLog.EntryWritten">
+      <summary>Occurs when an entry is written to an event log on the local computer.</summary>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.#ctor">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.EventLog" /> class. Does not associate the instance with any log.</summary>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.#ctor(System.String,System.String,System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.EventLog" /> class. Associates the instance with a log on the specified computer and creates or assigns the specified source to the <see cref="T:System.Diagnostics.EventLog" />.</summary>
+      <param name="logName">The name of the log on the specified computer.</param>
+      <param name="machineName">The computer on which the log exists.</param>
+      <param name="source">The source of event log entries.</param>
+      <exception cref="T:System.ArgumentNullException">The log name is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">The log name is invalid.
+
+ -or-
+
+ The computer name is invalid.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.#ctor(System.String,System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.EventLog" /> class. Associates the instance with a log on the specified computer.</summary>
+      <param name="logName">The name of the log on the specified computer.</param>
+      <param name="machineName">The computer on which the log exists.</param>
+      <exception cref="T:System.ArgumentNullException">The log name is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">The log name is invalid.
+
+ -or-
+
+ The computer name is invalid.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.#ctor(System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.EventLog" /> class. Associates the instance with a log on the local computer.</summary>
+      <param name="logName">The name of the log on the local computer.</param>
+      <exception cref="T:System.ArgumentNullException">The log name is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">The log name is invalid.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.BeginInit">
+      <summary>Begins the initialization of an <see cref="T:System.Diagnostics.EventLog" /> used on a form or used by another component. The initialization occurs at runtime.</summary>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="T:System.Diagnostics.EventLog" /> is already initialized.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.Clear">
+      <summary>Removes all entries from the event log.</summary>
+      <exception cref="T:System.ComponentModel.Win32Exception">The event log was not cleared successfully.
+
+ -or-
+
+ The log cannot be opened. A Windows error code is not available.</exception>
+      <exception cref="T:System.ArgumentException">A value is not specified for the <see cref="P:System.Diagnostics.EventLog.Log" /> property. Make sure the log name is not an empty string.</exception>
+      <exception cref="T:System.InvalidOperationException">The log does not exist.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.Close">
+      <summary>Closes the event log and releases read and write handles.</summary>
+      <exception cref="T:System.ComponentModel.Win32Exception">The event log's read handle or write handle was not released successfully.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.CreateEventSource(System.Diagnostics.EventSourceCreationData)">
+      <summary>Establishes a valid event source for writing localized event messages, using the specified configuration properties for the event source and the corresponding event log.</summary>
+      <param name="sourceData">The configuration properties for the event source and its target event log.</param>
+      <exception cref="T:System.ArgumentException">The computer name specified in <paramref name="sourceData" /> is not valid.
+
+-or-
+
+ The source name specified in <paramref name="sourceData" /> is <see langword="null" />.
+
+-or-
+
+ The log name specified in <paramref name="sourceData" /> is not valid. Event log names must consist of printable characters and cannot include the characters '*', '?', or '\'.
+
+-or-
+
+ The log name specified in <paramref name="sourceData" /> is not valid for user log creation. The Event log names AppEvent, SysEvent, and SecEvent are reserved for system use.
+
+-or-
+
+ The log name matches an existing event source name.
+
+-or-
+
+ The source name specified in <paramref name="sourceData" /> results in a registry key path longer than 254 characters.
+
+-or-
+
+ The first 8 characters of the log name specified in <paramref name="sourceData" /> are not unique.
+
+-or-
+
+ The source name specified in <paramref name="sourceData" /> is already registered.
+
+-or-
+
+ The source name specified in <paramref name="sourceData" /> matches an existing event log name.</exception>
+      <exception cref="T:System.InvalidOperationException">The registry key for the event log could not be opened.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="sourceData" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.CreateEventSource(System.String,System.String,System.String)">
+      <summary>Establishes the specified source name as a valid event source for writing entries to a log on the specified computer. This method can also be used to create a new custom log on the specified computer.</summary>
+      <param name="source">The source by which the application is registered on the specified computer.</param>
+      <param name="logName">The name of the log the source's entries are written to. Possible values include Application, System, or a custom event log. If you do not specify a value, <paramref name="logName" /> defaults to Application.</param>
+      <param name="machineName">The name of the computer to register this event source with, or "." for the local computer.</param>
+      <exception cref="T:System.ArgumentException">The <paramref name="machineName" /> is not a valid computer name.
+
+-or-
+
+ <paramref name="source" /> is an empty string ("") or <see langword="null" />.
+
+-or-
+
+ <paramref name="logName" /> is not a valid event log name. Event log names must consist of printable characters, and cannot include the characters '*', '?', or '\'.
+
+-or-
+
+ <paramref name="logName" /> is not valid for user log creation. The event log names AppEvent, SysEvent, and SecEvent are reserved for system use.
+
+-or-
+
+ The log name matches an existing event source name.
+
+-or-
+
+ The source name results in a registry key path longer than 254 characters.
+
+-or-
+
+ The first 8 characters of <paramref name="logName" /> match the first 8 characters of an existing event log name on the specified computer.
+
+-or-
+
+ The source cannot be registered because it already exists on the specified computer.
+
+-or-
+
+ The source name matches an existing event source name.</exception>
+      <exception cref="T:System.InvalidOperationException">The registry key for the event log could not be opened on the specified computer.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.CreateEventSource(System.String,System.String)">
+      <summary>Establishes the specified source name as a valid event source for writing entries to a log on the local computer. This method can also create a new custom log on the local computer.</summary>
+      <param name="source">The source name by which the application is registered on the local computer.</param>
+      <param name="logName">The name of the log the source's entries are written to. Possible values include Application, System, or a custom event log.</param>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="source" /> is an empty string ("") or <see langword="null" />.
+
+-or-
+
+ <paramref name="logName" /> is not a valid event log name. Event log names must consist of printable characters, and cannot include the characters '*', '?', or '\'.
+
+-or-
+
+ <paramref name="logName" /> is not valid for user log creation. The event log names AppEvent, SysEvent, and SecEvent are reserved for system use.
+
+-or-
+
+ The log name matches an existing event source name.
+
+-or-
+
+ The source name results in a registry key path longer than 254 characters.
+
+-or-
+
+ The first 8 characters of <paramref name="logName" /> match the first 8 characters of an existing event log name.
+
+-or-
+
+ The source cannot be registered because it already exists on the local computer.
+
+-or-
+
+ The source name matches an existing event log name.</exception>
+      <exception cref="T:System.InvalidOperationException">The registry key for the event log could not be opened on the local computer.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.Delete(System.String,System.String)">
+      <summary>Removes an event log from the specified computer.</summary>
+      <param name="logName">The name of the log to delete. Possible values include: Application, Security, System, and any custom event logs on the specified computer.</param>
+      <param name="machineName">The name of the computer to delete the log from, or "." for the local computer.</param>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="logName" /> is an empty string ("") or <see langword="null" />.
+
+-or-
+
+ <paramref name="machineName" /> is not a valid computer name.</exception>
+      <exception cref="T:System.InvalidOperationException">The registry key for the event log could not be opened on the specified computer.
+
+-or-
+
+ The log does not exist on the specified computer.</exception>
+      <exception cref="T:System.ComponentModel.Win32Exception">The event log was not cleared successfully.
+
+ -or-
+
+ The log cannot be opened. A Windows error code is not available.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.Delete(System.String)">
+      <summary>Removes an event log from the local computer.</summary>
+      <param name="logName">The name of the log to delete. Possible values include: Application, Security, System, and any custom event logs on the computer.</param>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="logName" /> is an empty string ("") or <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The registry key for the event log could not be opened on the local computer.
+
+-or-
+
+ The log does not exist on the local computer.</exception>
+      <exception cref="T:System.ComponentModel.Win32Exception">The event log was not cleared successfully.
+
+ -or-
+
+ The log cannot be opened. A Windows error code is not available.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.DeleteEventSource(System.String,System.String)">
+      <summary>Removes the application's event source registration from the specified computer.</summary>
+      <param name="source">The name by which the application is registered in the event log system.</param>
+      <param name="machineName">The name of the computer to remove the registration from, or "." for the local computer.</param>
+      <exception cref="T:System.ArgumentException">The <paramref name="machineName" /> parameter is invalid.
+
+-or-
+
+ The <paramref name="source" /> parameter does not exist in the registry of the specified computer.
+
+-or-
+
+ You do not have write access on the registry key for the event log.</exception>
+      <exception cref="T:System.InvalidOperationException">
+        <paramref name="source" /> cannot be deleted because in the registry, the parent registry key for <paramref name="source" /> does not contain a subkey with the same name.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.DeleteEventSource(System.String)">
+      <summary>Removes the event source registration from the event log of the local computer.</summary>
+      <param name="source">The name by which the application is registered in the event log system.</param>
+      <exception cref="T:System.ArgumentException">The <paramref name="source" /> parameter does not exist in the registry of the local computer.
+
+-or-
+
+ You do not have write access on the registry key for the event log.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.Dispose(System.Boolean)">
+      <summary>Releases the unmanaged resources used by the <see cref="T:System.Diagnostics.EventLog" />, and optionally releases the managed resources.</summary>
+      <param name="disposing">
+        <see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.EndInit">
+      <summary>Ends the initialization of an <see cref="T:System.Diagnostics.EventLog" /> used on a form or by another component. The initialization occurs at runtime.</summary>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.Exists(System.String,System.String)">
+      <summary>Determines whether the log exists on the specified computer.</summary>
+      <param name="logName">The log for which to search. Possible values include: Application, Security, System, other application-specific logs (such as those associated with Active Directory), or any custom log on the computer.</param>
+      <param name="machineName">The name of the computer on which to search for the log, or "." for the local computer.</param>
+      <exception cref="T:System.ArgumentException">The <paramref name="machineName" /> parameter is an invalid format. Make sure you have used proper syntax for the computer on which you are searching.
+
+ -or-
+
+ The <paramref name="logName" /> is <see langword="null" /> or the value is empty.</exception>
+      <returns>
+        <see langword="true" /> if the log exists on the specified computer; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.Exists(System.String)">
+      <summary>Determines whether the log exists on the local computer.</summary>
+      <param name="logName">The name of the log to search for. Possible values include: Application, Security, System, other application-specific logs (such as those associated with Active Directory), or any custom log on the computer.</param>
+      <exception cref="T:System.ArgumentException">The logName is <see langword="null" /> or the value is empty.</exception>
+      <returns>
+        <see langword="true" /> if the log exists on the local computer; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.GetEventLogs">
+      <summary>Searches for all event logs on the local computer and creates an array of <see cref="T:System.Diagnostics.EventLog" /> objects that contain the list.</summary>
+      <exception cref="T:System.SystemException">You do not have read access to the registry.
+
+ -or-
+
+ There is no event log service on the computer.</exception>
+      <returns>An array of type <see cref="T:System.Diagnostics.EventLog" /> that represents the logs on the local computer.</returns>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.GetEventLogs(System.String)">
+      <summary>Searches for all event logs on the given computer and creates an array of <see cref="T:System.Diagnostics.EventLog" /> objects that contain the list.</summary>
+      <param name="machineName">The computer on which to search for event logs.</param>
+      <exception cref="T:System.ArgumentException">The <paramref name="machineName" /> parameter is an invalid computer name.</exception>
+      <exception cref="T:System.InvalidOperationException">You do not have read access to the registry.
+
+ -or-
+
+ There is no event log service on the computer.</exception>
+      <returns>An array of type <see cref="T:System.Diagnostics.EventLog" /> that represents the logs on the given computer.</returns>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.LogNameFromSourceName(System.String,System.String)">
+      <summary>Gets the name of the log to which the specified source is registered.</summary>
+      <param name="source">The name of the event source.</param>
+      <param name="machineName">The name of the computer on which to look, or "." for the local computer.</param>
+      <returns>The name of the log associated with the specified source in the registry.</returns>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.ModifyOverflowPolicy(System.Diagnostics.OverflowAction,System.Int32)">
+      <summary>Changes the configured behavior for writing new entries when the event log reaches its maximum file size.</summary>
+      <param name="action">The overflow behavior for writing new entries to the event log.</param>
+      <param name="retentionDays">The minimum number of days each event log entry is retained. This parameter is used only if <paramref name="action" /> is set to <see cref="F:System.Diagnostics.OverflowAction.OverwriteOlder" />.</param>
+      <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">
+        <paramref name="action" /> is not a valid <see cref="P:System.Diagnostics.EventLog.OverflowAction" /> value.</exception>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        <paramref name="retentionDays" /> is less than one, or larger than 365.</exception>
+      <exception cref="T:System.InvalidOperationException">The <see cref="P:System.Diagnostics.EventLog.Log" /> value is not a valid log name.
+
+-or-
+
+ The registry key for the event log could not be opened on the target computer.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.RegisterDisplayName(System.String,System.Int64)">
+      <summary>Specifies the localized name of the event log, which is displayed in the server Event Viewer.</summary>
+      <param name="resourceFile">The fully specified path to a localized resource file.</param>
+      <param name="resourceId">The resource identifier that indexes a localized string within the resource file.</param>
+      <exception cref="T:System.InvalidOperationException">The <see cref="P:System.Diagnostics.EventLog.Log" /> value is not a valid log name.
+
+-or-
+
+ The registry key for the event log could not be opened on the target computer.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="resourceFile" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.SourceExists(System.String,System.String)">
+      <summary>Determines whether an event source is registered on a specified computer.</summary>
+      <param name="source">The name of the event source.</param>
+      <param name="machineName">The name the computer on which to look, or "." for the local computer.</param>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="machineName" /> is an invalid computer name.</exception>
+      <exception cref="T:System.Security.SecurityException">
+        <paramref name="source" /> was not found, but some or all of the event logs could not be searched.</exception>
+      <returns>
+        <see langword="true" /> if the event source is registered on the given computer; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.SourceExists(System.String)">
+      <summary>Determines whether an event source is registered on the local computer.</summary>
+      <param name="source">The name of the event source.</param>
+      <exception cref="T:System.Security.SecurityException">
+        <paramref name="source" /> was not found, but some or all of the event logs could not be searched.</exception>
+      <returns>
+        <see langword="true" /> if the event source is registered on the local computer; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.WriteEntry(System.String,System.Diagnostics.EventLogEntryType,System.Int32,System.Int16,System.Byte[])">
+      <summary>Writes an entry with the given message text, application-defined event identifier, and application-defined category to the event log, and appends binary data to the message.</summary>
+      <param name="message">The string to write to the event log.</param>
+      <param name="type">One of the <see cref="T:System.Diagnostics.EventLogEntryType" /> values.</param>
+      <param name="eventID">The application-specific identifier for the event.</param>
+      <param name="category">The application-specific subcategory associated with the message.</param>
+      <param name="rawData">An array of bytes that holds the binary data associated with the entry.</param>
+      <exception cref="T:System.ArgumentException">The <see cref="P:System.Diagnostics.EventLog.Source" /> property of the <see cref="T:System.Diagnostics.EventLog" /> has not been set.
+
+ -or-
+
+ The method attempted to register a new event source, but the computer name in <see cref="P:System.Diagnostics.EventLog.MachineName" /> is not valid.
+
+-or-
+
+ The source is already registered for a different event log.
+
+-or-
+
+ <paramref name="eventID" /> is less than zero or greater than <see cref="F:System.UInt16.MaxValue">UInt16.MaxValue</see>.
+
+-or-
+
+ The message string is longer than 31,839 bytes (32,766 bytes on Windows operating systems before Windows Vista).
+
+-or-
+
+ The source name results in a registry key path longer than 254 characters.</exception>
+      <exception cref="T:System.InvalidOperationException">The registry key for the event log could not be opened.</exception>
+      <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">
+        <paramref name="type" /> is not a valid <see cref="T:System.Diagnostics.EventLogEntryType" />.</exception>
+      <exception cref="T:System.ComponentModel.Win32Exception">The operating system reported an error when writing the event entry to the event log. A Windows error code is not available.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.WriteEntry(System.String,System.Diagnostics.EventLogEntryType,System.Int32,System.Int16)">
+      <summary>Writes an entry with the given message text, application-defined event identifier, and application-defined category to the event log.</summary>
+      <param name="message">The string to write to the event log.</param>
+      <param name="type">One of the <see cref="T:System.Diagnostics.EventLogEntryType" /> values.</param>
+      <param name="eventID">The application-specific identifier for the event.</param>
+      <param name="category">The application-specific subcategory associated with the message.</param>
+      <exception cref="T:System.ArgumentException">The <see cref="P:System.Diagnostics.EventLog.Source" /> property of the <see cref="T:System.Diagnostics.EventLog" /> has not been set.
+
+ -or-
+
+ The method attempted to register a new event source, but the computer name in <see cref="P:System.Diagnostics.EventLog.MachineName" /> is not valid.
+
+-or-
+
+ The source is already registered for a different event log.
+
+-or-
+
+ <paramref name="eventID" /> is less than zero or greater than <see cref="F:System.UInt16.MaxValue">UInt16.MaxValue</see>.
+
+-or-
+
+ The message string is longer than 31,839 bytes (32,766 bytes on Windows operating systems before Windows Vista).
+
+-or-
+
+ The source name results in a registry key path longer than 254 characters.</exception>
+      <exception cref="T:System.InvalidOperationException">The registry key for the event log could not be opened.</exception>
+      <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">
+        <paramref name="type" /> is not a valid <see cref="T:System.Diagnostics.EventLogEntryType" />.</exception>
+      <exception cref="T:System.ComponentModel.Win32Exception">The operating system reported an error when writing the event entry to the event log. A Windows error code is not available.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.WriteEntry(System.String,System.Diagnostics.EventLogEntryType,System.Int32)">
+      <summary>Writes an entry with the given message text and application-defined event identifier to the event log.</summary>
+      <param name="message">The string to write to the event log.</param>
+      <param name="type">One of the <see cref="T:System.Diagnostics.EventLogEntryType" /> values.</param>
+      <param name="eventID">The application-specific identifier for the event.</param>
+      <exception cref="T:System.ArgumentException">The <see cref="P:System.Diagnostics.EventLog.Source" /> property of the <see cref="T:System.Diagnostics.EventLog" /> has not been set.
+
+ -or-
+
+ The method attempted to register a new event source, but the computer name in <see cref="P:System.Diagnostics.EventLog.MachineName" /> is not valid.
+
+-or-
+
+ The source is already registered for a different event log.
+
+-or-
+
+ <paramref name="eventID" /> is less than zero or greater than <see cref="F:System.UInt16.MaxValue">UInt16.MaxValue</see>.
+
+-or-
+
+ The message string is longer than 31,839 bytes (32,766 bytes on Windows operating systems before Windows Vista).
+
+-or-
+
+ The source name results in a registry key path longer than 254 characters.</exception>
+      <exception cref="T:System.InvalidOperationException">The registry key for the event log could not be opened.</exception>
+      <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">
+        <paramref name="type" /> is not a valid <see cref="T:System.Diagnostics.EventLogEntryType" />.</exception>
+      <exception cref="T:System.ComponentModel.Win32Exception">The operating system reported an error when writing the event entry to the event log. A Windows error code is not available.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.WriteEntry(System.String,System.Diagnostics.EventLogEntryType)">
+      <summary>Writes an error, warning, information, success audit, or failure audit entry with the given message text to the event log.</summary>
+      <param name="message">The string to write to the event log.</param>
+      <param name="type">One of the <see cref="T:System.Diagnostics.EventLogEntryType" /> values.</param>
+      <exception cref="T:System.ArgumentException">The <see cref="P:System.Diagnostics.EventLog.Source" /> property of the <see cref="T:System.Diagnostics.EventLog" /> has not been set.
+
+ -or-
+
+ The method attempted to register a new event source, but the computer name in <see cref="P:System.Diagnostics.EventLog.MachineName" /> is not valid.
+
+-or-
+
+ The source is already registered for a different event log.
+
+-or-
+
+ The message string is longer than 31,839 bytes (32,766 bytes on Windows operating systems before Windows Vista).
+
+-or-
+
+ The source name results in a registry key path longer than 254 characters.</exception>
+      <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">
+        <paramref name="type" /> is not a valid <see cref="T:System.Diagnostics.EventLogEntryType" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The registry key for the event log could not be opened.</exception>
+      <exception cref="T:System.ComponentModel.Win32Exception">The operating system reported an error when writing the event entry to the event log. A Windows error code is not available.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.WriteEntry(System.String,System.String,System.Diagnostics.EventLogEntryType,System.Int32,System.Int16,System.Byte[])">
+      <summary>Writes an entry with the given message text, application-defined event identifier, and application-defined category to the event log (using the specified registered event source) and appends binary data to the message.</summary>
+      <param name="source">The source by which the application is registered on the specified computer.</param>
+      <param name="message">The string to write to the event log.</param>
+      <param name="type">One of the <see cref="T:System.Diagnostics.EventLogEntryType" /> values.</param>
+      <param name="eventID">The application-specific identifier for the event.</param>
+      <param name="category">The application-specific subcategory associated with the message.</param>
+      <param name="rawData">An array of bytes that holds the binary data associated with the entry.</param>
+      <exception cref="T:System.ArgumentException">The <paramref name="source" /> value is an empty string ("").
+
+-or-
+
+ The <paramref name="source" /> value is <see langword="null" />.
+
+-or-
+
+ <paramref name="eventID" /> is less than zero or greater than <see cref="F:System.UInt16.MaxValue">UInt16.MaxValue</see>.
+
+-or-
+
+ The message string is longer than 31,839 bytes (32,766 bytes on Windows operating systems before Windows Vista).
+
+-or-
+
+ The source name results in a registry key path longer than 254 characters.</exception>
+      <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">
+        <paramref name="type" /> is not a valid <see cref="T:System.Diagnostics.EventLogEntryType" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The registry key for the event log could not be opened.</exception>
+      <exception cref="T:System.ComponentModel.Win32Exception">The operating system reported an error when writing the event entry to the event log. A Windows error code is not available.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.WriteEntry(System.String,System.String,System.Diagnostics.EventLogEntryType,System.Int32,System.Int16)">
+      <summary>Writes an entry with the given message text, application-defined event identifier, and application-defined category to the event log, using the specified registered event source. The <paramref name="category" /> can be used by the Event Viewer to filter events in the log.</summary>
+      <param name="source">The source by which the application is registered on the specified computer.</param>
+      <param name="message">The string to write to the event log.</param>
+      <param name="type">One of the <see cref="T:System.Diagnostics.EventLogEntryType" /> values.</param>
+      <param name="eventID">The application-specific identifier for the event.</param>
+      <param name="category">The application-specific subcategory associated with the message.</param>
+      <exception cref="T:System.ArgumentException">The <paramref name="source" /> value is an empty string ("").
+
+-or-
+
+ The <paramref name="source" /> value is <see langword="null" />.
+
+-or-
+
+ <paramref name="eventID" /> is less than zero or greater than <see cref="F:System.UInt16.MaxValue">UInt16.MaxValue</see>.
+
+-or-
+
+ The message string is longer than 31,839 bytes (32,766 bytes on Windows operating systems before Windows Vista).
+
+-or-
+
+ The source name results in a registry key path longer than 254 characters.</exception>
+      <exception cref="T:System.InvalidOperationException">The registry key for the event log could not be opened.</exception>
+      <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">
+        <paramref name="type" /> is not a valid <see cref="T:System.Diagnostics.EventLogEntryType" />.</exception>
+      <exception cref="T:System.ComponentModel.Win32Exception">The operating system reported an error when writing the event entry to the event log. A Windows error code is not available.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.WriteEntry(System.String,System.String,System.Diagnostics.EventLogEntryType,System.Int32)">
+      <summary>Writes an entry with the given message text and application-defined event identifier to the event log, using the specified registered event source.</summary>
+      <param name="source">The source by which the application is registered on the specified computer.</param>
+      <param name="message">The string to write to the event log.</param>
+      <param name="type">One of the <see cref="T:System.Diagnostics.EventLogEntryType" /> values.</param>
+      <param name="eventID">The application-specific identifier for the event.</param>
+      <exception cref="T:System.ArgumentException">The <paramref name="source" /> value is an empty string ("").
+
+-or-
+
+ The <paramref name="source" /> value is <see langword="null" />.
+
+-or-
+
+ <paramref name="eventID" /> is less than zero or greater than <see cref="F:System.UInt16.MaxValue">UInt16.MaxValue</see>.
+
+-or-
+
+ The message string is longer than 31,839 bytes (32,766 bytes on Windows operating systems before Windows Vista).
+
+-or-
+
+ The source name results in a registry key path longer than 254 characters.</exception>
+      <exception cref="T:System.InvalidOperationException">The registry key for the event log could not be opened.</exception>
+      <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">
+        <paramref name="type" /> is not a valid <see cref="T:System.Diagnostics.EventLogEntryType" />.</exception>
+      <exception cref="T:System.ComponentModel.Win32Exception">The operating system reported an error when writing the event entry to the event log. A Windows error code is not available.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.WriteEntry(System.String,System.String,System.Diagnostics.EventLogEntryType)">
+      <summary>Writes an error, warning, information, success audit, or failure audit entry with the given message text to the event log, using the specified registered event source.</summary>
+      <param name="source">The source by which the application is registered on the specified computer.</param>
+      <param name="message">The string to write to the event log.</param>
+      <param name="type">One of the <see cref="T:System.Diagnostics.EventLogEntryType" /> values.</param>
+      <exception cref="T:System.ArgumentException">The <paramref name="source" /> value is an empty string ("").
+
+-or-
+
+ The <paramref name="source" /> value is <see langword="null" />.
+
+-or-
+
+ The message string is longer than 31,839 bytes (32,766 bytes on Windows operating systems before Windows Vista).
+
+-or-
+
+ The source name results in a registry key path longer than 254 characters.</exception>
+      <exception cref="T:System.InvalidOperationException">The registry key for the event log could not be opened.</exception>
+      <exception cref="T:System.ComponentModel.InvalidEnumArgumentException">
+        <paramref name="type" /> is not a valid <see cref="T:System.Diagnostics.EventLogEntryType" />.</exception>
+      <exception cref="T:System.ComponentModel.Win32Exception">The operating system reported an error when writing the event entry to the event log. A Windows error code is not available.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.WriteEntry(System.String,System.String)">
+      <summary>Writes an information type entry with the given message text to the event log, using the specified registered event source.</summary>
+      <param name="source">The source by which the application is registered on the specified computer.</param>
+      <param name="message">The string to write to the event log.</param>
+      <exception cref="T:System.ArgumentException">The <paramref name="source" /> value is an empty string ("").
+
+-or-
+
+ The <paramref name="source" /> value is <see langword="null" />.
+
+-or-
+
+ The message string is longer than 31,839 bytes (32,766 bytes on Windows operating systems before Windows Vista).
+
+-or-
+
+ The source name results in a registry key path longer than 254 characters.</exception>
+      <exception cref="T:System.InvalidOperationException">The registry key for the event log could not be opened.</exception>
+      <exception cref="T:System.ComponentModel.Win32Exception">The operating system reported an error when writing the event entry to the event log. A Windows error code is not available.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.WriteEntry(System.String)">
+      <summary>Writes an information type entry, with the given message text, to the event log.</summary>
+      <param name="message">The string to write to the event log.</param>
+      <exception cref="T:System.ArgumentException">The <see cref="P:System.Diagnostics.EventLog.Source" /> property of the <see cref="T:System.Diagnostics.EventLog" /> has not been set.
+
+ -or-
+
+ The method attempted to register a new event source, but the computer name in <see cref="P:System.Diagnostics.EventLog.MachineName" /> is not valid.
+
+-or-
+
+ The source is already registered for a different event log.
+
+-or-
+
+ The message string is longer than 31,839 bytes (32,766 bytes on Windows operating systems before Windows Vista).
+
+-or-
+
+ The source name results in a registry key path longer than 254 characters.</exception>
+      <exception cref="T:System.InvalidOperationException">The registry key for the event log could not be opened.</exception>
+      <exception cref="T:System.ComponentModel.Win32Exception">The operating system reported an error when writing the event entry to the event log. A Windows error code is not available.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.WriteEvent(System.Diagnostics.EventInstance,System.Byte[],System.Object[])">
+      <summary>Writes an event log entry with the given event data, message replacement strings, and associated binary data.</summary>
+      <param name="instance">An <see cref="T:System.Diagnostics.EventInstance" /> instance that represents a localized event log entry.</param>
+      <param name="data">An array of bytes that holds the binary data associated with the entry.</param>
+      <param name="values">An array of strings to merge into the message text of the event log entry.</param>
+      <exception cref="T:System.ArgumentException">The <see cref="P:System.Diagnostics.EventLog.Source" /> property of the <see cref="T:System.Diagnostics.EventLog" /> has not been set.
+
+ -or-
+
+ The method attempted to register a new event source, but the computer name in <see cref="P:System.Diagnostics.EventLog.MachineName" /> is not valid.
+
+-or-
+
+ The source is already registered for a different event log.
+
+-or-
+
+ <paramref name="instance.InstanceId" /> is less than zero or greater than <see cref="F:System.UInt16.MaxValue">UInt16.MaxValue</see>.
+
+-or-
+
+ <paramref name="values" /> has more than 256 elements.
+
+-or-
+
+ One of the <paramref name="values" /> elements is longer than 32766 bytes.
+
+-or-
+
+ The source name results in a registry key path longer than 254 characters.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="instance" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The registry key for the event log could not be opened.</exception>
+      <exception cref="T:System.ComponentModel.Win32Exception">The operating system reported an error when writing the event entry to the event log. A Windows error code is not available.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.WriteEvent(System.Diagnostics.EventInstance,System.Object[])">
+      <summary>Writes a localized entry to the event log.</summary>
+      <param name="instance">An <see cref="T:System.Diagnostics.EventInstance" /> instance that represents a localized event log entry.</param>
+      <param name="values">An array of strings to merge into the message text of the event log entry.</param>
+      <exception cref="T:System.ArgumentException">The <see cref="P:System.Diagnostics.EventLog.Source" /> property of the <see cref="T:System.Diagnostics.EventLog" /> has not been set.
+
+ -or-
+
+ The method attempted to register a new event source, but the computer name in <see cref="P:System.Diagnostics.EventLog.MachineName" /> is not valid.
+
+-or-
+
+ The source is already registered for a different event log.
+
+-or-
+
+ <paramref name="instance.InstanceId" /> is less than zero or greater than <see cref="F:System.UInt16.MaxValue">UInt16.MaxValue</see>.
+
+-or-
+
+ <paramref name="values" /> has more than 256 elements.
+
+-or-
+
+ One of the <paramref name="values" /> elements is longer than 32766 bytes.
+
+-or-
+
+ The source name results in a registry key path longer than 254 characters.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="instance" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The registry key for the event log could not be opened.</exception>
+      <exception cref="T:System.ComponentModel.Win32Exception">The operating system reported an error when writing the event entry to the event log. A Windows error code is not available.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.WriteEvent(System.String,System.Diagnostics.EventInstance,System.Byte[],System.Object[])">
+      <summary>Writes an event log entry with the given event data, message replacement strings, and associated binary data, and using the specified registered event source.</summary>
+      <param name="source">The name of the event source registered for the application on the specified computer.</param>
+      <param name="instance">An <see cref="T:System.Diagnostics.EventInstance" /> instance that represents a localized event log entry.</param>
+      <param name="data">An array of bytes that holds the binary data associated with the entry.</param>
+      <param name="values">An array of strings to merge into the message text of the event log entry.</param>
+      <exception cref="T:System.ArgumentException">The <paramref name="source" /> value is an empty string ("").
+
+-or-
+
+ The <paramref name="source" /> value is <see langword="null" />.
+
+-or-
+
+ <paramref name="instance.InstanceId" /> is less than zero or greater than <see cref="F:System.UInt16.MaxValue">UInt16.MaxValue</see>.
+
+-or-
+
+ <paramref name="values" /> has more than 256 elements.
+
+-or-
+
+ One of the <paramref name="values" /> elements is longer than 32766 bytes.
+
+-or-
+
+ The source name results in a registry key path longer than 254 characters.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="instance" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The registry key for the event log could not be opened.</exception>
+      <exception cref="T:System.ComponentModel.Win32Exception">The operating system reported an error when writing the event entry to the event log. A Windows error code is not available.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLog.WriteEvent(System.String,System.Diagnostics.EventInstance,System.Object[])">
+      <summary>Writes an event log entry with the given event data and message replacement strings, using the specified registered event source.</summary>
+      <param name="source">The name of the event source registered for the application on the specified computer.</param>
+      <param name="instance">An <see cref="T:System.Diagnostics.EventInstance" /> instance that represents a localized event log entry.</param>
+      <param name="values">An array of strings to merge into the message text of the event log entry.</param>
+      <exception cref="T:System.ArgumentException">The <paramref name="source" /> value is an empty string ("").
+
+-or-
+
+ The <paramref name="source" /> value is <see langword="null" />.
+
+-or-
+
+ <paramref name="instance.InstanceId" /> is less than zero or greater than <see cref="F:System.UInt16.MaxValue">UInt16.MaxValue</see>.
+
+-or-
+
+ <paramref name="values" /> has more than 256 elements.
+
+-or-
+
+ One of the <paramref name="values" /> elements is longer than 32766 bytes.
+
+-or-
+
+ The source name results in a registry key path longer than 254 characters.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="instance" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The registry key for the event log could not be opened.</exception>
+      <exception cref="T:System.ComponentModel.Win32Exception">The operating system reported an error when writing the event entry to the event log. A Windows error code is not available.</exception>
+    </member>
+    <member name="P:System.Diagnostics.EventLog.EnableRaisingEvents">
+      <summary>Gets or sets a value indicating whether the <see cref="T:System.Diagnostics.EventLog" /> receives <see cref="E:System.Diagnostics.EventLog.EntryWritten" /> event notifications.</summary>
+      <exception cref="T:System.InvalidOperationException">The event log is on a remote computer.</exception>
+      <returns>
+        <see langword="true" /> if the <see cref="T:System.Diagnostics.EventLog" /> receives notification when an entry is written to the log; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLog.Entries">
+      <summary>Gets the contents of the event log.</summary>
+      <returns>An <see cref="T:System.Diagnostics.EventLogEntryCollection" /> holding the entries in the event log. Each entry is associated with an instance of the <see cref="T:System.Diagnostics.EventLogEntry" /> class.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLog.Log">
+      <summary>Gets or sets the name of the log to read from or write to.</summary>
+      <returns>The name of the log. This can be Application, System, Security, or a custom log name. The default is an empty string ("").</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLog.LogDisplayName">
+      <summary>Gets the event log's friendly name.</summary>
+      <exception cref="T:System.InvalidOperationException">The specified <see cref="P:System.Diagnostics.EventLog.Log" /> does not exist in the registry for this computer.</exception>
+      <returns>A name that represents the event log in the system's event viewer.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLog.MachineName">
+      <summary>Gets or sets the name of the computer on which to read or write events.</summary>
+      <exception cref="T:System.ArgumentException">The computer name is invalid.</exception>
+      <returns>The name of the server on which the event log resides. The default is the local computer (".").</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLog.MaximumKilobytes">
+      <summary>Gets or sets the maximum event log size in kilobytes.</summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">The specified value is less than 64, or greater than 4194240, or not an even multiple of 64.</exception>
+      <exception cref="T:System.InvalidOperationException">The <see cref="P:System.Diagnostics.EventLog.Log" /> value is not a valid log name.
+
+-or-
+
+ The registry key for the event log could not be opened on the target computer.</exception>
+      <returns>The maximum event log size in kilobytes. The default is 512, indicating a maximum file size of 512 kilobytes.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLog.MinimumRetentionDays">
+      <summary>Gets the number of days to retain entries in the event log.</summary>
+      <returns>The number of days that entries in the event log are retained. The default value is 7.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLog.OverflowAction">
+      <summary>Gets the configured behavior for storing new entries when the event log reaches its maximum log file size.</summary>
+      <returns>The <see cref="T:System.Diagnostics.OverflowAction" /> value that specifies the configured behavior for storing new entries when the event log reaches its maximum log size. The default is <see cref="F:System.Diagnostics.OverflowAction.OverwriteOlder" />.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLog.Source">
+      <summary>Gets or sets the source name to register and use when writing to the event log.</summary>
+      <exception cref="T:System.ArgumentException">The source name results in a registry key path longer than 254 characters.</exception>
+      <returns>The name registered with the event log as a source of entries. The default is an empty string ("").</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLog.SynchronizingObject">
+      <summary>Gets or sets the object used to marshal the event handler calls issued as a result of an <see cref="T:System.Diagnostics.EventLog" /> entry written event.</summary>
+      <returns>The <see cref="T:System.ComponentModel.ISynchronizeInvoke" /> used to marshal event-handler calls issued as a result of an <see cref="E:System.Diagnostics.EventLog.EntryWritten" /> event on the event log.</returns>
+    </member>
+    <member name="T:System.Diagnostics.EventLogEntry">
+      <summary>Encapsulates a single record in the event log. This class cannot be inherited.</summary>
+    </member>
+    <member name="M:System.Diagnostics.EventLogEntry.Equals(System.Diagnostics.EventLogEntry)">
+      <summary>Performs a comparison between two event log entries.</summary>
+      <param name="otherEntry">The <see cref="T:System.Diagnostics.EventLogEntry" /> to compare.</param>
+      <returns>
+        <see langword="true" /> if the <see cref="T:System.Diagnostics.EventLogEntry" /> objects are identical; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Diagnostics.EventLogEntry.System#Runtime#Serialization#ISerializable#GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)">
+      <summary>Populates a <see cref="T:System.Runtime.Serialization.SerializationInfo" /> with the data needed to serialize the target object.</summary>
+      <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> to populate with data.</param>
+      <param name="context">The destination (see <see cref="T:System.Runtime.Serialization.StreamingContext" />) for this serialization.</param>
+    </member>
+    <member name="P:System.Diagnostics.EventLogEntry.Category">
+      <summary>Gets the text associated with the <see cref="P:System.Diagnostics.EventLogEntry.CategoryNumber" /> property for this entry.</summary>
+      <exception cref="T:System.Exception">The space could not be allocated for one of the insertion strings associated with the category.</exception>
+      <returns>The application-specific category text.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLogEntry.CategoryNumber">
+      <summary>Gets the category number of the event log entry.</summary>
+      <returns>The application-specific category number for this entry.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLogEntry.Data">
+      <summary>Gets the binary data associated with the entry.</summary>
+      <returns>An array of bytes that holds the binary data associated with the entry.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLogEntry.EntryType">
+      <summary>Gets the event type of this entry.</summary>
+      <returns>The event type that is associated with the entry in the event log.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLogEntry.EventID">
+      <summary>Gets the application-specific event identifier for the current event entry.</summary>
+      <returns>The application-specific identifier for the event message.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLogEntry.Index">
+      <summary>Gets the index of this entry in the event log.</summary>
+      <returns>The index of this entry in the event log.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLogEntry.InstanceId">
+      <summary>Gets the resource identifier that designates the message text of the event entry.</summary>
+      <returns>A resource identifier that corresponds to a string definition in the message resource file of the event source.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLogEntry.MachineName">
+      <summary>Gets the name of the computer on which this entry was generated.</summary>
+      <returns>The name of the computer that contains the event log.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLogEntry.Message">
+      <summary>Gets the localized message associated with this event entry.</summary>
+      <exception cref="T:System.Exception">The space could not be allocated for one of the insertion strings associated with the message.</exception>
+      <returns>The formatted, localized text for the message. This includes associated replacement strings.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLogEntry.ReplacementStrings">
+      <summary>Gets the replacement strings associated with the event log entry.</summary>
+      <returns>An array that holds the replacement strings stored in the event entry.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLogEntry.Source">
+      <summary>Gets the name of the application that generated this event.</summary>
+      <returns>The name registered with the event log as the source of this event.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLogEntry.TimeGenerated">
+      <summary>Gets the local time at which this event was generated.</summary>
+      <returns>The local time at which this event was generated.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLogEntry.TimeWritten">
+      <summary>Gets the local time at which this event was written to the log.</summary>
+      <returns>The local time at which this event was written to the log.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLogEntry.UserName">
+      <summary>Gets the name of the user who is responsible for this event.</summary>
+      <exception cref="T:System.SystemException">Account information could not be obtained for the user's SID.</exception>
+      <returns>The security identifier (SID) that uniquely identifies a user or group.</returns>
+    </member>
+    <member name="T:System.Diagnostics.EventLogEntryCollection">
+      <summary>Defines size and enumerators for a collection of <see cref="T:System.Diagnostics.EventLogEntry" /> instances.</summary>
+    </member>
+    <member name="M:System.Diagnostics.EventLogEntryCollection.CopyTo(System.Diagnostics.EventLogEntry[],System.Int32)">
+      <summary>Copies the elements of the <see cref="T:System.Diagnostics.EventLogEntryCollection" /> to an array of <see cref="T:System.Diagnostics.EventLogEntry" /> instances, starting at a particular array index.</summary>
+      <param name="entries">The one-dimensional array of <see cref="T:System.Diagnostics.EventLogEntry" /> instances that is the destination of the elements copied from the collection. The array must have zero-based indexing.</param>
+      <param name="index">The zero-based index in the array at which copying begins.</param>
+    </member>
+    <member name="M:System.Diagnostics.EventLogEntryCollection.GetEnumerator">
+      <summary>Supports a simple iteration over the <see cref="T:System.Diagnostics.EventLogEntryCollection" /> object.</summary>
+      <returns>An object that can be used to iterate over the collection.</returns>
+    </member>
+    <member name="M:System.Diagnostics.EventLogEntryCollection.System#Collections#ICollection#CopyTo(System.Array,System.Int32)">
+      <summary>Copies the elements of the collection to an <see cref="T:System.Array" />, starting at a particular <see cref="T:System.Array" /> index.</summary>
+      <param name="array">The one-dimensional <see cref="T:System.Array" /> that is the destination of the elements that are copied from the collection. The <see cref="T:System.Array" /> must have zero-based indexing.</param>
+      <param name="index">The zero-based index in <paramref name="array" /> at which copying begins.</param>
+    </member>
+    <member name="P:System.Diagnostics.EventLogEntryCollection.Count">
+      <summary>Gets the number of entries in the event log (that is, the number of elements in the <see cref="T:System.Diagnostics.EventLogEntry" /> collection).</summary>
+      <returns>The number of entries currently in the event log.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLogEntryCollection.Item(System.Int32)">
+      <summary>Gets an entry in the event log, based on an index that starts at 0 (zero).</summary>
+      <param name="index">The zero-based index that is associated with the event log entry.</param>
+      <returns>The event log entry at the location that is specified by the <paramref name="index" /> parameter.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLogEntryCollection.System#Collections#ICollection#IsSynchronized">
+      <summary>Gets a value that indicates whether access to the <see cref="T:System.Diagnostics.EventLogEntryCollection" /> is synchronized (thread-safe).</summary>
+      <returns>
+        <see langword="false" /> if access to the collection is not synchronized (thread-safe).</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLogEntryCollection.System#Collections#ICollection#SyncRoot">
+      <summary>Gets an object that can be used to synchronize access to the <see cref="T:System.Diagnostics.EventLogEntryCollection" /> object.</summary>
+      <returns>An object that can be used to synchronize access to the collection.</returns>
+    </member>
+    <member name="T:System.Diagnostics.EventLogEntryType">
+      <summary>Specifies the event type of an event log entry.</summary>
+    </member>
+    <member name="F:System.Diagnostics.EventLogEntryType.Error">
+      <summary>An error event. This indicates a significant problem the user should know about; usually a loss of functionality or data.</summary>
+    </member>
+    <member name="F:System.Diagnostics.EventLogEntryType.FailureAudit">
+      <summary>A failure audit event. This indicates a security event that occurs when an audited access attempt fails; for example, a failed attempt to open a file.</summary>
+    </member>
+    <member name="F:System.Diagnostics.EventLogEntryType.Information">
+      <summary>An information event. This indicates a significant, successful operation.</summary>
+    </member>
+    <member name="F:System.Diagnostics.EventLogEntryType.SuccessAudit">
+      <summary>A success audit event. This indicates a security event that occurs when an audited access attempt is successful; for example, logging on successfully.</summary>
+    </member>
+    <member name="F:System.Diagnostics.EventLogEntryType.Warning">
+      <summary>A warning event. This indicates a problem that is not immediately significant, but that may signify conditions that could cause future problems.</summary>
+    </member>
+    <member name="T:System.Diagnostics.EventLogTraceListener">
+      <summary>Provides a simple listener that directs tracing or debugging output to an <see cref="T:System.Diagnostics.EventLog" />.</summary>
+    </member>
+    <member name="M:System.Diagnostics.EventLogTraceListener.#ctor">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.EventLogTraceListener" /> class without a trace listener.</summary>
+    </member>
+    <member name="M:System.Diagnostics.EventLogTraceListener.#ctor(System.Diagnostics.EventLog)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.EventLogTraceListener" /> class using the specified event log.</summary>
+      <param name="eventLog">The event log to write to.</param>
+    </member>
+    <member name="M:System.Diagnostics.EventLogTraceListener.#ctor(System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.EventLogTraceListener" /> class using the specified source.</summary>
+      <param name="source">The name of an existing event log source.</param>
+    </member>
+    <member name="M:System.Diagnostics.EventLogTraceListener.Close">
+      <summary>Closes the event log so that it no longer receives tracing or debugging output.</summary>
+    </member>
+    <member name="M:System.Diagnostics.EventLogTraceListener.TraceData(System.Diagnostics.TraceEventCache,System.String,System.Diagnostics.TraceEventType,System.Int32,System.Object)">
+      <summary>Writes trace information, a data object, and event information to the event log.</summary>
+      <param name="eventCache">An object that contains the current process ID, thread ID, and stack trace information.</param>
+      <param name="source">A name used to identify the output; typically the name of the application that generated the trace event.</param>
+      <param name="severity">One of the enumeration values that specifies the type of event that has caused the trace.</param>
+      <param name="id">A numeric identifier for the event. The combination of <paramref name="source" /> and <paramref name="id" /> uniquely identifies an event.</param>
+      <param name="data">A data object to write to the output file or stream.</param>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="source" /> is not specified.  
+  
+ -or-  
+  
+ The log entry string exceeds 32,766 characters.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLogTraceListener.TraceData(System.Diagnostics.TraceEventCache,System.String,System.Diagnostics.TraceEventType,System.Int32,System.Object[])">
+      <summary>Writes trace information, an array of data objects, and event information to the event log.</summary>
+      <param name="eventCache">An object that contains the current process ID, thread ID, and stack trace information.</param>
+      <param name="source">A name used to identify the output; typically the name of the application that generated the trace event.</param>
+      <param name="severity">One of the enumeration values that specifies the type of event that has caused the trace.</param>
+      <param name="id">A numeric identifier for the event. The combination of <paramref name="source" /> and <paramref name="id" /> uniquely identifies an event.</param>
+      <param name="data">An array of data objects.</param>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="source" /> is not specified.  
+  
+ -or-  
+  
+ The log entry string exceeds 32,766 characters.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLogTraceListener.TraceEvent(System.Diagnostics.TraceEventCache,System.String,System.Diagnostics.TraceEventType,System.Int32,System.String,System.Object[])">
+      <summary>Writes trace information, a formatted array of objects, and event information to the event log.</summary>
+      <param name="eventCache">An object that contains the current process ID, thread ID, and stack trace information.</param>
+      <param name="source">A name used to identify the output; typically the name of the application that generated the trace event.</param>
+      <param name="severity">One of the enumeration values that specifies the type of event that has caused the trace.</param>
+      <param name="id">A numeric identifier for the event. The combination of <paramref name="source" /> and <paramref name="id" /> uniquely identifies an event.</param>
+      <param name="format">A format string that contains zero or more format items that correspond to objects in the <paramref name="args" /> array.</param>
+      <param name="args">An <see langword="object" /> array containing zero or more objects to format.</param>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="source" /> is not specified.  
+  
+ -or-  
+  
+ The log entry string exceeds 32,766 characters.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLogTraceListener.TraceEvent(System.Diagnostics.TraceEventCache,System.String,System.Diagnostics.TraceEventType,System.Int32,System.String)">
+      <summary>Writes trace information, a message, and event information to the event log.</summary>
+      <param name="eventCache">An object that contains the current process ID, thread ID, and stack trace information.</param>
+      <param name="source">A name used to identify the output; typically the name of the application that generated the trace event.</param>
+      <param name="severity">One of the enumeration values that specifies the type of event that has caused the trace.</param>
+      <param name="id">A numeric identifier for the event. The combination of <paramref name="source" /> and <paramref name="id" /> uniquely identifies an event.</param>
+      <param name="message">The trace message.</param>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="source" /> is not specified.  
+  
+ -or-  
+  
+ The log entry string exceeds 32,766 characters.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLogTraceListener.Write(System.String)">
+      <summary>Writes a message to the event log for this instance.</summary>
+      <param name="message">The message to write.</param>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="message" /> exceeds 32,766 characters.</exception>
+    </member>
+    <member name="M:System.Diagnostics.EventLogTraceListener.WriteLine(System.String)">
+      <summary>Writes a message to the event log for this instance.</summary>
+      <param name="message">The message to write.</param>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="message" /> exceeds 32,766 characters.</exception>
+    </member>
+    <member name="P:System.Diagnostics.EventLogTraceListener.EventLog">
+      <summary>Gets or sets the event log to write to.</summary>
+      <returns>The event log to write to.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventLogTraceListener.Name">
+      <summary>Gets or sets the name of this <see cref="T:System.Diagnostics.EventLogTraceListener" />.</summary>
+      <returns>The name of this trace listener.</returns>
+    </member>
+    <member name="T:System.Diagnostics.EventSourceCreationData">
+      <summary>Represents the configuration settings used to create an event log source on the local computer or a remote computer.</summary>
+    </member>
+    <member name="M:System.Diagnostics.EventSourceCreationData.#ctor(System.String,System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Diagnostics.EventSourceCreationData" /> class with a specified event source and event log name.</summary>
+      <param name="source">The name to register with the event log as a source of entries.</param>
+      <param name="logName">The name of the log to which entries from the source are written.</param>
+    </member>
+    <member name="P:System.Diagnostics.EventSourceCreationData.CategoryCount">
+      <summary>Gets or sets the number of categories in the category resource file.</summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">The property is set to a negative value or to a value larger than <see cref="F:System.UInt16.MaxValue">UInt16.MaxValue</see>.</exception>
+      <returns>The number of categories in the category resource file. The default value is zero.</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventSourceCreationData.CategoryResourceFile">
+      <summary>Gets or sets the path of the resource file that contains category strings for the source.</summary>
+      <returns>The path of the category resource file. The default is an empty string ("").</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventSourceCreationData.LogName">
+      <summary>Gets or sets the name of the event log to which the source writes entries.</summary>
+      <returns>The name of the event log. This can be Application, System, or a custom log name. The default value is "Application."</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventSourceCreationData.MachineName">
+      <summary>Gets or sets the name of the computer on which to register the event source.</summary>
+      <exception cref="T:System.ArgumentException">The computer name is invalid.</exception>
+      <returns>The name of the system on which to register the event source. The default is the local computer (".").</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventSourceCreationData.MessageResourceFile">
+      <summary>Gets or sets the path of the message resource file that contains message formatting strings for the source.</summary>
+      <returns>The path of the message resource file. The default is an empty string ("").</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventSourceCreationData.ParameterResourceFile">
+      <summary>Gets or sets the path of the resource file that contains message parameter strings for the source.</summary>
+      <returns>The path of the parameter resource file. The default is an empty string ("").</returns>
+    </member>
+    <member name="P:System.Diagnostics.EventSourceCreationData.Source">
+      <summary>Gets or sets the name to register with the event log as an event source.</summary>
+      <returns>The name to register with the event log as a source of entries. The default is an empty string ("").</returns>
+    </member>
+    <member name="T:System.Diagnostics.OverflowAction">
+      <summary>Specifies how to handle entries in an event log that has reached its maximum file size.</summary>
+    </member>
+    <member name="F:System.Diagnostics.OverflowAction.DoNotOverwrite">
+      <summary>Indicates that existing entries are retained when the event log is full and new entries are discarded.</summary>
+    </member>
+    <member name="F:System.Diagnostics.OverflowAction.OverwriteAsNeeded">
+      <summary>Indicates that each new entry overwrites the oldest entry when the event log is full.</summary>
+    </member>
+    <member name="F:System.Diagnostics.OverflowAction.OverwriteOlder">
+      <summary>Indicates that new events overwrite events older than specified by the <see cref="P:System.Diagnostics.EventLog.MinimumRetentionDays" /> property value when the event log is full. New events are discarded if the event log is full and there are no events older than specified by the <see cref="P:System.Diagnostics.EventLog.MinimumRetentionDays" /> property value.</summary>
+    </member>
+  </members>
+</doc>

--- a/Tests/Plugins/system.diagnostics.eventlog.9.0.5/System.Diagnostics.EventLog.xml.meta
+++ b/Tests/Plugins/system.diagnostics.eventlog.9.0.5/System.Diagnostics.EventLog.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 13090bcb392aaa74f96d7e2d74866aeb
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Plugins/system.reflection.emit.4.7.0.meta
+++ b/Tests/Plugins/system.reflection.emit.4.7.0.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e449602b36a0b014eb42616fda980ed5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Plugins/system.reflection.emit.4.7.0/System.Reflection.Emit.dll
+++ b/Tests/Plugins/system.reflection.emit.4.7.0/System.Reflection.Emit.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8960fac08425655e753f1fc1eafe9bb81e3dc006bc560c748ec4e6ee0bc0b9eb
+size 38984

--- a/Tests/Plugins/system.reflection.emit.4.7.0/System.Reflection.Emit.dll.meta
+++ b/Tests/Plugins/system.reflection.emit.4.7.0/System.Reflection.Emit.dll.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 04232799f31d2884fb674cd4f45b7da0

--- a/Tests/Plugins/system.reflection.emit.4.7.0/System.Reflection.Emit.xml
+++ b/Tests/Plugins/system.reflection.emit.4.7.0/System.Reflection.Emit.xml
@@ -1,0 +1,2902 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<doc>
+  <assembly>
+    <name>System.Reflection.Emit</name>
+  </assembly>
+  <members>
+    <member name="T:System.Reflection.Emit.AssemblyBuilder">
+      <summary>Defines and represents a dynamic assembly.</summary>
+    </member>
+    <member name="P:System.Reflection.Emit.AssemblyBuilder.CodeBase">
+      <summary>Gets the location of the assembly, as specified originally (such as in an <see cref="T:System.Reflection.AssemblyName" /> object).</summary>
+      <returns>The location of the assembly, as specified originally.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.DefineDynamicAssembly(System.Reflection.AssemblyName,System.Reflection.Emit.AssemblyBuilderAccess)">
+      <summary>Defines a dynamic assembly that has the specified name and access rights.</summary>
+      <param name="name">The name of the assembly.</param>
+      <param name="access">The access rights of the assembly.</param>
+      <returns>An object that represents the new assembly.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.DefineDynamicAssembly(System.Reflection.AssemblyName,System.Reflection.Emit.AssemblyBuilderAccess,System.Collections.Generic.IEnumerable{System.Reflection.Emit.CustomAttributeBuilder})">
+      <summary>Defines a new assembly that has the specified name, access rights, and attributes.</summary>
+      <param name="name">The name of the assembly.</param>
+      <param name="access">The access rights of the assembly.</param>
+      <param name="assemblyAttributes">A collection that contains the attributes of the assembly.</param>
+      <returns>An object that represents the new assembly.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.DefineDynamicModule(System.String)">
+      <summary>Defines a named transient dynamic module in this assembly.</summary>
+      <param name="name">The name of the dynamic module.</param>
+      <returns>A <see cref="T:System.Reflection.Emit.ModuleBuilder" /> representing the defined dynamic module.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="name" /> begins with white space.
+-or-
+The length of <paramref name="name" /> is zero.
+-or-
+The length of <paramref name="name" /> is greater than the system-defined maximum length.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
+      <exception cref="T:System.ExecutionEngineException">The assembly for default symbol writer cannot be loaded.
+-or-
+The type that implements the default symbol writer interface cannot be found.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.AssemblyBuilder.EntryPoint">
+      <summary>Returns the entry point of this assembly.</summary>
+      <returns>The entry point of this assembly.</returns>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.Equals(System.Object)">
+      <summary>Returns a value that indicates whether this instance is equal to the specified object.</summary>
+      <param name="obj">An object to compare with this instance, or <see langword="null" />.</param>
+      <returns>
+        <see langword="true" /> if <paramref name="obj" /> equals the type and value of this instance; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.AssemblyBuilder.FullName">
+      <summary>Gets the display name of the current dynamic assembly.</summary>
+      <returns>The display name of the dynamic assembly.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.GetCustomAttributes(System.Boolean)">
+      <summary>Returns all the custom attributes that have been applied to the current <see cref="T:System.Reflection.Emit.AssemblyBuilder" />.</summary>
+      <param name="inherit">This argument is ignored for objects of this type.</param>
+      <returns>An array that contains the custom attributes; the array is empty if there are no attributes.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.GetCustomAttributes(System.Type,System.Boolean)">
+      <summary>Returns all the custom attributes that have been applied to the current <see cref="T:System.Reflection.Emit.AssemblyBuilder" />, and that derive from a specified attribute type.</summary>
+      <param name="attributeType">The base type from which attributes derive.</param>
+      <param name="inherit">This argument is ignored for objects of this type.</param>
+      <returns>An array that contains the custom attributes that are derived at any level from <paramref name="attributeType" />; the array is empty if there are no such attributes.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="attributeType" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="attributeType" /> is not a <see cref="T:System.Type" /> object supplied by the runtime. For example, <paramref name="attributeType" /> is a <see cref="T:System.Reflection.Emit.TypeBuilder" /> object.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.GetCustomAttributesData">
+      <summary>Returns <see cref="T:System.Reflection.CustomAttributeData" /> objects that contain information about the attributes that have been applied to the current <see cref="T:System.Reflection.Emit.AssemblyBuilder" />.</summary>
+      <returns>A generic list of <see cref="T:System.Reflection.CustomAttributeData" /> objects representing data about the attributes that have been applied to the current module.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.GetDynamicModule(System.String)">
+      <summary>Returns the dynamic module with the specified name.</summary>
+      <param name="name">The name of the requested dynamic module.</param>
+      <returns>A ModuleBuilder object representing the requested dynamic module.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">The length of <paramref name="name" /> is zero.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.GetExportedTypes">
+      <summary>Gets the exported types defined in this assembly.</summary>
+      <returns>An array of <see cref="T:System.Type" /> containing the exported types defined in this assembly.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not implemented.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.GetFile(System.String)">
+      <summary>Gets a <see cref="T:System.IO.FileStream" /> for the specified file in the file table of the manifest of this assembly.</summary>
+      <param name="name">The name of the specified file.</param>
+      <returns>A <see cref="T:System.IO.FileStream" /> for the specified file, or <see langword="null" />, if the file is not found.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.GetFiles(System.Boolean)">
+      <summary>Gets the files in the file table of an assembly manifest, specifying whether to include resource modules.</summary>
+      <param name="getResourceModules">
+        <see langword="true" /> to include resource modules; otherwise, <see langword="false" />.</param>
+      <returns>An array of <see cref="T:System.IO.FileStream" /> objects.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.GetHashCode">
+      <summary>Returns the hash code for this instance.</summary>
+      <returns>A 32-bit signed integer hash code.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.GetLoadedModules(System.Boolean)">
+      <summary>Returns all the loaded modules that are part of this assembly, and optionally includes resource modules.</summary>
+      <param name="getResourceModules">
+        <see langword="true" /> to include resource modules; otherwise, <see langword="false" />.</param>
+      <returns>The loaded modules that are part of this assembly.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.GetManifestResourceInfo(System.String)">
+      <summary>Returns information about how the given resource has been persisted.</summary>
+      <param name="resourceName">The name of the resource.</param>
+      <returns>
+        <see cref="T:System.Reflection.ManifestResourceInfo" /> populated with information about the resource's topology, or <see langword="null" /> if the resource is not found.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.GetManifestResourceNames">
+      <summary>Loads the specified manifest resource from this assembly.</summary>
+      <returns>An array of type <see langword="String" /> containing the names of all the resources.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not supported on a dynamic assembly. To get the manifest resource names, use <see cref="M:System.Reflection.Assembly.GetManifestResourceNames" />.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.GetManifestResourceStream(System.String)">
+      <summary>Loads the specified manifest resource from this assembly.</summary>
+      <param name="name">The name of the manifest resource being requested.</param>
+      <returns>A <see cref="T:System.IO.Stream" /> representing this manifest resource.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.GetManifestResourceStream(System.Type,System.String)">
+      <summary>Loads the specified manifest resource, scoped by the namespace of the specified type, from this assembly.</summary>
+      <param name="type">The type whose namespace is used to scope the manifest resource name.</param>
+      <param name="name">The name of the manifest resource being requested.</param>
+      <returns>A <see cref="T:System.IO.Stream" /> representing this manifest resource.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.GetModule(System.String)">
+      <summary>Gets the specified module in this assembly.</summary>
+      <param name="name">The name of the requested module.</param>
+      <returns>The module being requested, or <see langword="null" /> if the module is not found.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.GetModules(System.Boolean)">
+      <summary>Gets all the modules that are part of this assembly, and optionally includes resource modules.</summary>
+      <param name="getResourceModules">
+        <see langword="true" /> to include resource modules; otherwise, <see langword="false" />.</param>
+      <returns>The modules that are part of this assembly.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.GetName(System.Boolean)">
+      <summary>Gets the <see cref="T:System.Reflection.AssemblyName" /> that was specified when the current dynamic assembly was created, and sets the code base as specified.</summary>
+      <param name="copiedName">
+        <see langword="true" /> to set the code base to the location of the assembly after it is shadow-copied; <see langword="false" /> to set the code base to the original location.</param>
+      <returns>The name of the dynamic assembly.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.GetReferencedAssemblies">
+      <summary>Gets an incomplete list of <see cref="T:System.Reflection.AssemblyName" /> objects for the assemblies that are referenced by this <see cref="T:System.Reflection.Emit.AssemblyBuilder" />.</summary>
+      <returns>An array of assembly names for the referenced assemblies. This array is not a complete list.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.GetSatelliteAssembly(System.Globalization.CultureInfo)">
+      <summary>Gets the satellite assembly for the specified culture.</summary>
+      <param name="culture">The specified culture.</param>
+      <returns>The specified satellite assembly.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="culture" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.IO.FileNotFoundException">The assembly cannot be found.</exception>
+      <exception cref="T:System.IO.FileLoadException">The satellite assembly with a matching file name was found, but the <see langword="CultureInfo" /> did not match the one specified.</exception>
+      <exception cref="T:System.BadImageFormatException">The satellite assembly is not a valid assembly.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.GetSatelliteAssembly(System.Globalization.CultureInfo,System.Version)">
+      <summary>Gets the specified version of the satellite assembly for the specified culture.</summary>
+      <param name="culture">The specified culture.</param>
+      <param name="version">The version of the satellite assembly.</param>
+      <returns>The specified satellite assembly.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="culture" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.IO.FileLoadException">The satellite assembly with a matching file name was found, but the <see langword="CultureInfo" /> or the version did not match the one specified.</exception>
+      <exception cref="T:System.IO.FileNotFoundException">The assembly cannot be found.</exception>
+      <exception cref="T:System.BadImageFormatException">The satellite assembly is not a valid assembly.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.GetType(System.String,System.Boolean,System.Boolean)">
+      <summary>Gets the specified type from the types that have been defined and created in the current <see cref="T:System.Reflection.Emit.AssemblyBuilder" />.</summary>
+      <param name="name">The name of the type to search for.</param>
+      <param name="throwOnError">
+        <see langword="true" /> to throw an exception if the type is not found; otherwise, <see langword="false" />.</param>
+      <param name="ignoreCase">
+        <see langword="true" /> to ignore the case of the type name when searching; otherwise, <see langword="false" />.</param>
+      <returns>The specified type, or <see langword="null" /> if the type is not found or has not been created yet.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.AssemblyBuilder.GlobalAssemblyCache">
+      <summary>Gets a value that indicates whether the assembly was loaded from the global assembly cache.</summary>
+      <returns>Always <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.AssemblyBuilder.HostContext">
+      <summary>Gets the host context where the dynamic assembly is being created.</summary>
+      <returns>A value that indicates the host context where the dynamic assembly is being created.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.AssemblyBuilder.ImageRuntimeVersion">
+      <summary>Gets the version of the common language runtime that will be saved in the file containing the manifest.</summary>
+      <returns>A string representing the common language runtime version.</returns>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.IsDefined(System.Type,System.Boolean)">
+      <summary>Returns a value that indicates whether one or more instances of the specified attribute type is applied to this member.</summary>
+      <param name="attributeType">The type of attribute to test for.</param>
+      <param name="inherit">This argument is ignored for objects of this type.</param>
+      <returns>
+        <see langword="true" /> if one or more instances of <paramref name="attributeType" /> is applied to this dynamic assembly; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.AssemblyBuilder.IsDynamic">
+      <summary>Gets a value that indicates that the current assembly is a dynamic assembly.</summary>
+      <returns>Always <see langword="true" />.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.AssemblyBuilder.Location">
+      <summary>Gets the location, in codebase format, of the loaded file that contains the manifest if it is not shadow-copied.</summary>
+      <returns>The location of the loaded file that contains the manifest. If the loaded file has been shadow-copied, the <see langword="Location" /> is that of the file before being shadow-copied.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.AssemblyBuilder.ManifestModule">
+      <summary>Gets the module in the current <see cref="T:System.Reflection.Emit.AssemblyBuilder" /> that contains the assembly manifest.</summary>
+      <returns>The manifest module.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.AssemblyBuilder.ReflectionOnly">
+      <summary>Gets a value indicating whether the dynamic assembly is in the reflection-only context.</summary>
+      <returns>
+        <see langword="true" /> if the dynamic assembly is in the reflection-only context; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.SetCustomAttribute(System.Reflection.ConstructorInfo,System.Byte[])">
+      <summary>Set a custom attribute on this assembly using a specified custom attribute blob.</summary>
+      <param name="con">The constructor for the custom attribute.</param>
+      <param name="binaryAttribute">A byte blob representing the attributes.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="con" /> or <paramref name="binaryAttribute" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="con" /> is not a <see langword="RuntimeConstructorInfo" /> object.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.AssemblyBuilder.SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder)">
+      <summary>Set a custom attribute on this assembly using a custom attribute builder.</summary>
+      <param name="customBuilder">An instance of a helper class to define the custom attribute.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="con" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
+    </member>
+    <member name="T:System.Reflection.Emit.AssemblyBuilderAccess">
+      <summary>Defines the access modes for a dynamic assembly.</summary>
+    </member>
+    <member name="F:System.Reflection.Emit.AssemblyBuilderAccess.Run">
+      <summary>The dynamic assembly can be executed, but not saved.</summary>
+    </member>
+    <member name="F:System.Reflection.Emit.AssemblyBuilderAccess.RunAndCollect">
+      <summary>The dynamic assembly will be automatically unloaded and its memory reclaimed, when it's no longer accessible.</summary>
+    </member>
+    <member name="T:System.Reflection.Emit.ConstructorBuilder">
+      <summary>Defines and represents a constructor of a dynamic class.</summary>
+    </member>
+    <member name="P:System.Reflection.Emit.ConstructorBuilder.Attributes">
+      <summary>Gets the attributes for this constructor.</summary>
+      <returns>The attributes for this constructor.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.ConstructorBuilder.CallingConvention">
+      <summary>Gets a <see cref="T:System.Reflection.CallingConventions" /> value that depends on whether the declaring type is generic.</summary>
+      <returns>
+        <see cref="F:System.Reflection.CallingConventions.HasThis" /> if the declaring type is generic; otherwise, <see cref="F:System.Reflection.CallingConventions.Standard" />.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.ConstructorBuilder.DeclaringType">
+      <summary>Gets a reference to the <see cref="T:System.Type" /> object for the type that declares this member.</summary>
+      <returns>The type that declares this member.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.ConstructorBuilder.DefineParameter(System.Int32,System.Reflection.ParameterAttributes,System.String)">
+      <summary>Defines a parameter of this constructor.</summary>
+      <param name="iSequence">The position of the parameter in the parameter list. Parameters are indexed beginning with the number 1 for the first parameter.</param>
+      <param name="attributes">The attributes of the parameter.</param>
+      <param name="strParamName">The name of the parameter. The name can be the null string.</param>
+      <returns>An object that represents the new parameter of this constructor.</returns>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        <paramref name="iSequence" /> is less than 0 (zero), or it is greater than the number of parameters of the constructor.</exception>
+      <exception cref="T:System.InvalidOperationException">The containing type has been created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ConstructorBuilder.GetCustomAttributes(System.Boolean)">
+      <summary>Returns all the custom attributes defined for this constructor.</summary>
+      <param name="inherit">Controls inheritance of custom attributes from base classes. This parameter is ignored.</param>
+      <returns>An array of objects representing all the custom attributes of the constructor represented by this <see cref="T:System.Reflection.Emit.ConstructorBuilder" /> instance.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ConstructorBuilder.GetCustomAttributes(System.Type,System.Boolean)">
+      <summary>Returns the custom attributes identified by the given type.</summary>
+      <param name="attributeType">The custom attribute type.</param>
+      <param name="inherit">Controls inheritance of custom attributes from base classes. This parameter is ignored.</param>
+      <returns>An object array that represents the attributes of this constructor.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ConstructorBuilder.GetILGenerator">
+      <summary>Gets an <see cref="T:System.Reflection.Emit.ILGenerator" /> for this constructor.</summary>
+      <returns>An <see cref="T:System.Reflection.Emit.ILGenerator" /> object for this constructor.</returns>
+      <exception cref="T:System.InvalidOperationException">The constructor is a parameterless constructor.
+-or-
+The constructor has <see cref="T:System.Reflection.MethodAttributes" /> or <see cref="T:System.Reflection.MethodImplAttributes" /> flags indicating that it should not have a method body.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ConstructorBuilder.GetILGenerator(System.Int32)">
+      <summary>Gets an <see cref="T:System.Reflection.Emit.ILGenerator" /> object, with the specified MSIL stream size, that can be used to build a method body for this constructor.</summary>
+      <param name="streamSize">The size of the MSIL stream, in bytes.</param>
+      <returns>An <see cref="T:System.Reflection.Emit.ILGenerator" /> for this constructor.</returns>
+      <exception cref="T:System.InvalidOperationException">The constructor is a parameterless constructor.
+-or-
+The constructor has <see cref="T:System.Reflection.MethodAttributes" /> or <see cref="T:System.Reflection.MethodImplAttributes" /> flags indicating that it should not have a method body.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ConstructorBuilder.GetMethodImplementationFlags">
+      <summary>Returns the method implementation flags for this constructor.</summary>
+      <returns>The method implementation flags for this constructor.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.ConstructorBuilder.GetParameters">
+      <summary>Returns the parameters of this constructor.</summary>
+      <returns>An array that represents the parameters of this constructor.</returns>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> has not been called on this constructor's type, in the .NET Framework versions 1.0 and 1.1.</exception>
+      <exception cref="T:System.NotSupportedException">
+        <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> has not been called on this constructor's type, in the .NET Framework version 2.0.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.ConstructorBuilder.InitLocals">
+      <summary>Gets or sets whether the local variables in this constructor should be zero-initialized.</summary>
+      <returns>Read/write. Gets or sets whether the local variables in this constructor should be zero-initialized.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.ConstructorBuilder.Invoke(System.Object,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo)">
+      <summary>Dynamically invokes the constructor reflected by this instance with the specified arguments, under the constraints of the specified <see langword="Binder" />.</summary>
+      <param name="obj">The object that needs to be reinitialized.</param>
+      <param name="invokeAttr">One of the <see langword="BindingFlags" /> values that specifies the type of binding that is desired.</param>
+      <param name="binder">A <see langword="Binder" /> that defines a set of properties and enables the binding, coercion of argument types, and invocation of members using reflection. If <paramref name="binder" /> is <see langword="null" />, then Binder.DefaultBinding is used.</param>
+      <param name="parameters">An argument list. This is an array of arguments with the same number, order, and type as the parameters of the constructor to be invoked. If there are no parameters, this should be a null reference (<see langword="Nothing" /> in Visual Basic).</param>
+      <param name="culture">A <see cref="T:System.Globalization.CultureInfo" /> used to govern the coercion of types. If this is null, the <see cref="T:System.Globalization.CultureInfo" /> for the current thread is used.</param>
+      <returns>An instance of the class associated with the constructor.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported. You can retrieve the constructor using <see cref="M:System.Type.GetConstructor(System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])" /> and call <see cref="M:System.Reflection.ConstructorInfo.Invoke(System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo)" /> on the returned <see cref="T:System.Reflection.ConstructorInfo" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ConstructorBuilder.Invoke(System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo)">
+      <summary>Dynamically invokes the constructor represented by this instance on the given object, passing along the specified parameters, and under the constraints of the given binder.</summary>
+      <param name="invokeAttr">This must be a bit flag from <see cref="T:System.Reflection.BindingFlags" />, such as InvokeMethod, NonPublic, and so on.</param>
+      <param name="binder">An object that enables the binding, coercion of argument types, invocation of members, and retrieval of <see langword="MemberInfo" /> objects using reflection. If binder is <see langword="null" />, the default binder is used. See <see cref="T:System.Reflection.Binder" />.</param>
+      <param name="parameters">An argument list. This is an array of arguments with the same number, order, and type as the parameters of the constructor to be invoked. If there are no parameters this should be <see langword="null" />.</param>
+      <param name="culture">An instance of <see cref="T:System.Globalization.CultureInfo" /> used to govern the coercion of types. If this is null, the <see cref="T:System.Globalization.CultureInfo" /> for the current thread is used. (For example, this is necessary to convert a <see cref="T:System.String" /> that represents 1000 to a <see cref="T:System.Double" /> value, since 1000 is represented differently by different cultures.)</param>
+      <returns>The value returned by the invoked constructor.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported. You can retrieve the constructor using <see cref="M:System.Type.GetConstructor(System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])" /> and call <see cref="M:System.Reflection.ConstructorInfo.Invoke(System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo)" /> on the returned <see cref="T:System.Reflection.ConstructorInfo" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ConstructorBuilder.IsDefined(System.Type,System.Boolean)">
+      <summary>Checks if the specified custom attribute type is defined.</summary>
+      <param name="attributeType">A custom attribute type.</param>
+      <param name="inherit">Controls inheritance of custom attributes from base classes. This parameter is ignored.</param>
+      <returns>
+        <see langword="true" /> if the specified custom attribute type is defined; otherwise, <see langword="false" />.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported. You can retrieve the constructor using <see cref="M:System.Type.GetConstructor(System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])" /> and call <see cref="M:System.Reflection.MemberInfo.IsDefined(System.Type,System.Boolean)" /> on the returned <see cref="T:System.Reflection.ConstructorInfo" />.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.ConstructorBuilder.MethodHandle">
+      <summary>Gets the internal handle for the method. Use this handle to access the underlying metadata handle.</summary>
+      <returns>The internal handle for the method. Use this handle to access the underlying metadata handle.</returns>
+      <exception cref="T:System.NotSupportedException">This property is not supported on this class.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.ConstructorBuilder.Module">
+      <summary>Gets the dynamic module in which this constructor is defined.</summary>
+      <returns>A <see cref="T:System.Reflection.Module" /> object that represents the dynamic module in which this constructor is defined.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.ConstructorBuilder.Name">
+      <summary>Retrieves the name of this constructor.</summary>
+      <returns>The name of this constructor.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.ConstructorBuilder.ReflectedType">
+      <summary>Holds a reference to the <see cref="T:System.Type" /> object from which this object was obtained.</summary>
+      <returns>The <see langword="Type" /> object from which this object was obtained.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.ConstructorBuilder.SetCustomAttribute(System.Reflection.ConstructorInfo,System.Byte[])">
+      <summary>Set a custom attribute using a specified custom attribute blob.</summary>
+      <param name="con">The constructor for the custom attribute.</param>
+      <param name="binaryAttribute">A byte blob representing the attributes.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="con" /> or <paramref name="binaryAttribute" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ConstructorBuilder.SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder)">
+      <summary>Set a custom attribute using a custom attribute builder.</summary>
+      <param name="customBuilder">An instance of a helper class to define the custom attribute.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="customBuilder" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ConstructorBuilder.SetImplementationFlags(System.Reflection.MethodImplAttributes)">
+      <summary>Sets the method implementation flags for this constructor.</summary>
+      <param name="attributes">The method implementation flags.</param>
+      <exception cref="T:System.InvalidOperationException">The containing type has been created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ConstructorBuilder.ToString">
+      <summary>Returns this <see cref="T:System.Reflection.Emit.ConstructorBuilder" /> instance as a <see cref="T:System.String" />.</summary>
+      <returns>A string containing the name, attributes, and exceptions of this constructor, followed by the current Microsoft intermediate language (MSIL) stream.</returns>
+    </member>
+    <member name="T:System.Reflection.Emit.EnumBuilder">
+      <summary>Describes and represents an enumeration type.</summary>
+    </member>
+    <member name="P:System.Reflection.Emit.EnumBuilder.Assembly">
+      <summary>Retrieves the dynamic assembly that contains this enum definition.</summary>
+      <returns>Read-only. The dynamic assembly that contains this enum definition.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.EnumBuilder.AssemblyQualifiedName">
+      <summary>Returns the full path of this enum qualified by the display name of the parent assembly.</summary>
+      <returns>Read-only. The full path of this enum qualified by the display name of the parent assembly.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.EnumBuilder.BaseType">
+      <summary>Returns the parent <see cref="T:System.Type" /> of this type which is always <see cref="T:System.Enum" />.</summary>
+      <returns>Read-only. The parent <see cref="T:System.Type" /> of this type.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.CreateTypeInfo">
+      <summary>Gets a <see cref="T:System.Reflection.TypeInfo" /> object that represents this enumeration.</summary>
+      <returns>An object that represents this enumeration.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.EnumBuilder.DeclaringType">
+      <summary>Returns the type that declared this <see cref="T:System.Reflection.Emit.EnumBuilder" />.</summary>
+      <returns>Read-only. The type that declared this <see cref="T:System.Reflection.Emit.EnumBuilder" />.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.DefineLiteral(System.String,System.Object)">
+      <summary>Defines the named static field in an enumeration type with the specified constant value.</summary>
+      <param name="literalName">The name of the static field.</param>
+      <param name="literalValue">The constant value of the literal.</param>
+      <returns>The defined field.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.EnumBuilder.FullName">
+      <summary>Returns the full path of this enum.</summary>
+      <returns>Read-only. The full path of this enum.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.GetConstructors(System.Reflection.BindingFlags)">
+      <summary>Returns an array of <see cref="T:System.Reflection.ConstructorInfo" /> objects representing the public and non-public constructors defined for this class, as specified.</summary>
+      <param name="bindingAttr">This must be a bit flag from <see cref="T:System.Reflection.BindingFlags" /> : <see langword="InvokeMethod" />, <see langword="NonPublic" />, and so on.</param>
+      <returns>Returns an array of <see cref="T:System.Reflection.ConstructorInfo" /> objects representing the specified constructors defined for this class. If no constructors are defined, an empty array is returned.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported in types that are not complete.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.GetCustomAttributes(System.Boolean)">
+      <summary>Returns all the custom attributes defined for this constructor.</summary>
+      <param name="inherit">Specifies whether to search this member's inheritance chain to find the attributes.</param>
+      <returns>Returns an array of objects representing all the custom attributes of the constructor represented by this <see cref="T:System.Reflection.Emit.ConstructorBuilder" /> instance.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported in types that are not complete.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.GetCustomAttributes(System.Type,System.Boolean)">
+      <summary>Returns the custom attributes identified by the given type.</summary>
+      <param name="attributeType">The <see langword="Type" /> object to which the custom attributes are applied.</param>
+      <param name="inherit">Specifies whether to search this member's inheritance chain to find the attributes.</param>
+      <returns>Returns an array of objects representing the attributes of this constructor that are of <see cref="T:System.Type" /><paramref name="attributeType" />.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported in types that are not complete.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.GetElementType">
+      <summary>Calling this method always throws <see cref="T:System.NotSupportedException" />.</summary>
+      <returns>This method is not supported. No value is returned.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.GetEnumUnderlyingType">
+      <summary>Returns the underlying integer type of the current enumeration, which is set when the enumeration builder is defined.</summary>
+      <returns>The underlying type.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.GetEvent(System.String,System.Reflection.BindingFlags)">
+      <summary>Returns the event with the specified name.</summary>
+      <param name="name">The name of the event to get.</param>
+      <param name="bindingAttr">This invocation attribute. This must be a bit flag from <see cref="T:System.Reflection.BindingFlags" /> : <see langword="InvokeMethod" />, <see langword="NonPublic" />, and so on.</param>
+      <returns>Returns an <see cref="T:System.Reflection.EventInfo" /> object representing the event declared or inherited by this type with the specified name. If there are no matches, <see langword="null" /> is returned.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported in types that are not complete.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.GetEvents">
+      <summary>Returns the events for the public events declared or inherited by this type.</summary>
+      <returns>Returns an array of <see cref="T:System.Reflection.EventInfo" /> objects representing the public events declared or inherited by this type. An empty array is returned if there are no public events.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported in types that are not complete.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.GetEvents(System.Reflection.BindingFlags)">
+      <summary>Returns the public and non-public events that are declared by this type.</summary>
+      <param name="bindingAttr">This must be a bit flag from <see cref="T:System.Reflection.BindingFlags" />, such as <see langword="InvokeMethod" />, <see langword="NonPublic" />, and so on.</param>
+      <returns>Returns an array of <see cref="T:System.Reflection.EventInfo" /> objects representing the public and non-public events declared or inherited by this type. An empty array is returned if there are no events, as specified.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported in types that are not complete.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.GetField(System.String,System.Reflection.BindingFlags)">
+      <summary>Returns the field specified by the given name.</summary>
+      <param name="name">The name of the field to get.</param>
+      <param name="bindingAttr">This must be a bit flag from <see cref="T:System.Reflection.BindingFlags" /> : <see langword="InvokeMethod" />, <see langword="NonPublic" />, and so on.</param>
+      <returns>Returns the <see cref="T:System.Reflection.FieldInfo" /> object representing the field declared or inherited by this type with the specified name and public or non-public modifier. If there are no matches, then null is returned.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported in types that are not complete.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.GetFields(System.Reflection.BindingFlags)">
+      <summary>Returns the public and non-public fields that are declared by this type.</summary>
+      <param name="bindingAttr">This must be a bit flag from <see cref="T:System.Reflection.BindingFlags" />, such as InvokeMethod, NonPublic, and so on.</param>
+      <returns>Returns an array of <see cref="T:System.Reflection.FieldInfo" /> objects representing the public and non-public fields declared or inherited by this type. An empty array is returned if there are no fields, as specified.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported in types that are not complete.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.GetInterface(System.String,System.Boolean)">
+      <summary>Returns the interface implemented (directly or indirectly) by this type, with the specified fully-qualified name.</summary>
+      <param name="name">The name of the interface.</param>
+      <param name="ignoreCase">If <see langword="true" />, the search is case-insensitive. If <see langword="false" />, the search is case-sensitive.</param>
+      <returns>Returns a <see cref="T:System.Type" /> object representing the implemented interface. Returns null if no interface matching name is found.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported in types that are not complete.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.GetInterfaceMap(System.Type)">
+      <summary>Returns an interface mapping for the interface requested.</summary>
+      <param name="interfaceType">The type of the interface for which the interface mapping is to be retrieved.</param>
+      <returns>The requested interface mapping.</returns>
+      <exception cref="T:System.ArgumentException">The type does not implement the interface.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.GetInterfaces">
+      <summary>Returns an array of all the interfaces implemented on this a class and its base classes.</summary>
+      <returns>Returns an array of <see cref="T:System.Type" /> objects representing the implemented interfaces. If none are defined, an empty array is returned.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.GetMember(System.String,System.Reflection.MemberTypes,System.Reflection.BindingFlags)">
+      <summary>Returns all members with the specified name, type, and binding that are declared or inherited by this type.</summary>
+      <param name="name">The name of the member.</param>
+      <param name="type">The type of member that is to be returned.</param>
+      <param name="bindingAttr">This must be a bit flag from <see cref="T:System.Reflection.BindingFlags" /> : <see langword="InvokeMethod" />, <see langword="NonPublic" />, and so on.</param>
+      <returns>Returns an array of <see cref="T:System.Reflection.MemberInfo" /> objects representing the public and non-public members defined on this type if <paramref name="nonPublic" /> is used; otherwise, only the public members are returned.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported in types that are not complete.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.GetMembers(System.Reflection.BindingFlags)">
+      <summary>Returns the specified members declared or inherited by this type,.</summary>
+      <param name="bindingAttr">This must be a bit flag from <see cref="T:System.Reflection.BindingFlags" /> : <see langword="InvokeMethod" />, <see langword="NonPublic" />, and so on.</param>
+      <returns>Returns an array of <see cref="T:System.Reflection.MemberInfo" /> objects representing the public and non-public members declared or inherited by this type. An empty array is returned if there are no matching members.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported in types that are not complete.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.GetMethods(System.Reflection.BindingFlags)">
+      <summary>Returns all the public and non-public methods declared or inherited by this type, as specified.</summary>
+      <param name="bindingAttr">This must be a bit flag from <see cref="T:System.Reflection.BindingFlags" />, such as <see langword="InvokeMethod" />, <see langword="NonPublic" />, and so on.</param>
+      <returns>Returns an array of <see cref="T:System.Reflection.MethodInfo" /> objects representing the public and non-public methods defined on this type if <paramref name="nonPublic" /> is used; otherwise, only the public methods are returned.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported in types that are not complete.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.GetNestedType(System.String,System.Reflection.BindingFlags)">
+      <summary>Returns the specified nested type that is declared by this type.</summary>
+      <param name="name">The <see cref="T:System.String" /> containing the name of the nested type to get.</param>
+      <param name="bindingAttr">A bitmask comprised of one or more <see cref="T:System.Reflection.BindingFlags" /> that specify how the search is conducted.
+-or-
+Zero, to conduct a case-sensitive search for public methods.</param>
+      <returns>A <see cref="T:System.Type" /> object representing the nested type that matches the specified requirements, if found; otherwise, <see langword="null" />.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported in types that are not complete.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.GetNestedTypes(System.Reflection.BindingFlags)">
+      <summary>Returns the public and non-public nested types that are declared or inherited by this type.</summary>
+      <param name="bindingAttr">This must be a bit flag from <see cref="T:System.Reflection.BindingFlags" />, such as <see langword="InvokeMethod" />, <see langword="NonPublic" />, and so on.</param>
+      <returns>An array of <see cref="T:System.Type" /> objects representing all the types nested within the current <see cref="T:System.Type" /> that match the specified binding constraints.
+An empty array of type <see cref="T:System.Type" />, if no types are nested within the current <see cref="T:System.Type" />, or if none of the nested types match the binding constraints.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported in types that are not complete.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.GetProperties(System.Reflection.BindingFlags)">
+      <summary>Returns all the public and non-public properties declared or inherited by this type, as specified.</summary>
+      <param name="bindingAttr">This invocation attribute. This must be a bit flag from <see cref="T:System.Reflection.BindingFlags" /> : <see langword="InvokeMethod" />, <see langword="NonPublic" />, and so on.</param>
+      <returns>Returns an array of <see cref="T:System.Reflection.PropertyInfo" /> objects representing the public and non-public properties defined on this type if <paramref name="nonPublic" /> is used; otherwise, only the public properties are returned.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported in types that are not complete.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.EnumBuilder.GUID">
+      <summary>Returns the GUID of this enum.</summary>
+      <returns>Read-only. The GUID of this enum.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported in types that are not complete.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.InvokeMember(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object,System.Object[],System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[])">
+      <summary>Invokes the specified member. The method that is to be invoked must be accessible and provide the most specific match with the specified argument list, under the constraints of the specified binder and invocation attributes.</summary>
+      <param name="name">The name of the member to invoke. This can be a constructor, method, property, or field. A suitable invocation attribute must be specified. Note that it is possible to invoke the default member of a class by passing an empty string as the name of the member.</param>
+      <param name="invokeAttr">The invocation attribute. This must be a bit flag from <see langword="BindingFlags" />.</param>
+      <param name="binder">An object that enables the binding, coercion of argument types, invocation of members, and retrieval of <see langword="MemberInfo" /> objects using reflection. If binder is <see langword="null" />, the default binder is used. See <see cref="T:System.Reflection.Binder" />.</param>
+      <param name="target">The object on which to invoke the specified member. If the member is static, this parameter is ignored.</param>
+      <param name="args">An argument list. This is an array of objects that contains the number, order, and type of the parameters of the member to be invoked. If there are no parameters this should be null.</param>
+      <param name="modifiers">An array of the same length as <paramref name="args" /> with elements that represent the attributes associated with the arguments of the member to be invoked. A parameter has attributes associated with it in the metadata. They are used by various interoperability services. See the metadata specs for details such as this.</param>
+      <param name="culture">An instance of <see langword="CultureInfo" /> used to govern the coercion of types. If this is null, the <see langword="CultureInfo" /> for the current thread is used. (Note that this is necessary to, for example, convert a string that represents 1000 to a double value, since 1000 is represented differently by different cultures.)</param>
+      <param name="namedParameters">Each parameter in the <paramref name="namedParameters" /> array gets the value in the corresponding element in the <paramref name="args" /> array. If the length of <paramref name="args" /> is greater than the length of <paramref name="namedParameters" />, the remaining argument values are passed in order.</param>
+      <returns>Returns the return value of the invoked member.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported in types that are not complete.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.EnumBuilder.IsByRefLike" />
+    <member name="P:System.Reflection.Emit.EnumBuilder.IsConstructedGenericType">
+      <summary>Gets a value that indicates whether this object represents a constructed generic type.</summary>
+      <returns>
+        <see langword="true" /> if this object represents a constructed generic type; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.IsDefined(System.Type,System.Boolean)">
+      <summary>Checks if the specified custom attribute type is defined.</summary>
+      <param name="attributeType">The <see langword="Type" /> object to which the custom attributes are applied.</param>
+      <param name="inherit">Specifies whether to search this member's inheritance chain to find the attributes.</param>
+      <returns>
+        <see langword="true" /> if one or more instance of <paramref name="attributeType" /> is defined on this member; otherwise, <see langword="false" />.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported in types that are not complete.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.EnumBuilder.IsSZArray" />
+    <member name="P:System.Reflection.Emit.EnumBuilder.IsTypeDefinition" />
+    <member name="P:System.Reflection.Emit.EnumBuilder.IsVariableBoundArray" />
+    <member name="M:System.Reflection.Emit.EnumBuilder.MakeArrayType">
+      <summary>Returns a <see cref="T:System.Type" /> object representing a one-dimensional array of the current type, with a lower bound of zero.</summary>
+      <returns>A <see cref="T:System.Type" /> object representing a one-dimensional array of the current type, with a lower bound of zero.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.MakeArrayType(System.Int32)">
+      <summary>Returns a <see cref="T:System.Type" /> object representing an array of the current type, with the specified number of dimensions.</summary>
+      <param name="rank">The number of dimensions for the array. This number must be less than or equal to 32.</param>
+      <returns>An object representing an array of the current type, with the specified number of dimensions.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        <paramref name="rank" /> is less than 1.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.MakeByRefType">
+      <summary>Returns a <see cref="T:System.Type" /> object that represents the current type when passed as a ref parameter (ByRef parameter in Visual Basic).</summary>
+      <returns>A <see cref="T:System.Type" /> object that represents the current type when passed as a ref parameter (ByRef parameter in Visual Basic).</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.MakePointerType">
+      <summary>Returns a <see cref="T:System.Type" /> object that represents a pointer to the current type.</summary>
+      <returns>A <see cref="T:System.Type" /> object that represents a pointer to the current type.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.EnumBuilder.Module">
+      <summary>Retrieves the dynamic module that contains this <see cref="T:System.Reflection.Emit.EnumBuilder" /> definition.</summary>
+      <returns>Read-only. The dynamic module that contains this <see cref="T:System.Reflection.Emit.EnumBuilder" /> definition.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.EnumBuilder.Name">
+      <summary>Returns the name of this enum.</summary>
+      <returns>Read-only. The name of this enum.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.EnumBuilder.Namespace">
+      <summary>Returns the namespace of this enum.</summary>
+      <returns>Read-only. The namespace of this enum.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.EnumBuilder.ReflectedType">
+      <summary>Returns the type that was used to obtain this <see cref="T:System.Reflection.Emit.EnumBuilder" />.</summary>
+      <returns>Read-only. The type that was used to obtain this <see cref="T:System.Reflection.Emit.EnumBuilder" />.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.SetCustomAttribute(System.Reflection.ConstructorInfo,System.Byte[])">
+      <summary>Sets a custom attribute using a specified custom attribute blob.</summary>
+      <param name="con">The constructor for the custom attribute.</param>
+      <param name="binaryAttribute">A byte blob representing the attributes.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="con" /> or <paramref name="binaryAttribute" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EnumBuilder.SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder)">
+      <summary>Sets a custom attribute using a custom attribute builder.</summary>
+      <param name="customBuilder">An instance of a helper class to define the custom attribute.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="con" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.EnumBuilder.TypeHandle">
+      <summary>Retrieves the internal handle for this enum.</summary>
+      <returns>Read-only. The internal handle for this enum.</returns>
+      <exception cref="T:System.NotSupportedException">This property is not currently supported.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.EnumBuilder.UnderlyingField">
+      <summary>Returns the underlying field for this enum.</summary>
+      <returns>Read-only. The underlying field for this enum.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.EnumBuilder.UnderlyingSystemType">
+      <summary>Returns the underlying system type for this enum.</summary>
+      <returns>Read-only. Returns the underlying system type.</returns>
+    </member>
+    <member name="T:System.Reflection.Emit.EventBuilder">
+      <summary>Defines events for a class.</summary>
+    </member>
+    <member name="M:System.Reflection.Emit.EventBuilder.AddOtherMethod(System.Reflection.Emit.MethodBuilder)">
+      <summary>Adds one of the "other" methods associated with this event. "Other" methods are methods other than the "on" and "raise" methods associated with an event. This function can be called many times to add as many "other" methods.</summary>
+      <param name="mdBuilder">A <see langword="MethodBuilder" /> object that represents the other method.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="mdBuilder" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> has been called on the enclosing type.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EventBuilder.SetAddOnMethod(System.Reflection.Emit.MethodBuilder)">
+      <summary>Sets the method used to subscribe to this event.</summary>
+      <param name="mdBuilder">A <see langword="MethodBuilder" /> object that represents the method used to subscribe to this event.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="mdBuilder" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> has been called on the enclosing type.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EventBuilder.SetCustomAttribute(System.Reflection.ConstructorInfo,System.Byte[])">
+      <summary>Set a custom attribute using a specified custom attribute blob.</summary>
+      <param name="con">The constructor for the custom attribute.</param>
+      <param name="binaryAttribute">A byte blob representing the attributes.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="con" /> or <paramref name="binaryAttribute" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> has been called on the enclosing type.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EventBuilder.SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder)">
+      <summary>Sets a custom attribute using a custom attribute builder.</summary>
+      <param name="customBuilder">An instance of a helper class to describe the custom attribute.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="con" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> has been called on the enclosing type.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EventBuilder.SetRaiseMethod(System.Reflection.Emit.MethodBuilder)">
+      <summary>Sets the method used to raise this event.</summary>
+      <param name="mdBuilder">A <see langword="MethodBuilder" /> object that represents the method used to raise this event.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="mdBuilder" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> has been called on the enclosing type.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.EventBuilder.SetRemoveOnMethod(System.Reflection.Emit.MethodBuilder)">
+      <summary>Sets the method used to unsubscribe to this event.</summary>
+      <param name="mdBuilder">A <see langword="MethodBuilder" /> object that represents the method used to unsubscribe to this event.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="mdBuilder" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> has been called on the enclosing type.</exception>
+    </member>
+    <member name="T:System.Reflection.Emit.FieldBuilder">
+      <summary>Defines and represents a field. This class cannot be inherited.</summary>
+    </member>
+    <member name="P:System.Reflection.Emit.FieldBuilder.Attributes">
+      <summary>Indicates the attributes of this field. This property is read-only.</summary>
+      <returns>The attributes of this field.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.FieldBuilder.DeclaringType">
+      <summary>Indicates a reference to the <see cref="T:System.Type" /> object for the type that declares this field. This property is read-only.</summary>
+      <returns>A reference to the <see cref="T:System.Type" /> object for the type that declares this field.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.FieldBuilder.FieldHandle">
+      <summary>Indicates the internal metadata handle for this field. This property is read-only.</summary>
+      <returns>The internal metadata handle for this field.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not supported.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.FieldBuilder.FieldType">
+      <summary>Indicates the <see cref="T:System.Type" /> object that represents the type of this field. This property is read-only.</summary>
+      <returns>The <see cref="T:System.Type" /> object that represents the type of this field.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.FieldBuilder.GetCustomAttributes(System.Boolean)">
+      <summary>Returns all the custom attributes defined for this field.</summary>
+      <param name="inherit">Controls inheritance of custom attributes from base classes.</param>
+      <returns>An array of type <see cref="T:System.Object" /> representing all the custom attributes of the constructor represented by this <see cref="T:System.Reflection.Emit.FieldBuilder" /> instance.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not supported.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.FieldBuilder.GetCustomAttributes(System.Type,System.Boolean)">
+      <summary>Returns all the custom attributes defined for this field identified by the given type.</summary>
+      <param name="attributeType">The custom attribute type.</param>
+      <param name="inherit">Controls inheritance of custom attributes from base classes.</param>
+      <returns>An array of type <see cref="T:System.Object" /> representing all the custom attributes of the constructor represented by this <see cref="T:System.Reflection.Emit.FieldBuilder" /> instance.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not supported.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.FieldBuilder.GetValue(System.Object)">
+      <summary>Retrieves the value of the field supported by the given object.</summary>
+      <param name="obj">The object on which to access the field.</param>
+      <returns>An <see cref="T:System.Object" /> containing the value of the field reflected by this instance.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not supported.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.FieldBuilder.IsDefined(System.Type,System.Boolean)">
+      <summary>Indicates whether an attribute having the specified type is defined on a field.</summary>
+      <param name="attributeType">The type of the attribute.</param>
+      <param name="inherit">Controls inheritance of custom attributes from base classes.</param>
+      <returns>
+        <see langword="true" /> if one or more instance of <paramref name="attributeType" /> is defined on this field; otherwise, <see langword="false" />.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported. Retrieve the field using <see cref="M:System.Type.GetField(System.String,System.Reflection.BindingFlags)" /> and call <see cref="M:System.Reflection.MemberInfo.IsDefined(System.Type,System.Boolean)" /> on the returned <see cref="T:System.Reflection.FieldInfo" />.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.FieldBuilder.Module">
+      <summary>Gets the module in which the type that contains this field is being defined.</summary>
+      <returns>A <see cref="T:System.Reflection.Module" /> that represents the dynamic module in which this field is being defined.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.FieldBuilder.Name">
+      <summary>Indicates the name of this field. This property is read-only.</summary>
+      <returns>A <see cref="T:System.String" /> containing the name of this field.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.FieldBuilder.ReflectedType">
+      <summary>Indicates the reference to the <see cref="T:System.Type" /> object from which this object was obtained. This property is read-only.</summary>
+      <returns>A reference to the <see cref="T:System.Type" /> object from which this instance was obtained.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.FieldBuilder.SetConstant(System.Object)">
+      <summary>Sets the default value of this field.</summary>
+      <param name="defaultValue">The new default value for this field.</param>
+      <exception cref="T:System.InvalidOperationException">The containing type has been created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.</exception>
+      <exception cref="T:System.ArgumentException">The field is not one of the supported types.
+-or-
+The type of <paramref name="defaultValue" /> does not match the type of the field.
+-or-
+The field is of type <see cref="T:System.Object" /> or other reference type, <paramref name="defaultValue" /> is not <see langword="null" />, and the value cannot be assigned to the reference type.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.FieldBuilder.SetCustomAttribute(System.Reflection.ConstructorInfo,System.Byte[])">
+      <summary>Sets a custom attribute using a specified custom attribute blob.</summary>
+      <param name="con">The constructor for the custom attribute.</param>
+      <param name="binaryAttribute">A byte blob representing the attributes.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="con" /> or <paramref name="binaryAttribute" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The parent type of this field is complete.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.FieldBuilder.SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder)">
+      <summary>Sets a custom attribute using a custom attribute builder.</summary>
+      <param name="customBuilder">An instance of a helper class to define the custom attribute.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="con" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The parent type of this field is complete.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.FieldBuilder.SetOffset(System.Int32)">
+      <summary>Specifies the field layout.</summary>
+      <param name="iOffset">The offset of the field within the type containing this field.</param>
+      <exception cref="T:System.InvalidOperationException">The containing type has been created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.</exception>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="iOffset" /> is less than zero.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.FieldBuilder.SetValue(System.Object,System.Object,System.Reflection.BindingFlags,System.Reflection.Binder,System.Globalization.CultureInfo)">
+      <summary>Sets the value of the field supported by the given object.</summary>
+      <param name="obj">The object on which to access the field.</param>
+      <param name="val">The value to assign to the field.</param>
+      <param name="invokeAttr">A member of <see langword="IBinder" /> that specifies the type of binding that is desired (for example, IBinder.CreateInstance, IBinder.ExactBinding).</param>
+      <param name="binder">A set of properties and enabling for binding, coercion of argument types, and invocation of members using reflection. If binder is null, then IBinder.DefaultBinding is used.</param>
+      <param name="culture">The software preferences of a particular culture.</param>
+      <exception cref="T:System.NotSupportedException">This method is not supported.</exception>
+    </member>
+    <member name="T:System.Reflection.Emit.GenericTypeParameterBuilder">
+      <summary>Defines and creates generic type parameters for dynamically defined generic types and methods. This class cannot be inherited.</summary>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.Assembly">
+      <summary>Gets an <see cref="T:System.Reflection.Assembly" /> object representing the dynamic assembly that contains the generic type definition the current type parameter belongs to.</summary>
+      <returns>An <see cref="T:System.Reflection.Assembly" /> object representing the dynamic assembly that contains the generic type definition the current type parameter belongs to.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.AssemblyQualifiedName">
+      <summary>Gets <see langword="null" /> in all cases.</summary>
+      <returns>A null reference (<see langword="Nothing" /> in Visual Basic) in all cases.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.BaseType">
+      <summary>Gets the base type constraint of the current generic type parameter.</summary>
+      <returns>A <see cref="T:System.Type" /> object that represents the base type constraint of the generic type parameter, or <see langword="null" /> if the type parameter has no base type constraint.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.ContainsGenericParameters">
+      <summary>Gets <see langword="true" /> in all cases.</summary>
+      <returns>
+        <see langword="true" /> in all cases.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.DeclaringMethod">
+      <summary>Gets a <see cref="T:System.Reflection.MethodInfo" /> that represents the declaring method, if the current <see cref="T:System.Reflection.Emit.GenericTypeParameterBuilder" /> represents a type parameter of a generic method.</summary>
+      <returns>A <see cref="T:System.Reflection.MethodInfo" /> that represents the declaring method, if the current <see cref="T:System.Reflection.Emit.GenericTypeParameterBuilder" /> represents a type parameter of a generic method; otherwise, <see langword="null" />.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.DeclaringType">
+      <summary>Gets the generic type definition or generic method definition to which the generic type parameter belongs.</summary>
+      <returns>If the type parameter belongs to a generic type, a <see cref="T:System.Type" /> object representing that generic type; if the type parameter belongs to a generic method, a <see cref="T:System.Type" /> object representing that type that declared that generic method.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.Equals(System.Object)">
+      <summary>Tests whether the given object is an instance of <see langword="EventToken" /> and is equal to the current instance.</summary>
+      <param name="o">The object to be compared with the current instance.</param>
+      <returns>
+        <see langword="true" /> if <paramref name="o" /> is an instance of <see langword="EventToken" /> and equals the current instance; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.FullName">
+      <summary>Gets <see langword="null" /> in all cases.</summary>
+      <returns>A null reference (<see langword="Nothing" /> in Visual Basic) in all cases.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.GenericParameterAttributes">
+      <summary>Gets a combination of <see cref="T:System.Reflection.GenericParameterAttributes" /> flags that describe the covariance and special constraints of the current generic type parameter.</summary>
+      <returns>A bitwise combination of values that describes the covariance and special constraints of the current generic type parameter.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.GenericParameterPosition">
+      <summary>Gets the position of the type parameter in the type parameter list of the generic type or method that declared the parameter.</summary>
+      <returns>The position of the type parameter in the type parameter list of the generic type or method that declared the parameter.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetConstructors(System.Reflection.BindingFlags)">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <param name="bindingAttr">Not supported.</param>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetCustomAttributes(System.Boolean)">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <param name="inherit">Specifies whether to search this member's inheritance chain to find the attributes.</param>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetCustomAttributes(System.Type,System.Boolean)">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <param name="attributeType">The type of attribute to search for. Only attributes that are assignable to this type are returned.</param>
+      <param name="inherit">Specifies whether to search this member's inheritance chain to find the attributes.</param>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetElementType">
+      <summary>Throws a <see cref="T:System.NotSupportedException" /> in all cases.</summary>
+      <returns>The type referred to by the current array type, pointer type, or <see langword="ByRef" /> type; or <see langword="null" /> if the current type is not an array type, is not a pointer type, and is not passed by reference.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetEvent(System.String,System.Reflection.BindingFlags)">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <param name="name">Not supported.</param>
+      <param name="bindingAttr">Not supported.</param>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetEvents">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetEvents(System.Reflection.BindingFlags)">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <param name="bindingAttr">Not supported.</param>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetField(System.String,System.Reflection.BindingFlags)">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <param name="name">Not supported.</param>
+      <param name="bindingAttr">Not supported.</param>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetFields(System.Reflection.BindingFlags)">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <param name="bindingAttr">Not supported.</param>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetGenericArguments">
+      <summary>Not valid for generic type parameters.</summary>
+      <returns>Not valid for generic type parameters.</returns>
+      <exception cref="T:System.InvalidOperationException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetGenericTypeDefinition">
+      <summary>Not valid for generic type parameters.</summary>
+      <returns>Not valid for generic type parameters.</returns>
+      <exception cref="T:System.InvalidOperationException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetHashCode">
+      <summary>Returns a 32-bit integer hash code for the current instance.</summary>
+      <returns>A 32-bit integer hash code.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetInterface(System.String,System.Boolean)">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <param name="name">The name of the interface.</param>
+      <param name="ignoreCase">
+        <see langword="true" /> to search without regard for case; <see langword="false" /> to make a case-sensitive search.</param>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetInterfaceMap(System.Type)">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <param name="interfaceType">A <see cref="T:System.Type" /> object that represents the interface type for which the mapping is to be retrieved.</param>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetInterfaces">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetMember(System.String,System.Reflection.MemberTypes,System.Reflection.BindingFlags)">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <param name="name">Not supported.</param>
+      <param name="type">Not supported.</param>
+      <param name="bindingAttr">Not supported.</param>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetMembers(System.Reflection.BindingFlags)">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <param name="bindingAttr">Not supported.</param>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetMethods(System.Reflection.BindingFlags)">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <param name="bindingAttr">Not supported.</param>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetNestedType(System.String,System.Reflection.BindingFlags)">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <param name="name">Not supported.</param>
+      <param name="bindingAttr">Not supported.</param>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetNestedTypes(System.Reflection.BindingFlags)">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <param name="bindingAttr">Not supported.</param>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.GetProperties(System.Reflection.BindingFlags)">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <param name="bindingAttr">Not supported.</param>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.GUID">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.InvokeMember(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object,System.Object[],System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[])">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <param name="name">Not supported.</param>
+      <param name="invokeAttr">Not supported.</param>
+      <param name="binder">Not supported.</param>
+      <param name="target">Not supported.</param>
+      <param name="args">Not supported.</param>
+      <param name="modifiers">Not supported.</param>
+      <param name="culture">Not supported.</param>
+      <param name="namedParameters">Not supported.</param>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.IsAssignableFrom(System.Type)">
+      <summary>Throws a <see cref="T:System.NotSupportedException" /> exception in all cases.</summary>
+      <param name="c">The object to test.</param>
+      <returns>Throws a <see cref="T:System.NotSupportedException" /> exception in all cases.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.IsByRefLike" />
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.IsConstructedGenericType">
+      <summary>Gets a value that indicates whether this object represents a constructed generic type.</summary>
+      <returns>
+        <see langword="true" /> if this object represents a constructed generic type; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.IsDefined(System.Type,System.Boolean)">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <param name="attributeType">Not supported.</param>
+      <param name="inherit">Not supported.</param>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.IsGenericParameter">
+      <summary>Gets <see langword="true" /> in all cases.</summary>
+      <returns>
+        <see langword="true" /> in all cases.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.IsGenericType">
+      <summary>Returns <see langword="false" /> in all cases.</summary>
+      <returns>
+        <see langword="false" /> in all cases.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.IsGenericTypeDefinition">
+      <summary>Gets <see langword="false" /> in all cases.</summary>
+      <returns>
+        <see langword="false" /> in all cases.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.IsSubclassOf(System.Type)">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <param name="c">Not supported.</param>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.IsSZArray" />
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.IsTypeDefinition" />
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.IsVariableBoundArray" />
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.MakeArrayType">
+      <summary>Returns the type of a one-dimensional array whose element type is the generic type parameter.</summary>
+      <returns>A <see cref="T:System.Type" /> object that represents the type of a one-dimensional array whose element type is the generic type parameter.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.MakeArrayType(System.Int32)">
+      <summary>Returns the type of an array whose element type is the generic type parameter, with the specified number of dimensions.</summary>
+      <param name="rank">The number of dimensions for the array.</param>
+      <returns>A <see cref="T:System.Type" /> object that represents the type of an array whose element type is the generic type parameter, with the specified number of dimensions.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        <paramref name="rank" /> is not a valid number of dimensions. For example, its value is less than 1.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.MakeByRefType">
+      <summary>Returns a <see cref="T:System.Type" /> object that represents the current generic type parameter when passed as a reference parameter.</summary>
+      <returns>A <see cref="T:System.Type" /> object that represents the current generic type parameter when passed as a reference parameter.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.MakeGenericType(System.Type[])">
+      <summary>Not valid for incomplete generic type parameters.</summary>
+      <param name="typeArguments">An array of type arguments.</param>
+      <returns>This method is invalid for incomplete generic type parameters.</returns>
+      <exception cref="T:System.InvalidOperationException">In all cases.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.MakePointerType">
+      <summary>Returns a <see cref="T:System.Type" /> object that represents a pointer to the current generic type parameter.</summary>
+      <returns>A <see cref="T:System.Type" /> object that represents a pointer to the current generic type parameter.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.Module">
+      <summary>Gets the dynamic module that contains the generic type parameter.</summary>
+      <returns>A <see cref="T:System.Reflection.Module" /> object that represents the dynamic module that contains the generic type parameter.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.Name">
+      <summary>Gets the name of the generic type parameter.</summary>
+      <returns>The name of the generic type parameter.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.Namespace">
+      <summary>Gets <see langword="null" /> in all cases.</summary>
+      <returns>A null reference (<see langword="Nothing" /> in Visual Basic) in all cases.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.ReflectedType">
+      <summary>Gets the <see cref="T:System.Type" /> object that was used to obtain the <see cref="T:System.Reflection.Emit.GenericTypeParameterBuilder" />.</summary>
+      <returns>The <see cref="T:System.Type" /> object that was used to obtain the <see cref="T:System.Reflection.Emit.GenericTypeParameterBuilder" />.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.SetBaseTypeConstraint(System.Type)">
+      <summary>Sets the base type that a type must inherit in order to be substituted for the type parameter.</summary>
+      <param name="baseTypeConstraint">The <see cref="T:System.Type" /> that must be inherited by any type that is to be substituted for the type parameter.</param>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.SetCustomAttribute(System.Reflection.ConstructorInfo,System.Byte[])">
+      <summary>Sets a custom attribute using a specified custom attribute blob.</summary>
+      <param name="con">The constructor for the custom attribute.</param>
+      <param name="binaryAttribute">A byte blob representing the attribute.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="con" /> is <see langword="null" />.
+-or-
+<paramref name="binaryAttribute" /> is a null reference.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder)">
+      <summary>Set a custom attribute using a custom attribute builder.</summary>
+      <param name="customBuilder">An instance of a helper class that defines the custom attribute.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="customBuilder" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.SetGenericParameterAttributes(System.Reflection.GenericParameterAttributes)">
+      <summary>Sets the variance characteristics and special constraints of the generic parameter, such as the parameterless constructor constraint.</summary>
+      <param name="genericParameterAttributes">A bitwise combination of <see cref="T:System.Reflection.GenericParameterAttributes" /> values that represent the variance characteristics and special constraints of the generic type parameter.</param>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.SetInterfaceConstraints(System.Type[])">
+      <summary>Sets the interfaces a type must implement in order to be substituted for the type parameter.</summary>
+      <param name="interfaceConstraints">An array of <see cref="T:System.Type" /> objects that represent the interfaces a type must implement in order to be substituted for the type parameter.</param>
+    </member>
+    <member name="M:System.Reflection.Emit.GenericTypeParameterBuilder.ToString">
+      <summary>Returns a string representation of the current generic type parameter.</summary>
+      <returns>A string that contains the name of the generic type parameter.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.TypeHandle">
+      <summary>Not supported for incomplete generic type parameters.</summary>
+      <returns>Not supported for incomplete generic type parameters.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.GenericTypeParameterBuilder.UnderlyingSystemType">
+      <summary>Gets the current generic type parameter.</summary>
+      <returns>The current <see cref="T:System.Reflection.Emit.GenericTypeParameterBuilder" /> object.</returns>
+    </member>
+    <member name="T:System.Reflection.Emit.MethodBuilder">
+      <summary>Defines and represents a method (or constructor) on a dynamic class.</summary>
+    </member>
+    <member name="P:System.Reflection.Emit.MethodBuilder.Attributes">
+      <summary>Retrieves the attributes for this method.</summary>
+      <returns>Read-only. Retrieves the <see langword="MethodAttributes" /> for this method.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.MethodBuilder.CallingConvention">
+      <summary>Returns the calling convention of the method.</summary>
+      <returns>Read-only. The calling convention of the method.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.MethodBuilder.ContainsGenericParameters">
+      <summary>Not supported for this type.</summary>
+      <returns>Not supported.</returns>
+      <exception cref="T:System.NotSupportedException">The invoked method is not supported in the base class.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.MethodBuilder.DeclaringType">
+      <summary>Returns the type that declares this method.</summary>
+      <returns>Read-only. The type that declares this method.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.DefineGenericParameters(System.String[])">
+      <summary>Sets the number of generic type parameters for the current method, specifies their names, and returns an array of <see cref="T:System.Reflection.Emit.GenericTypeParameterBuilder" /> objects that can be used to define their constraints.</summary>
+      <param name="names">An array of strings that represent the names of the generic type parameters.</param>
+      <returns>An array of <see cref="T:System.Reflection.Emit.GenericTypeParameterBuilder" /> objects representing the type parameters of the generic method.</returns>
+      <exception cref="T:System.InvalidOperationException">Generic type parameters have already been defined for this method.
+-or-
+The method has been completed already.
+-or-
+The <see cref="M:System.Reflection.Emit.MethodBuilder.SetImplementationFlags(System.Reflection.MethodImplAttributes)" /> method has been called for the current method.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="names" /> is <see langword="null" />.
+-or-
+An element of <paramref name="names" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="names" /> is an empty array.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.DefineParameter(System.Int32,System.Reflection.ParameterAttributes,System.String)">
+      <summary>Sets the parameter attributes and the name of a parameter of this method, or of the return value of this method. Returns a ParameterBuilder that can be used to apply custom attributes.</summary>
+      <param name="position">The position of the parameter in the parameter list. Parameters are indexed beginning with the number 1 for the first parameter; the number 0 represents the return value of the method.</param>
+      <param name="attributes">The parameter attributes of the parameter.</param>
+      <param name="strParamName">The name of the parameter. The name can be the null string.</param>
+      <returns>Returns a <see langword="ParameterBuilder" /> object that represents a parameter of this method or the return value of this method.</returns>
+      <exception cref="T:System.ArgumentOutOfRangeException">The method has no parameters.
+-or-
+<paramref name="position" /> is less than zero.
+-or-
+<paramref name="position" /> is greater than the number of the method's parameters.</exception>
+      <exception cref="T:System.InvalidOperationException">The containing type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.
+-or-
+For the current method, the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethod" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethodDefinition" /> property is <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.Equals(System.Object)">
+      <summary>Determines whether the given object is equal to this instance.</summary>
+      <param name="obj">The object to compare with this <see langword="MethodBuilder" /> instance.</param>
+      <returns>
+        <see langword="true" /> if <paramref name="obj" /> is an instance of <see langword="MethodBuilder" /> and is equal to this object; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.GetBaseDefinition">
+      <summary>Return the base implementation for a method.</summary>
+      <returns>The base implementation of this method.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.GetCustomAttributes(System.Boolean)">
+      <summary>Returns all the custom attributes defined for this method.</summary>
+      <param name="inherit">Specifies whether to search this member's inheritance chain to find the custom attributes.</param>
+      <returns>Returns an array of objects representing all the custom attributes of this method.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported. Retrieve the method using <see cref="M:System.Type.GetMethod(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])" /> and call <see cref="M:System.Reflection.MemberInfo.GetCustomAttributes(System.Boolean)" /> on the returned <see cref="T:System.Reflection.MethodInfo" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.GetCustomAttributes(System.Type,System.Boolean)">
+      <summary>Returns the custom attributes identified by the given type.</summary>
+      <param name="attributeType">The custom attribute type.</param>
+      <param name="inherit">Specifies whether to search this member's inheritance chain to find the custom attributes.</param>
+      <returns>Returns an array of objects representing the attributes of this method that are of type <paramref name="attributeType" />.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported. Retrieve the method using <see cref="M:System.Type.GetMethod(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])" /> and call <see cref="M:System.Reflection.MemberInfo.GetCustomAttributes(System.Boolean)" /> on the returned <see cref="T:System.Reflection.MethodInfo" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.GetGenericArguments">
+      <summary>Returns an array of <see cref="T:System.Reflection.Emit.GenericTypeParameterBuilder" /> objects that represent the type parameters of the method, if it is generic.</summary>
+      <returns>An array of <see cref="T:System.Reflection.Emit.GenericTypeParameterBuilder" /> objects representing the type parameters, if the method is generic, or <see langword="null" /> if the method is not generic.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.GetGenericMethodDefinition">
+      <summary>Returns this method.</summary>
+      <returns>The current instance of <see cref="T:System.Reflection.Emit.MethodBuilder" />.</returns>
+      <exception cref="T:System.InvalidOperationException">The current method is not generic. That is, the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethod" /> property returns <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.GetHashCode">
+      <summary>Gets the hash code for this method.</summary>
+      <returns>The hash code for this method.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.GetILGenerator">
+      <summary>Returns an <see langword="ILGenerator" /> for this method with a default Microsoft intermediate language (MSIL) stream size of 64 bytes.</summary>
+      <returns>Returns an <see langword="ILGenerator" /> object for this method.</returns>
+      <exception cref="T:System.InvalidOperationException">The method should not have a body because of its <see cref="T:System.Reflection.MethodAttributes" /> or <see cref="T:System.Reflection.MethodImplAttributes" /> flags, for example because it has the <see cref="F:System.Reflection.MethodAttributes.PinvokeImpl" /> flag.
+-or-
+The method is a generic method, but not a generic method definition. That is, the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethod" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethodDefinition" /> property is <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.GetILGenerator(System.Int32)">
+      <summary>Returns an <see langword="ILGenerator" /> for this method with the specified Microsoft intermediate language (MSIL) stream size.</summary>
+      <param name="size">The size of the MSIL stream, in bytes.</param>
+      <returns>Returns an <see langword="ILGenerator" /> object for this method.</returns>
+      <exception cref="T:System.InvalidOperationException">The method should not have a body because of its <see cref="T:System.Reflection.MethodAttributes" /> or <see cref="T:System.Reflection.MethodImplAttributes" /> flags, for example because it has the <see cref="F:System.Reflection.MethodAttributes.PinvokeImpl" /> flag.
+-or-
+The method is a generic method, but not a generic method definition. That is, the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethod" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethodDefinition" /> property is <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.GetMethodImplementationFlags">
+      <summary>Returns the implementation flags for the method.</summary>
+      <returns>Returns the implementation flags for the method.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.GetParameters">
+      <summary>Returns the parameters of this method.</summary>
+      <returns>An array of <see langword="ParameterInfo" /> objects that represent the parameters of the method.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported. Retrieve the method using <see cref="M:System.Type.GetMethod(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])" /> and call <see langword="GetParameters" /> on the returned <see cref="T:System.Reflection.MethodInfo" />.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.MethodBuilder.InitLocals">
+      <summary>Gets or sets a Boolean value that specifies whether the local variables in this method are zero initialized. The default value of this property is <see langword="true" />.</summary>
+      <returns>
+        <see langword="true" /> if the local variables in this method should be zero initialized; otherwise <see langword="false" />.</returns>
+      <exception cref="T:System.InvalidOperationException">For the current method, the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethod" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethodDefinition" /> property is <see langword="false" />. (Get or set.)</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.Invoke(System.Object,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo)">
+      <summary>Dynamically invokes the method reflected by this instance on the given object, passing along the specified parameters, and under the constraints of the given binder.</summary>
+      <param name="obj">The object on which to invoke the specified method. If the method is static, this parameter is ignored.</param>
+      <param name="invokeAttr">This must be a bit flag from <see cref="T:System.Reflection.BindingFlags" /> : <see langword="InvokeMethod" />, <see langword="NonPublic" />, and so on.</param>
+      <param name="binder">An object that enables the binding, coercion of argument types, invocation of members, and retrieval of MemberInfo objects via reflection. If binder is <see langword="null" />, the default binder is used. For more details, see <see cref="T:System.Reflection.Binder" />.</param>
+      <param name="parameters">An argument list. This is an array of arguments with the same number, order, and type as the parameters of the method to be invoked. If there are no parameters this should be <see langword="null" />.</param>
+      <param name="culture">An instance of <see cref="T:System.Globalization.CultureInfo" /> used to govern the coercion of types. If this is null, the <see cref="T:System.Globalization.CultureInfo" /> for the current thread is used. (Note that this is necessary to, for example, convert a <see cref="T:System.String" /> that represents 1000 to a <see cref="T:System.Double" /> value, since 1000 is represented differently by different cultures.)</param>
+      <returns>Returns an object containing the return value of the invoked method.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported. Retrieve the method using <see cref="M:System.Type.GetMethod(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])" /> and call <see cref="M:System.Type.InvokeMember(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object,System.Object[],System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[])" /> on the returned <see cref="T:System.Reflection.MethodInfo" />.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.MethodBuilder.IsConstructedGenericMethod" />
+    <member name="M:System.Reflection.Emit.MethodBuilder.IsDefined(System.Type,System.Boolean)">
+      <summary>Checks if the specified custom attribute type is defined.</summary>
+      <param name="attributeType">The custom attribute type.</param>
+      <param name="inherit">Specifies whether to search this member's inheritance chain to find the custom attributes.</param>
+      <returns>
+        <see langword="true" /> if the specified custom attribute type is defined; otherwise, <see langword="false" />.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported. Retrieve the method using <see cref="M:System.Type.GetMethod(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])" /> and call <see cref="M:System.Reflection.MemberInfo.IsDefined(System.Type,System.Boolean)" /> on the returned <see cref="T:System.Reflection.MethodInfo" />.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.MethodBuilder.IsGenericMethod">
+      <summary>Gets a value indicating whether the method is a generic method.</summary>
+      <returns>
+        <see langword="true" /> if the method is generic; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.MethodBuilder.IsGenericMethodDefinition">
+      <summary>Gets a value indicating whether the current <see cref="T:System.Reflection.Emit.MethodBuilder" /> object represents the definition of a generic method.</summary>
+      <returns>
+        <see langword="true" /> if the current <see cref="T:System.Reflection.Emit.MethodBuilder" /> object represents the definition of a generic method; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.MethodBuilder.IsSecurityCritical">
+      <summary>Throws a <see cref="T:System.NotSupportedException" /> in all cases.</summary>
+      <returns>Throws a <see cref="T:System.NotSupportedException" /> in all cases.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases. This property is not supported in dynamic assemblies.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.MethodBuilder.IsSecuritySafeCritical">
+      <summary>Throws a <see cref="T:System.NotSupportedException" /> in all cases.</summary>
+      <returns>Throws a <see cref="T:System.NotSupportedException" /> in all cases.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases. This property is not supported in dynamic assemblies.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.MethodBuilder.IsSecurityTransparent">
+      <summary>Throws a <see cref="T:System.NotSupportedException" /> in all cases.</summary>
+      <returns>Throws a <see cref="T:System.NotSupportedException" /> in all cases.</returns>
+      <exception cref="T:System.NotSupportedException">In all cases. This property is not supported in dynamic assemblies.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.MakeGenericMethod(System.Type[])">
+      <summary>Returns a generic method constructed from the current generic method definition using the specified generic type arguments.</summary>
+      <param name="typeArguments">An array of <see cref="T:System.Type" /> objects that represent the type arguments for the generic method.</param>
+      <returns>A <see cref="T:System.Reflection.MethodInfo" /> representing the generic method constructed from the current generic method definition using the specified generic type arguments.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.MethodBuilder.MethodHandle">
+      <summary>Retrieves the internal handle for the method. Use this handle to access the underlying metadata handle.</summary>
+      <returns>Read-only. The internal handle for the method. Use this handle to access the underlying metadata handle.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported. Retrieve the method using <see cref="M:System.Type.GetMethod(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Reflection.CallingConventions,System.Type[],System.Reflection.ParameterModifier[])" /> and call <see cref="P:System.Reflection.MethodBase.MethodHandle" /> on the returned <see cref="T:System.Reflection.MethodInfo" />.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.MethodBuilder.Module">
+      <summary>Gets the module in which the current method is being defined.</summary>
+      <returns>The <see cref="T:System.Reflection.Module" /> in which the member represented by the current <see cref="T:System.Reflection.MemberInfo" /> is being defined.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.MethodBuilder.Name">
+      <summary>Retrieves the name of this method.</summary>
+      <returns>Read-only. Retrieves a string containing the simple name of this method.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.MethodBuilder.ReflectedType">
+      <summary>Retrieves the class that was used in reflection to obtain this object.</summary>
+      <returns>Read-only. The type used to obtain this method.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.MethodBuilder.ReturnParameter">
+      <summary>Gets a <see cref="T:System.Reflection.ParameterInfo" /> object that contains information about the return type of the method, such as whether the return type has custom modifiers.</summary>
+      <returns>A <see cref="T:System.Reflection.ParameterInfo" /> object that contains information about the return type.</returns>
+      <exception cref="T:System.InvalidOperationException">The declaring type has not been created.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.MethodBuilder.ReturnType">
+      <summary>Gets the return type of the method represented by this <see cref="T:System.Reflection.Emit.MethodBuilder" />.</summary>
+      <returns>The return type of the method.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.MethodBuilder.ReturnTypeCustomAttributes">
+      <summary>Returns the custom attributes of the method's return type.</summary>
+      <returns>Read-only. The custom attributes of the method's return type.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.SetCustomAttribute(System.Reflection.ConstructorInfo,System.Byte[])">
+      <summary>Sets a custom attribute using a specified custom attribute blob.</summary>
+      <param name="con">The constructor for the custom attribute.</param>
+      <param name="binaryAttribute">A byte blob representing the attributes.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="con" /> or <paramref name="binaryAttribute" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">For the current method, the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethod" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethodDefinition" /> property is <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder)">
+      <summary>Sets a custom attribute using a custom attribute builder.</summary>
+      <param name="customBuilder">An instance of a helper class to describe the custom attribute.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="customBuilder" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">For the current method, the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethod" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethodDefinition" /> property is <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.SetImplementationFlags(System.Reflection.MethodImplAttributes)">
+      <summary>Sets the implementation flags for this method.</summary>
+      <param name="attributes">The implementation flags to set.</param>
+      <exception cref="T:System.InvalidOperationException">The containing type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.
+-or-
+For the current method, the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethod" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethodDefinition" /> property is <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.SetParameters(System.Type[])">
+      <summary>Sets the number and types of parameters for a method.</summary>
+      <param name="parameterTypes">An array of <see cref="T:System.Type" /> objects representing the parameter types.</param>
+      <exception cref="T:System.InvalidOperationException">The current method is generic, but is not a generic method definition. That is, the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethod" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethodDefinition" /> property is <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.SetReturnType(System.Type)">
+      <summary>Sets the return type of the method.</summary>
+      <param name="returnType">A <see cref="T:System.Type" /> object that represents the return type of the method.</param>
+      <exception cref="T:System.InvalidOperationException">The current method is generic, but is not a generic method definition. That is, the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethod" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethodDefinition" /> property is <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.SetSignature(System.Type,System.Type[],System.Type[],System.Type[],System.Type[][],System.Type[][])">
+      <summary>Sets the method signature, including the return type, the parameter types, and the required and optional custom modifiers of the return type and parameter types.</summary>
+      <param name="returnType">The return type of the method.</param>
+      <param name="returnTypeRequiredCustomModifiers">An array of types representing the required custom modifiers, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />, for the return type of the method. If the return type has no required custom modifiers, specify <see langword="null" />.</param>
+      <param name="returnTypeOptionalCustomModifiers">An array of types representing the optional custom modifiers, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />, for the return type of the method. If the return type has no optional custom modifiers, specify <see langword="null" />.</param>
+      <param name="parameterTypes">The types of the parameters of the method.</param>
+      <param name="parameterTypeRequiredCustomModifiers">An array of arrays of types. Each array of types represents the required custom modifiers for the corresponding parameter, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />. If a particular parameter has no required custom modifiers, specify <see langword="null" /> instead of an array of types. If none of the parameters have required custom modifiers, specify <see langword="null" /> instead of an array of arrays.</param>
+      <param name="parameterTypeOptionalCustomModifiers">An array of arrays of types. Each array of types represents the optional custom modifiers for the corresponding parameter, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />. If a particular parameter has no optional custom modifiers, specify <see langword="null" /> instead of an array of types. If none of the parameters have optional custom modifiers, specify <see langword="null" /> instead of an array of arrays.</param>
+      <exception cref="T:System.InvalidOperationException">The current method is generic, but is not a generic method definition. That is, the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethod" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.MethodBuilder.IsGenericMethodDefinition" /> property is <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.MethodBuilder.ToString">
+      <summary>Returns this <see langword="MethodBuilder" /> instance as a string.</summary>
+      <returns>Returns a string containing the name, attributes, method signature, exceptions, and local signature of this method followed by the current Microsoft intermediate language (MSIL) stream.</returns>
+    </member>
+    <member name="T:System.Reflection.Emit.ModuleBuilder">
+      <summary>Defines and represents a module in a dynamic assembly.</summary>
+    </member>
+    <member name="P:System.Reflection.Emit.ModuleBuilder.Assembly">
+      <summary>Gets the dynamic assembly that defined this instance of <see cref="T:System.Reflection.Emit.ModuleBuilder" />.</summary>
+      <returns>The dynamic assembly that defined the current dynamic module.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.CreateGlobalFunctions">
+      <summary>Completes the global function definitions and global data definitions for this dynamic module.</summary>
+      <exception cref="T:System.InvalidOperationException">This method was called previously.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.DefineEnum(System.String,System.Reflection.TypeAttributes,System.Type)">
+      <summary>Defines an enumeration type that is a value type with a single non-static field called <paramref name="value__" /> of the specified type.</summary>
+      <param name="name">The full path of the enumeration type. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="visibility">The type attributes for the enumeration. The attributes are any bits defined by <see cref="F:System.Reflection.TypeAttributes.VisibilityMask" />.</param>
+      <param name="underlyingType">The underlying type for the enumeration. This must be a built-in integer type.</param>
+      <returns>The defined enumeration.</returns>
+      <exception cref="T:System.ArgumentException">Attributes other than visibility attributes are provided.
+-or-
+An enumeration with the given name exists in the parent assembly of this module.
+-or-
+The visibility attributes do not match the scope of the enumeration. For example, <see cref="F:System.Reflection.TypeAttributes.NestedPublic" /> is specified for <paramref name="visibility" />, but the enumeration is not a nested type.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.DefineGlobalMethod(System.String,System.Reflection.MethodAttributes,System.Reflection.CallingConventions,System.Type,System.Type[])">
+      <summary>Defines a global method with the specified name, attributes, calling convention, return type, and parameter types.</summary>
+      <param name="name">The name of the method. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attributes">The attributes of the method. <paramref name="attributes" /> must include <see cref="F:System.Reflection.MethodAttributes.Static" />.</param>
+      <param name="callingConvention">The calling convention for the method.</param>
+      <param name="returnType">The return type of the method.</param>
+      <param name="parameterTypes">The types of the method's parameters.</param>
+      <returns>The defined global method.</returns>
+      <exception cref="T:System.ArgumentException">The method is not static. That is, <paramref name="attributes" /> does not include <see cref="F:System.Reflection.MethodAttributes.Static" />.
+-or-
+An element in the <see cref="T:System.Type" /> array is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="M:System.Reflection.Emit.ModuleBuilder.CreateGlobalFunctions" /> has been previously called.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.DefineGlobalMethod(System.String,System.Reflection.MethodAttributes,System.Reflection.CallingConventions,System.Type,System.Type[],System.Type[],System.Type[],System.Type[][],System.Type[][])">
+      <summary>Defines a global method with the specified name, attributes, calling convention, return type, custom modifiers for the return type, parameter types, and custom modifiers for the parameter types.</summary>
+      <param name="name">The name of the method. <paramref name="name" /> cannot contain embedded null characters.</param>
+      <param name="attributes">The attributes of the method. <paramref name="attributes" /> must include <see cref="F:System.Reflection.MethodAttributes.Static" />.</param>
+      <param name="callingConvention">The calling convention for the method.</param>
+      <param name="returnType">The return type of the method.</param>
+      <param name="requiredReturnTypeCustomModifiers">An array of types representing the required custom modifiers for the return type, such as <see cref="T:System.Runtime.CompilerServices.IsConst" /> or <see cref="T:System.Runtime.CompilerServices.IsBoxed" />. If the return type has no required custom modifiers, specify <see langword="null" />.</param>
+      <param name="optionalReturnTypeCustomModifiers">An array of types representing the optional custom modifiers for the return type, such as <see cref="T:System.Runtime.CompilerServices.IsConst" /> or <see cref="T:System.Runtime.CompilerServices.IsBoxed" />. If the return type has no optional custom modifiers, specify <see langword="null" />.</param>
+      <param name="parameterTypes">The types of the method's parameters.</param>
+      <param name="requiredParameterTypeCustomModifiers">An array of arrays of types. Each array of types represents the required custom modifiers for the corresponding parameter of the global method. If a particular argument has no required custom modifiers, specify <see langword="null" /> instead of an array of types. If the global method has no arguments, or if none of the arguments have required custom modifiers, specify <see langword="null" /> instead of an array of arrays.</param>
+      <param name="optionalParameterTypeCustomModifiers">An array of arrays of types. Each array of types represents the optional custom modifiers for the corresponding parameter. If a particular argument has no optional custom modifiers, specify <see langword="null" /> instead of an array of types. If the global method has no arguments, or if none of the arguments have optional custom modifiers, specify <see langword="null" /> instead of an array of arrays.</param>
+      <returns>The defined global method.</returns>
+      <exception cref="T:System.ArgumentException">The method is not static. That is, <paramref name="attributes" /> does not include <see cref="F:System.Reflection.MethodAttributes.Static" />.
+-or-
+An element in the <see cref="T:System.Type" /> array is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The <see cref="M:System.Reflection.Emit.ModuleBuilder.CreateGlobalFunctions" /> method has been previously called.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.DefineGlobalMethod(System.String,System.Reflection.MethodAttributes,System.Type,System.Type[])">
+      <summary>Defines a global method with the specified name, attributes, return type, and parameter types.</summary>
+      <param name="name">The name of the method. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attributes">The attributes of the method. <paramref name="attributes" /> must include <see cref="F:System.Reflection.MethodAttributes.Static" />.</param>
+      <param name="returnType">The return type of the method.</param>
+      <param name="parameterTypes">The types of the method's parameters.</param>
+      <returns>The defined global method.</returns>
+      <exception cref="T:System.ArgumentException">The method is not static. That is, <paramref name="attributes" /> does not include <see cref="F:System.Reflection.MethodAttributes.Static" />.
+-or-
+The length of <paramref name="name" /> is zero
+-or-
+An element in the <see cref="T:System.Type" /> array is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="M:System.Reflection.Emit.ModuleBuilder.CreateGlobalFunctions" /> has been previously called.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.DefineInitializedData(System.String,System.Byte[],System.Reflection.FieldAttributes)">
+      <summary>Defines an initialized data field in the .sdata section of the portable executable (PE) file.</summary>
+      <param name="name">The name used to refer to the data. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="data">The binary large object (BLOB) of data.</param>
+      <param name="attributes">The attributes for the field. The default is <see langword="Static" />.</param>
+      <returns>A field to reference the data.</returns>
+      <exception cref="T:System.ArgumentException">The length of <paramref name="name" /> is zero.
+-or-
+The size of <paramref name="data" /> is less than or equal to zero or greater than or equal to 0x3f0000.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> or <paramref name="data" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="M:System.Reflection.Emit.ModuleBuilder.CreateGlobalFunctions" /> has been previously called.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.DefinePInvokeMethod(System.String,System.String,System.Reflection.MethodAttributes,System.Reflection.CallingConventions,System.Type,System.Type[],System.Runtime.InteropServices.CallingConvention,System.Runtime.InteropServices.CharSet)">
+      <summary>Defines a <see langword="PInvoke" /> method with the specified name, the name of the DLL in which the method is defined, the attributes of the method, the calling convention of the method, the return type of the method, the types of the parameters of the method, and the <see langword="PInvoke" /> flags.</summary>
+      <param name="name">The name of the <see langword="PInvoke" /> method. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="dllName">The name of the DLL in which the <see langword="PInvoke" /> method is defined.</param>
+      <param name="attributes">The attributes of the method.</param>
+      <param name="callingConvention">The method's calling convention.</param>
+      <param name="returnType">The method's return type.</param>
+      <param name="parameterTypes">The types of the method's parameters.</param>
+      <param name="nativeCallConv">The native calling convention.</param>
+      <param name="nativeCharSet">The method's native character set.</param>
+      <returns>The defined <see langword="PInvoke" /> method.</returns>
+      <exception cref="T:System.ArgumentException">The method is not static or if the containing type is an interface.
+-or-
+The method is abstract.
+-or-
+The method was previously defined.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> or <paramref name="dllName" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The containing type has been previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /></exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.DefinePInvokeMethod(System.String,System.String,System.String,System.Reflection.MethodAttributes,System.Reflection.CallingConventions,System.Type,System.Type[],System.Runtime.InteropServices.CallingConvention,System.Runtime.InteropServices.CharSet)">
+      <summary>Defines a <see langword="PInvoke" /> method with the specified name, the name of the DLL in which the method is defined, the attributes of the method, the calling convention of the method, the return type of the method, the types of the parameters of the method, and the <see langword="PInvoke" /> flags.</summary>
+      <param name="name">The name of the <see langword="PInvoke" /> method. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="dllName">The name of the DLL in which the <see langword="PInvoke" /> method is defined.</param>
+      <param name="entryName">The name of the entry point in the DLL.</param>
+      <param name="attributes">The attributes of the method.</param>
+      <param name="callingConvention">The method's calling convention.</param>
+      <param name="returnType">The method's return type.</param>
+      <param name="parameterTypes">The types of the method's parameters.</param>
+      <param name="nativeCallConv">The native calling convention.</param>
+      <param name="nativeCharSet">The method's native character set.</param>
+      <returns>The defined <see langword="PInvoke" /> method.</returns>
+      <exception cref="T:System.ArgumentException">The method is not static or if the containing type is an interface or if the method is abstract of if the method was previously defined.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> or <paramref name="dllName" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The containing type has been previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /></exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.DefineType(System.String)">
+      <summary>Constructs a <see langword="TypeBuilder" /> for a private type with the specified name in this module.</summary>
+      <param name="name">The full path of the type, including the namespace. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <returns>A private type with the specified name.</returns>
+      <exception cref="T:System.ArgumentException">A type with the given name exists in the parent assembly of this module.
+-or-
+Nested type attributes are set on a type that is not nested.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.DefineType(System.String,System.Reflection.TypeAttributes)">
+      <summary>Constructs a <see langword="TypeBuilder" /> given the type name and the type attributes.</summary>
+      <param name="name">The full path of the type. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attr">The attributes of the defined type.</param>
+      <returns>A <see langword="TypeBuilder" /> created with all of the requested attributes.</returns>
+      <exception cref="T:System.ArgumentException">A type with the given name exists in the parent assembly of this module.
+-or-
+Nested type attributes are set on a type that is not nested.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.DefineType(System.String,System.Reflection.TypeAttributes,System.Type)">
+      <summary>Constructs a <see langword="TypeBuilder" /> given type name, its attributes, and the type that the defined type extends.</summary>
+      <param name="name">The full path of the type. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attr">The attribute to be associated with the type.</param>
+      <param name="parent">The type that the defined type extends.</param>
+      <returns>A <see langword="TypeBuilder" /> created with all of the requested attributes.</returns>
+      <exception cref="T:System.ArgumentException">A type with the given name exists in the parent assembly of this module.
+-or-
+Nested type attributes are set on a type that is not nested.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.DefineType(System.String,System.Reflection.TypeAttributes,System.Type,System.Int32)">
+      <summary>Constructs a <see langword="TypeBuilder" /> given the type name, the attributes, the type that the defined type extends, and the total size of the type.</summary>
+      <param name="name">The full path of the type. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attr">The attributes of the defined type.</param>
+      <param name="parent">The type that the defined type extends.</param>
+      <param name="typesize">The total size of the type.</param>
+      <returns>A <see langword="TypeBuilder" /> object.</returns>
+      <exception cref="T:System.ArgumentException">A type with the given name exists in the parent assembly of this module.
+-or-
+Nested type attributes are set on a type that is not nested.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.DefineType(System.String,System.Reflection.TypeAttributes,System.Type,System.Reflection.Emit.PackingSize)">
+      <summary>Constructs a <see langword="TypeBuilder" /> given the type name, the attributes, the type that the defined type extends, and the packing size of the type.</summary>
+      <param name="name">The full path of the type. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attr">The attributes of the defined type.</param>
+      <param name="parent">The type that the defined type extends.</param>
+      <param name="packsize">The packing size of the type.</param>
+      <returns>A <see langword="TypeBuilder" /> object.</returns>
+      <exception cref="T:System.ArgumentException">A type with the given name exists in the parent assembly of this module.
+-or-
+Nested type attributes are set on a type that is not nested.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.DefineType(System.String,System.Reflection.TypeAttributes,System.Type,System.Reflection.Emit.PackingSize,System.Int32)">
+      <summary>Constructs a <see langword="TypeBuilder" /> given the type name, attributes, the type that the defined type extends, the packing size of the defined type, and the total size of the defined type.</summary>
+      <param name="name">The full path of the type. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attr">The attributes of the defined type.</param>
+      <param name="parent">The type that the defined type extends.</param>
+      <param name="packingSize">The packing size of the type.</param>
+      <param name="typesize">The total size of the type.</param>
+      <returns>A <see langword="TypeBuilder" /> created with all of the requested attributes.</returns>
+      <exception cref="T:System.ArgumentException">A type with the given name exists in the parent assembly of this module.
+-or-
+Nested type attributes are set on a type that is not nested.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.DefineType(System.String,System.Reflection.TypeAttributes,System.Type,System.Type[])">
+      <summary>Constructs a <see langword="TypeBuilder" /> given the type name, attributes, the type that the defined type extends, and the interfaces that the defined type implements.</summary>
+      <param name="name">The full path of the type. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attr">The attributes to be associated with the type.</param>
+      <param name="parent">The type that the defined type extends.</param>
+      <param name="interfaces">The list of interfaces that the type implements.</param>
+      <returns>A <see langword="TypeBuilder" /> created with all of the requested attributes.</returns>
+      <exception cref="T:System.ArgumentException">A type with the given name exists in the parent assembly of this module.
+-or-
+Nested type attributes are set on a type that is not nested.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.DefineUninitializedData(System.String,System.Int32,System.Reflection.FieldAttributes)">
+      <summary>Defines an uninitialized data field in the .sdata section of the portable executable (PE) file.</summary>
+      <param name="name">The name used to refer to the data. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="size">The size of the data field.</param>
+      <param name="attributes">The attributes for the field.</param>
+      <returns>A field to reference the data.</returns>
+      <exception cref="T:System.ArgumentException">The length of <paramref name="name" /> is zero.
+-or-
+<paramref name="size" /> is less than or equal to zero, or greater than or equal to 0x003f0000.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="M:System.Reflection.Emit.ModuleBuilder.CreateGlobalFunctions" /> has been previously called.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.Equals(System.Object)">
+      <summary>Returns a value that indicates whether this instance is equal to the specified object.</summary>
+      <param name="obj">An object to compare with this instance, or <see langword="null" />.</param>
+      <returns>
+        <see langword="true" /> if <paramref name="obj" /> equals the type and value of this instance; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.ModuleBuilder.FullyQualifiedName">
+      <summary>Gets a <see langword="String" /> representing the fully qualified name and path to this module.</summary>
+      <returns>The fully qualified module name.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.GetArrayMethod(System.Type,System.String,System.Reflection.CallingConventions,System.Type,System.Type[])">
+      <summary>Returns the named method on an array class.</summary>
+      <param name="arrayClass">An array class.</param>
+      <param name="methodName">The name of a method on the array class.</param>
+      <param name="callingConvention">The method's calling convention.</param>
+      <param name="returnType">The return type of the method.</param>
+      <param name="parameterTypes">The types of the method's parameters.</param>
+      <returns>The named method on an array class.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="arrayClass" /> is not an array.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="arrayClass" /> or <paramref name="methodName" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.GetCustomAttributes(System.Boolean)">
+      <summary>Returns all the custom attributes that have been applied to the current <see cref="T:System.Reflection.Emit.ModuleBuilder" />.</summary>
+      <param name="inherit">This argument is ignored for objects of this type.</param>
+      <returns>An array that contains the custom attributes; the array is empty if there are no attributes.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.GetCustomAttributes(System.Type,System.Boolean)">
+      <summary>Returns all the custom attributes that have been applied to the current <see cref="T:System.Reflection.Emit.ModuleBuilder" />, and that derive from a specified attribute type.</summary>
+      <param name="attributeType">The base type from which attributes derive.</param>
+      <param name="inherit">This argument is ignored for objects of this type.</param>
+      <returns>An array that contains the custom attributes that are derived, at any level, from <paramref name="attributeType" />; the array is empty if there are no such attributes.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="attributeType" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="attributeType" /> is not a <see cref="T:System.Type" /> object supplied by the runtime. For example, <paramref name="attributeType" /> is a <see cref="T:System.Reflection.Emit.TypeBuilder" /> object.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.GetCustomAttributesData">
+      <summary>Returns information about the attributes that have been applied to the current <see cref="T:System.Reflection.Emit.ModuleBuilder" />, expressed as <see cref="T:System.Reflection.CustomAttributeData" /> objects.</summary>
+      <returns>A generic list of <see cref="T:System.Reflection.CustomAttributeData" /> objects representing data about the attributes that have been applied to the current module.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.GetField(System.String,System.Reflection.BindingFlags)">
+      <summary>Returns a module-level field, defined in the .sdata region of the portable executable (PE) file, that has the specified name and binding attributes.</summary>
+      <param name="name">The field name.</param>
+      <param name="bindingAttr">A combination of the <see langword="BindingFlags" /> bit flags used to control the search.</param>
+      <returns>A field that has the specified name and binding attributes, or <see langword="null" /> if the field does not exist.</returns>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="name" /> parameter is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.GetFields(System.Reflection.BindingFlags)">
+      <summary>Returns all fields defined in the .sdata region of the portable executable (PE) file that match the specified binding flags.</summary>
+      <param name="bindingFlags">A combination of the <see langword="BindingFlags" /> bit flags used to control the search.</param>
+      <returns>An array of fields that match the specified flags; the array is empty if no such fields exist.</returns>
+      <exception cref="T:System.ArgumentNullException">The <paramref name="name" /> parameter is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.GetHashCode">
+      <summary>Returns the hash code for this instance.</summary>
+      <returns>A 32-bit signed integer hash code.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.GetMethods(System.Reflection.BindingFlags)">
+      <summary>Returns all the methods that have been defined at the module level for the current <see cref="T:System.Reflection.Emit.ModuleBuilder" />, and that match the specified binding flags.</summary>
+      <param name="bindingFlags">A combination of <see langword="BindingFlags" /> bit flags used to control the search.</param>
+      <returns>An array that contains all the module-level methods that match <paramref name="bindingFlags" />.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.GetPEKind(System.Reflection.PortableExecutableKinds@,System.Reflection.ImageFileMachine@)">
+      <summary>Gets a pair of values indicating the nature of the code in a module and the platform targeted by the module.</summary>
+      <param name="peKind">When this method returns, a combination of the <see cref="T:System.Reflection.PortableExecutableKinds" /> values indicating the nature of the code in the module.</param>
+      <param name="machine">When this method returns, one of the <see cref="T:System.Reflection.ImageFileMachine" /> values indicating the platform targeted by the module.</param>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.GetType(System.String)">
+      <summary>Gets the named type defined in the module.</summary>
+      <param name="className">The name of the <see cref="T:System.Type" /> to get.</param>
+      <returns>The requested type, if the type is defined in this module; otherwise, <see langword="null" />.</returns>
+      <exception cref="T:System.ArgumentException">Length of <paramref name="className" /> is zero or is greater than 1023.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="className" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.Security.SecurityException">The requested <see cref="T:System.Type" /> is non-public and the caller does not have <see cref="T:System.Security.Permissions.ReflectionPermission" /> to reflect non-public objects outside the current assembly.</exception>
+      <exception cref="T:System.Reflection.TargetInvocationException">A class initializer is invoked and throws an exception.</exception>
+      <exception cref="T:System.TypeLoadException">An error is encountered while loading the <see cref="T:System.Type" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.GetType(System.String,System.Boolean)">
+      <summary>Gets the named type defined in the module, optionally ignoring the case of the type name.</summary>
+      <param name="className">The name of the <see cref="T:System.Type" /> to get.</param>
+      <param name="ignoreCase">If <see langword="true" />, the search is case-insensitive. If <see langword="false" />, the search is case-sensitive.</param>
+      <returns>The requested type, if the type is defined in this module; otherwise, <see langword="null" />.</returns>
+      <exception cref="T:System.ArgumentException">Length of <paramref name="className" /> is zero or is greater than 1023.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="className" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.Security.SecurityException">The requested <see cref="T:System.Type" /> is non-public and the caller does not have <see cref="T:System.Security.Permissions.ReflectionPermission" /> to reflect non-public objects outside the current assembly.</exception>
+      <exception cref="T:System.Reflection.TargetInvocationException">A class initializer is invoked and throws an exception.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.GetType(System.String,System.Boolean,System.Boolean)">
+      <summary>Gets the named type defined in the module, optionally ignoring the case of the type name. Optionally throws an exception if the type is not found.</summary>
+      <param name="className">The name of the <see cref="T:System.Type" /> to get.</param>
+      <param name="throwOnError">
+        <see langword="true" /> to throw an exception if the type cannot be found; <see langword="false" /> to return <see langword="null" />.</param>
+      <param name="ignoreCase">If <see langword="true" />, the search is case-insensitive. If <see langword="false" />, the search is case-sensitive.</param>
+      <returns>The specified type, if the type is declared in this module; otherwise, <see langword="null" />.</returns>
+      <exception cref="T:System.ArgumentException">Length of <paramref name="className" /> is zero or is greater than 1023.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="className" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.Security.SecurityException">The requested <see cref="T:System.Type" /> is non-public and the caller does not have <see cref="T:System.Security.Permissions.ReflectionPermission" /> to reflect non-public objects outside the current assembly.</exception>
+      <exception cref="T:System.Reflection.TargetInvocationException">A class initializer is invoked and throws an exception.</exception>
+      <exception cref="T:System.TypeLoadException">
+        <paramref name="throwOnError" /> is <see langword="true" /> and the specified type is not found.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.GetTypes">
+      <summary>Returns all the classes defined within this module.</summary>
+      <returns>An array that contains the types defined within the module that is reflected by this instance.</returns>
+      <exception cref="T:System.Reflection.ReflectionTypeLoadException">One or more classes in a module could not be loaded.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.IsDefined(System.Type,System.Boolean)">
+      <summary>Returns a value that indicates whether the specified attribute type has been applied to this module.</summary>
+      <param name="attributeType">The type of custom attribute to test for.</param>
+      <param name="inherit">This argument is ignored for objects of this type.</param>
+      <returns>
+        <see langword="true" /> if one or more instances of <paramref name="attributeType" /> have been applied to this module; otherwise, <see langword="false" />.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="attributeType" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="attributeType" /> is not a <see cref="T:System.Type" /> object supplied by the runtime. For example, <paramref name="attributeType" /> is a <see cref="T:System.Reflection.Emit.TypeBuilder" /> object.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.IsResource">
+      <summary>Gets a value indicating whether the object is a resource.</summary>
+      <returns>
+        <see langword="true" /> if the object is a resource; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.ModuleBuilder.MDStreamVersion">
+      <summary>Gets the metadata stream version.</summary>
+      <returns>A 32-bit integer representing the metadata stream version. The high-order two bytes represent the major version number, and the low-order two bytes represent the minor version number.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.ModuleBuilder.MetadataToken">
+      <summary>Gets a token that identifies the current dynamic module in metadata.</summary>
+      <returns>An integer token that identifies the current module in metadata.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.ModuleBuilder.ModuleVersionId">
+      <summary>Gets a universally unique identifier (UUID) that can be used to distinguish between two versions of a module.</summary>
+      <returns>A <see cref="T:System.Guid" /> that can be used to distinguish between two versions of a module.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.ModuleBuilder.Name">
+      <summary>A string that indicates that this is an in-memory module.</summary>
+      <returns>Text that indicates that this is an in-memory module.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.ResolveField(System.Int32,System.Type[],System.Type[])">
+      <summary>Returns the field identified by the specified metadata token, in the context defined by the specified generic type parameters.</summary>
+      <param name="metadataToken">A metadata token that identifies a field in the module.</param>
+      <param name="genericTypeArguments">An array of <see cref="T:System.Type" /> objects representing the generic type arguments of the type where the token is in scope, or <see langword="null" /> if that type is not generic.</param>
+      <param name="genericMethodArguments">An array of <see cref="T:System.Type" /> objects representing the generic type arguments of the method where the token is in scope, or <see langword="null" /> if that method is not generic.</param>
+      <returns>A <see cref="T:System.Reflection.FieldInfo" /> object representing the field that is identified by the specified metadata token.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="metadataToken" /> is not a token for a field in the scope of the current module.
+-or-
+<paramref name="metadataToken" /> identifies a field whose parent <see langword="TypeSpec" /> has a signature containing element type <see langword="var" /> (a type parameter of a generic type) or <see langword="mvar" /> (a type parameter of a generic method), and the necessary generic type arguments were not supplied for either or both of <paramref name="genericTypeArguments" /> and <paramref name="genericMethodArguments" />.</exception>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        <paramref name="metadataToken" /> is not a valid token in the scope of the current module.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.ResolveMember(System.Int32,System.Type[],System.Type[])">
+      <summary>Returns the type or member identified by the specified metadata token, in the context defined by the specified generic type parameters.</summary>
+      <param name="metadataToken">A metadata token that identifies a type or member in the module.</param>
+      <param name="genericTypeArguments">An array of <see cref="T:System.Type" /> objects representing the generic type arguments of the type where the token is in scope, or <see langword="null" /> if that type is not generic.</param>
+      <param name="genericMethodArguments">An array of <see cref="T:System.Type" /> objects representing the generic type arguments of the method where the token is in scope, or <see langword="null" /> if that method is not generic.</param>
+      <returns>A <see cref="T:System.Reflection.MemberInfo" /> object representing the type or member that is identified by the specified metadata token.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="metadataToken" /> is not a token for a type or member in the scope of the current module.
+-or-
+<paramref name="metadataToken" /> is a <see langword="MethodSpec" /> or <see langword="TypeSpec" /> whose signature contains element type <see langword="var" /> (a type parameter of a generic type) or <see langword="mvar" /> (a type parameter of a generic method), and the necessary generic type arguments were not supplied for either or both of <paramref name="genericTypeArguments" /> and <paramref name="genericMethodArguments" />.
+-or-
+<paramref name="metadataToken" /> identifies a property or event.</exception>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        <paramref name="metadataToken" /> is not a valid token in the scope of the current module.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.ResolveMethod(System.Int32,System.Type[],System.Type[])">
+      <summary>Returns the method or constructor identified by the specified metadata token, in the context defined by the specified generic type parameters.</summary>
+      <param name="metadataToken">A metadata token that identifies a method or constructor in the module.</param>
+      <param name="genericTypeArguments">An array of <see cref="T:System.Type" /> objects representing the generic type arguments of the type where the token is in scope, or <see langword="null" /> if that type is not generic.</param>
+      <param name="genericMethodArguments">An array of <see cref="T:System.Type" /> objects representing the generic type arguments of the method where the token is in scope, or <see langword="null" /> if that method is not generic.</param>
+      <returns>A <see cref="T:System.Reflection.MethodBase" /> object representing the method that is identified by the specified metadata token.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="metadataToken" /> is not a token for a method or constructor in the scope of the current module.
+-or-
+<paramref name="metadataToken" /> is a <see langword="MethodSpec" /> whose signature contains element type <see langword="var" /> (a type parameter of a generic type) or <see langword="mvar" /> (a type parameter of a generic method), and the necessary generic type arguments were not supplied for either or both of <paramref name="genericTypeArguments" /> and <paramref name="genericMethodArguments" />.</exception>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        <paramref name="metadataToken" /> is not a valid token in the scope of the current module.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.ResolveSignature(System.Int32)">
+      <summary>Returns the signature blob identified by a metadata token.</summary>
+      <param name="metadataToken">A metadata token that identifies a signature in the module.</param>
+      <returns>An array of bytes representing the signature blob.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="metadataToken" /> is not a valid <see langword="MemberRef" />, <see langword="MethodDef" />, <see langword="TypeSpec" />, signature, or <see langword="FieldDef" /> token in the scope of the current module.</exception>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        <paramref name="metadataToken" /> is not a valid token in the scope of the current module.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.ResolveString(System.Int32)">
+      <summary>Returns the string identified by the specified metadata token.</summary>
+      <param name="metadataToken">A metadata token that identifies a string in the string heap of the module.</param>
+      <returns>A <see cref="T:System.String" /> containing a string value from the metadata string heap.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="metadataToken" /> is not a token for a string in the scope of the current module.</exception>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        <paramref name="metadataToken" /> is not a valid token in the scope of the current module.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.ResolveType(System.Int32,System.Type[],System.Type[])">
+      <summary>Returns the type identified by the specified metadata token, in the context defined by the specified generic type parameters.</summary>
+      <param name="metadataToken">A metadata token that identifies a type in the module.</param>
+      <param name="genericTypeArguments">An array of <see cref="T:System.Type" /> objects representing the generic type arguments of the type where the token is in scope, or <see langword="null" /> if that type is not generic.</param>
+      <param name="genericMethodArguments">An array of <see cref="T:System.Type" /> objects representing the generic type arguments of the method where the token is in scope, or <see langword="null" /> if that method is not generic.</param>
+      <returns>A <see cref="T:System.Type" /> object representing the type that is identified by the specified metadata token.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="metadataToken" /> is not a token for a type in the scope of the current module.
+-or-
+<paramref name="metadataToken" /> is a <see langword="TypeSpec" /> whose signature contains element type <see langword="var" /> (a type parameter of a generic type) or <see langword="mvar" /> (a type parameter of a generic method), and the necessary generic type arguments were not supplied for either or both of <paramref name="genericTypeArguments" /> and <paramref name="genericMethodArguments" />.</exception>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        <paramref name="metadataToken" /> is not a valid token in the scope of the current module.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.ModuleBuilder.ScopeName">
+      <summary>Gets a string that represents the name of the dynamic module.</summary>
+      <returns>The name of the dynamic module.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.SetCustomAttribute(System.Reflection.ConstructorInfo,System.Byte[])">
+      <summary>Applies a custom attribute to this module by using a specified binary large object (BLOB) that represents the attribute.</summary>
+      <param name="con">The constructor for the custom attribute.</param>
+      <param name="binaryAttribute">A byte BLOB representing the attribute.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="con" /> or <paramref name="binaryAttribute" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ModuleBuilder.SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder)">
+      <summary>Applies a custom attribute to this module by using a custom attribute builder.</summary>
+      <param name="customBuilder">An instance of a helper class that specifies the custom attribute to apply.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="customBuilder" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="T:System.Reflection.Emit.PropertyBuilder">
+      <summary>Defines the properties for a type.</summary>
+    </member>
+    <member name="M:System.Reflection.Emit.PropertyBuilder.AddOtherMethod(System.Reflection.Emit.MethodBuilder)">
+      <summary>Adds one of the other methods associated with this property.</summary>
+      <param name="mdBuilder">A <see langword="MethodBuilder" /> object that represents the other method.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="mdBuilder" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> has been called on the enclosing type.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.PropertyBuilder.Attributes">
+      <summary>Gets the attributes for this property.</summary>
+      <returns>Attributes of this property.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.PropertyBuilder.CanRead">
+      <summary>Gets a value indicating whether the property can be read.</summary>
+      <returns>
+        <see langword="true" /> if this property can be read; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.PropertyBuilder.CanWrite">
+      <summary>Gets a value indicating whether the property can be written to.</summary>
+      <returns>
+        <see langword="true" /> if this property can be written to; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.PropertyBuilder.DeclaringType">
+      <summary>Gets the class that declares this member.</summary>
+      <returns>The <see langword="Type" /> object for the class that declares this member.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.PropertyBuilder.GetAccessors(System.Boolean)">
+      <summary>Returns an array of the public and non-public <see langword="get" /> and <see langword="set" /> accessors on this property.</summary>
+      <param name="nonPublic">Indicates whether non-public methods should be returned in the <see langword="MethodInfo" /> array. <see langword="true" /> if non-public methods are to be included; otherwise, <see langword="false" />.</param>
+      <returns>An array of type <see langword="MethodInfo" /> containing the matching public or non-public accessors, or an empty array if matching accessors do not exist on this property.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not supported.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.PropertyBuilder.GetCustomAttributes(System.Boolean)">
+      <summary>Returns an array of all the custom attributes for this property.</summary>
+      <param name="inherit">If <see langword="true" />, walks up this property's inheritance chain to find the custom attributes</param>
+      <returns>An array of all the custom attributes.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not supported.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.PropertyBuilder.GetCustomAttributes(System.Type,System.Boolean)">
+      <summary>Returns an array of custom attributes identified by <see cref="T:System.Type" />.</summary>
+      <param name="attributeType">An array of custom attributes identified by type.</param>
+      <param name="inherit">If <see langword="true" />, walks up this property's inheritance chain to find the custom attributes.</param>
+      <returns>An array of custom attributes defined on this reflected member, or <see langword="null" /> if no attributes are defined on this member.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not supported.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.PropertyBuilder.GetGetMethod(System.Boolean)">
+      <summary>Returns the public and non-public get accessor for this property.</summary>
+      <param name="nonPublic">Indicates whether non-public get accessors should be returned. <see langword="true" /> if non-public methods are to be included; otherwise, <see langword="false" />.</param>
+      <returns>A <see langword="MethodInfo" /> object representing the get accessor for this property, if <paramref name="nonPublic" /> is <see langword="true" />. Returns <see langword="null" /> if <paramref name="nonPublic" /> is <see langword="false" /> and the get accessor is non-public, or if <paramref name="nonPublic" /> is <see langword="true" /> but no get accessors exist.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.PropertyBuilder.GetIndexParameters">
+      <summary>Returns an array of all the index parameters for the property.</summary>
+      <returns>An array of type <see langword="ParameterInfo" /> containing the parameters for the indexes.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not supported.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.PropertyBuilder.GetSetMethod(System.Boolean)">
+      <summary>Returns the set accessor for this property.</summary>
+      <param name="nonPublic">Indicates whether the accessor should be returned if it is non-public. <see langword="true" /> if non-public methods are to be included; otherwise, <see langword="false" />.</param>
+      <returns>The property's <see langword="Set" /> method, or <see langword="null" />, as shown in the following table.
+  Value  
+  
+  Condition  
+  
+  A <see cref="T:System.Reflection.MethodInfo" /> object representing the Set method for this property.  
+  
+  The set accessor is public.  
+  
+ <paramref name="nonPublic" /> is true and non-public methods can be returned.  
+  
+  null  
+  
+ <paramref name="nonPublic" /> is true, but the property is read-only.  
+  
+ <paramref name="nonPublic" /> is false and the set accessor is non-public.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.PropertyBuilder.GetValue(System.Object,System.Object[])">
+      <summary>Gets the value of the indexed property by calling the property's getter method.</summary>
+      <param name="obj">The object whose property value will be returned.</param>
+      <param name="index">Optional index values for indexed properties. This value should be <see langword="null" /> for non-indexed properties.</param>
+      <returns>The value of the specified indexed property.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not supported.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.PropertyBuilder.GetValue(System.Object,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo)">
+      <summary>Gets the value of a property having the specified binding, index, and <see langword="CultureInfo" />.</summary>
+      <param name="obj">The object whose property value will be returned.</param>
+      <param name="invokeAttr">The invocation attribute. This must be a bit flag from <see langword="BindingFlags" /> : <see langword="InvokeMethod" />, <see langword="CreateInstance" />, <see langword="Static" />, <see langword="GetField" />, <see langword="SetField" />, <see langword="GetProperty" />, or <see langword="SetProperty" />. A suitable invocation attribute must be specified. If a static member is to be invoked, the <see langword="Static" /> flag of <see langword="BindingFlags" /> must be set.</param>
+      <param name="binder">An object that enables the binding, coercion of argument types, invocation of members, and retrieval of <see langword="MemberInfo" /> objects using reflection. If <paramref name="binder" /> is <see langword="null" />, the default binder is used.</param>
+      <param name="index">Optional index values for indexed properties. This value should be <see langword="null" /> for non-indexed properties.</param>
+      <param name="culture">The <see langword="CultureInfo" /> object that represents the culture for which the resource is to be localized. Note that if the resource is not localized for this culture, the <see langword="CultureInfo.Parent" /> method will be called successively in search of a match. If this value is <see langword="null" />, the <see langword="CultureInfo" /> is obtained from the <see langword="CultureInfo.CurrentUICulture" /> property.</param>
+      <returns>The property value for <paramref name="obj" />.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not supported.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.PropertyBuilder.IsDefined(System.Type,System.Boolean)">
+      <summary>Indicates whether one or more instance of <paramref name="attributeType" /> is defined on this property.</summary>
+      <param name="attributeType">The <see langword="Type" /> object to which the custom attributes are applied.</param>
+      <param name="inherit">Specifies whether to walk up this property's inheritance chain to find the custom attributes.</param>
+      <returns>
+        <see langword="true" /> if one or more instance of <paramref name="attributeType" /> is defined on this property; otherwise <see langword="false" />.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not supported.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.PropertyBuilder.Module">
+      <summary>Gets the module in which the type that declares the current property is being defined.</summary>
+      <returns>The <see cref="T:System.Reflection.Module" /> in which the type that declares the current property is defined.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.PropertyBuilder.Name">
+      <summary>Gets the name of this member.</summary>
+      <returns>A <see cref="T:System.String" /> containing the name of this member.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.PropertyBuilder.PropertyType">
+      <summary>Gets the type of the field of this property.</summary>
+      <returns>The type of this property.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.PropertyBuilder.ReflectedType">
+      <summary>Gets the class object that was used to obtain this instance of <see langword="MemberInfo" />.</summary>
+      <returns>The <see langword="Type" /> object through which this <see langword="MemberInfo" /> object was obtained.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.PropertyBuilder.SetConstant(System.Object)">
+      <summary>Sets the default value of this property.</summary>
+      <param name="defaultValue">The default value of this property.</param>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> has been called on the enclosing type.</exception>
+      <exception cref="T:System.ArgumentException">The property is not one of the supported types.
+-or-
+The type of <paramref name="defaultValue" /> does not match the type of the property.
+-or-
+The property is of type <see cref="T:System.Object" /> or other reference type, <paramref name="defaultValue" /> is not <see langword="null" />, and the value cannot be assigned to the reference type.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.PropertyBuilder.SetCustomAttribute(System.Reflection.ConstructorInfo,System.Byte[])">
+      <summary>Set a custom attribute using a specified custom attribute blob.</summary>
+      <param name="con">The constructor for the custom attribute.</param>
+      <param name="binaryAttribute">A byte blob representing the attributes.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="con" /> or <paramref name="binaryAttribute" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> has been called on the enclosing type.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.PropertyBuilder.SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder)">
+      <summary>Set a custom attribute using a custom attribute builder.</summary>
+      <param name="customBuilder">An instance of a helper class to define the custom attribute.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="customBuilder" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">if <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> has been called on the enclosing type.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.PropertyBuilder.SetGetMethod(System.Reflection.Emit.MethodBuilder)">
+      <summary>Sets the method that gets the property value.</summary>
+      <param name="mdBuilder">A <see langword="MethodBuilder" /> object that represents the method that gets the property value.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="mdBuilder" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> has been called on the enclosing type.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.PropertyBuilder.SetSetMethod(System.Reflection.Emit.MethodBuilder)">
+      <summary>Sets the method that sets the property value.</summary>
+      <param name="mdBuilder">A <see langword="MethodBuilder" /> object that represents the method that sets the property value.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="mdBuilder" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> has been called on the enclosing type.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.PropertyBuilder.SetValue(System.Object,System.Object,System.Object[])">
+      <summary>Sets the value of the property with optional index values for index properties.</summary>
+      <param name="obj">The object whose property value will be set.</param>
+      <param name="value">The new value for this property.</param>
+      <param name="index">Optional index values for indexed properties. This value should be <see langword="null" /> for non-indexed properties.</param>
+      <exception cref="T:System.NotSupportedException">This method is not supported.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.PropertyBuilder.SetValue(System.Object,System.Object,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo)">
+      <summary>Sets the property value for the given object to the given value.</summary>
+      <param name="obj">The object whose property value will be returned.</param>
+      <param name="value">The new value for this property.</param>
+      <param name="invokeAttr">The invocation attribute. This must be a bit flag from <see langword="BindingFlags" /> : <see langword="InvokeMethod" />, <see langword="CreateInstance" />, <see langword="Static" />, <see langword="GetField" />, <see langword="SetField" />, <see langword="GetProperty" />, or <see langword="SetProperty" />. A suitable invocation attribute must be specified. If a static member is to be invoked, the <see langword="Static" /> flag of <see langword="BindingFlags" /> must be set.</param>
+      <param name="binder">An object that enables the binding, coercion of argument types, invocation of members, and retrieval of <see langword="MemberInfo" /> objects using reflection. If <paramref name="binder" /> is <see langword="null" />, the default binder is used.</param>
+      <param name="index">Optional index values for indexed properties. This value should be <see langword="null" /> for non-indexed properties.</param>
+      <param name="culture">The <see langword="CultureInfo" /> object that represents the culture for which the resource is to be localized. Note that if the resource is not localized for this culture, the <see langword="CultureInfo.Parent" /> method will be called successively in search of a match. If this value is <see langword="null" />, the <see langword="CultureInfo" /> is obtained from the <see langword="CultureInfo.CurrentUICulture" /> property.</param>
+      <exception cref="T:System.NotSupportedException">This method is not supported.</exception>
+    </member>
+    <member name="T:System.Reflection.Emit.TypeBuilder">
+      <summary>Defines and creates new instances of classes during run time.</summary>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.AddInterfaceImplementation(System.Type)">
+      <summary>Adds an interface that this type implements.</summary>
+      <param name="interfaceType">The interface that this type implements.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="interfaceType" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.Assembly">
+      <summary>Retrieves the dynamic assembly that contains this type definition.</summary>
+      <returns>Read-only. Retrieves the dynamic assembly that contains this type definition.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.AssemblyQualifiedName">
+      <summary>Returns the full name of this type qualified by the display name of the assembly.</summary>
+      <returns>Read-only. The full name of this type qualified by the display name of the assembly.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.BaseType">
+      <summary>Retrieves the base type of this type.</summary>
+      <returns>Read-only. Retrieves the base type of this type.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.CreateType">
+      <summary>Creates a <see cref="T:System.Type" /> object for the class. After defining fields and methods on the class, <see langword="CreateType" /> is called in order to load its <see langword="Type" /> object.</summary>
+      <returns>Returns the new <see cref="T:System.Type" /> object for this class.</returns>
+      <exception cref="T:System.InvalidOperationException">The enclosing type has not been created.
+-or-
+This type is non-abstract and contains an abstract method.
+-or-
+This type is not an abstract class or an interface and has a method without a method body.</exception>
+      <exception cref="T:System.ArgumentException">Bad label content in <see cref="T:System.Reflection.Emit.ILGenerator" />: You have defined a label without calling <see cref="M:System.Reflection.Emit.ILGenerator.MarkLabel(System.Reflection.Emit.Label)" />.</exception>
+      <exception cref="T:System.NotSupportedException">The type contains invalid Microsoft intermediate language (MSIL) code.
+-or-
+The branch target is specified using a 1-byte offset, but the target is at a distance greater than 127 bytes from the branch.</exception>
+      <exception cref="T:System.TypeLoadException">The type cannot be loaded. For example, it contains a <see langword="static" /> method that has the calling convention <see cref="F:System.Reflection.CallingConventions.HasThis" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.CreateTypeInfo">
+      <summary>Gets a <see cref="T:System.Reflection.TypeInfo" /> object that represents this type.</summary>
+      <returns>An object that represents this type.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.DeclaringMethod">
+      <summary>Gets the method that declared the current generic type parameter.</summary>
+      <returns>A <see cref="T:System.Reflection.MethodBase" /> that represents the method that declared the current type, if the current type is a generic type parameter; otherwise, <see langword="null" />.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.DeclaringType">
+      <summary>Returns the type that declared this type.</summary>
+      <returns>Read-only. The type that declared this type.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineConstructor(System.Reflection.MethodAttributes,System.Reflection.CallingConventions,System.Type[])">
+      <summary>Adds a new constructor to the type, with the given attributes and signature.</summary>
+      <param name="attributes">The attributes of the constructor.</param>
+      <param name="callingConvention">The calling convention of the constructor.</param>
+      <param name="parameterTypes">The parameter types of the constructor.</param>
+      <returns>The defined constructor.</returns>
+      <exception cref="T:System.InvalidOperationException">The type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineConstructor(System.Reflection.MethodAttributes,System.Reflection.CallingConventions,System.Type[],System.Type[][],System.Type[][])">
+      <summary>Adds a new constructor to the type, with the given attributes, signature, and custom modifiers.</summary>
+      <param name="attributes">The attributes of the constructor.</param>
+      <param name="callingConvention">The calling convention of the constructor.</param>
+      <param name="parameterTypes">The parameter types of the constructor.</param>
+      <param name="requiredCustomModifiers">An array of arrays of types. Each array of types represents the required custom modifiers for the corresponding parameter, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />. If a particular parameter has no required custom modifiers, specify <see langword="null" /> instead of an array of types. If none of the parameters have required custom modifiers, specify <see langword="null" /> instead of an array of arrays.</param>
+      <param name="optionalCustomModifiers">An array of arrays of types. Each array of types represents the optional custom modifiers for the corresponding parameter, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />. If a particular parameter has no optional custom modifiers, specify <see langword="null" /> instead of an array of types. If none of the parameters have optional custom modifiers, specify <see langword="null" /> instead of an array of arrays.</param>
+      <returns>The defined constructor.</returns>
+      <exception cref="T:System.ArgumentException">The size of <paramref name="requiredCustomModifiers" /> or <paramref name="optionalCustomModifiers" /> does not equal the size of <paramref name="parameterTypes" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.
+-or-
+For the current dynamic type, the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericType" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericTypeDefinition" /> property is <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineDefaultConstructor(System.Reflection.MethodAttributes)">
+      <summary>Defines the parameterless constructor. The constructor defined here will simply call the parameterless constructor of the parent.</summary>
+      <param name="attributes">A <see langword="MethodAttributes" /> object representing the attributes to be applied to the constructor.</param>
+      <returns>Returns the constructor.</returns>
+      <exception cref="T:System.NotSupportedException">The parent type (base type) does not have a parameterless constructor.</exception>
+      <exception cref="T:System.InvalidOperationException">The type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.
+-or-
+For the current dynamic type, the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericType" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericTypeDefinition" /> property is <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineEvent(System.String,System.Reflection.EventAttributes,System.Type)">
+      <summary>Adds a new event to the type, with the given name, attributes and event type.</summary>
+      <param name="name">The name of the event. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attributes">The attributes of the event.</param>
+      <param name="eventtype">The type of the event.</param>
+      <returns>The defined event.</returns>
+      <exception cref="T:System.ArgumentException">The length of <paramref name="name" /> is zero.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.
+-or-
+<paramref name="eventtype" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineField(System.String,System.Type,System.Reflection.FieldAttributes)">
+      <summary>Adds a new field to the type, with the given name, attributes, and field type.</summary>
+      <param name="fieldName">The name of the field. <paramref name="fieldName" /> cannot contain embedded nulls.</param>
+      <param name="type">The type of the field</param>
+      <param name="attributes">The attributes of the field.</param>
+      <returns>The defined field.</returns>
+      <exception cref="T:System.ArgumentException">The length of <paramref name="fieldName" /> is zero.
+-or-
+<paramref name="type" /> is System.Void.
+-or-
+A total size was specified for the parent class of this field.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="fieldName" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineField(System.String,System.Type,System.Type[],System.Type[],System.Reflection.FieldAttributes)">
+      <summary>Adds a new field to the type, with the given name, attributes, field type, and custom modifiers.</summary>
+      <param name="fieldName">The name of the field. <paramref name="fieldName" /> cannot contain embedded nulls.</param>
+      <param name="type">The type of the field</param>
+      <param name="requiredCustomModifiers">An array of types representing the required custom modifiers for the field, such as <see cref="T:Microsoft.VisualC.IsConstModifier" />.</param>
+      <param name="optionalCustomModifiers">An array of types representing the optional custom modifiers for the field, such as <see cref="T:Microsoft.VisualC.IsConstModifier" />.</param>
+      <param name="attributes">The attributes of the field.</param>
+      <returns>The defined field.</returns>
+      <exception cref="T:System.ArgumentException">The length of <paramref name="fieldName" /> is zero.
+-or-
+<paramref name="type" /> is System.Void.
+-or-
+A total size was specified for the parent class of this field.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="fieldName" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineGenericParameters(System.String[])">
+      <summary>Defines the generic type parameters for the current type, specifying their number and their names, and returns an array of <see cref="T:System.Reflection.Emit.GenericTypeParameterBuilder" /> objects that can be used to set their constraints.</summary>
+      <param name="names">An array of names for the generic type parameters.</param>
+      <returns>An array of <see cref="T:System.Reflection.Emit.GenericTypeParameterBuilder" /> objects that can be used to define the constraints of the generic type parameters for the current type.</returns>
+      <exception cref="T:System.InvalidOperationException">Generic type parameters have already been defined for this type.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="names" /> is <see langword="null" />.
+-or-
+An element of <paramref name="names" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="names" /> is an empty array.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineInitializedData(System.String,System.Byte[],System.Reflection.FieldAttributes)">
+      <summary>Defines initialized data field in the .sdata section of the portable executable (PE) file.</summary>
+      <param name="name">The name used to refer to the data. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="data">The blob of data.</param>
+      <param name="attributes">The attributes for the field.</param>
+      <returns>A field to reference the data.</returns>
+      <exception cref="T:System.ArgumentException">Length of <paramref name="name" /> is zero.
+-or-
+The size of the data is less than or equal to zero, or greater than or equal to 0x3f0000.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> or <paramref name="data" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">
+        <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> has been previously called.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineMethod(System.String,System.Reflection.MethodAttributes)">
+      <summary>Adds a new method to the type, with the specified name and method attributes.</summary>
+      <param name="name">The name of the method. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attributes">The attributes of the method.</param>
+      <returns>A <see cref="T:System.Reflection.Emit.MethodBuilder" /> representing the newly defined method.</returns>
+      <exception cref="T:System.ArgumentException">The length of <paramref name="name" /> is zero.
+-or-
+The type of the parent of this method is an interface, and this method is not virtual (<see langword="Overridable" /> in Visual Basic).</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.
+-or-
+For the current dynamic type, the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericType" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericTypeDefinition" /> property is <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineMethod(System.String,System.Reflection.MethodAttributes,System.Reflection.CallingConventions)">
+      <summary>Adds a new method to the type, with the specified name, method attributes, and calling convention.</summary>
+      <param name="name">The name of the method. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attributes">The attributes of the method.</param>
+      <param name="callingConvention">The calling convention of the method.</param>
+      <returns>A <see cref="T:System.Reflection.Emit.MethodBuilder" /> representing the newly defined method.</returns>
+      <exception cref="T:System.ArgumentException">The length of <paramref name="name" /> is zero.
+-or-
+The type of the parent of this method is an interface and this method is not virtual (<see langword="Overridable" /> in Visual Basic).</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.
+-or-
+For the current dynamic type, the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericType" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericTypeDefinition" /> property is <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineMethod(System.String,System.Reflection.MethodAttributes,System.Reflection.CallingConventions,System.Type,System.Type[])">
+      <summary>Adds a new method to the type, with the specified name, method attributes, calling convention, and method signature.</summary>
+      <param name="name">The name of the method. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attributes">The attributes of the method.</param>
+      <param name="callingConvention">The calling convention of the method.</param>
+      <param name="returnType">The return type of the method.</param>
+      <param name="parameterTypes">The types of the parameters of the method.</param>
+      <returns>A <see cref="T:System.Reflection.Emit.MethodBuilder" /> representing the newly defined method.</returns>
+      <exception cref="T:System.ArgumentException">The length of <paramref name="name" /> is zero.
+-or-
+The type of the parent of this method is an interface, and this method is not virtual (<see langword="Overridable" /> in Visual Basic).</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.
+-or-
+For the current dynamic type, the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericType" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericTypeDefinition" /> property is <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineMethod(System.String,System.Reflection.MethodAttributes,System.Reflection.CallingConventions,System.Type,System.Type[],System.Type[],System.Type[],System.Type[][],System.Type[][])">
+      <summary>Adds a new method to the type, with the specified name, method attributes, calling convention, method signature, and custom modifiers.</summary>
+      <param name="name">The name of the method. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attributes">The attributes of the method.</param>
+      <param name="callingConvention">The calling convention of the method.</param>
+      <param name="returnType">The return type of the method.</param>
+      <param name="returnTypeRequiredCustomModifiers">An array of types representing the required custom modifiers, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />, for the return type of the method. If the return type has no required custom modifiers, specify <see langword="null" />.</param>
+      <param name="returnTypeOptionalCustomModifiers">An array of types representing the optional custom modifiers, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />, for the return type of the method. If the return type has no optional custom modifiers, specify <see langword="null" />.</param>
+      <param name="parameterTypes">The types of the parameters of the method.</param>
+      <param name="parameterTypeRequiredCustomModifiers">An array of arrays of types. Each array of types represents the required custom modifiers for the corresponding parameter, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />. If a particular parameter has no required custom modifiers, specify <see langword="null" /> instead of an array of types. If none of the parameters have required custom modifiers, specify <see langword="null" /> instead of an array of arrays.</param>
+      <param name="parameterTypeOptionalCustomModifiers">An array of arrays of types. Each array of types represents the optional custom modifiers for the corresponding parameter, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />. If a particular parameter has no optional custom modifiers, specify <see langword="null" /> instead of an array of types. If none of the parameters have optional custom modifiers, specify <see langword="null" /> instead of an array of arrays.</param>
+      <returns>A <see cref="T:System.Reflection.Emit.MethodBuilder" /> object representing the newly added method.</returns>
+      <exception cref="T:System.ArgumentException">The length of <paramref name="name" /> is zero.
+-or-
+The type of the parent of this method is an interface, and this method is not virtual (<see langword="Overridable" /> in Visual Basic).
+-or-
+The size of <paramref name="parameterTypeRequiredCustomModifiers" /> or <paramref name="parameterTypeOptionalCustomModifiers" /> does not equal the size of <paramref name="parameterTypes" />.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.
+-or-
+For the current dynamic type, the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericType" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericTypeDefinition" /> property is <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineMethod(System.String,System.Reflection.MethodAttributes,System.Type,System.Type[])">
+      <summary>Adds a new method to the type, with the specified name, method attributes, and method signature.</summary>
+      <param name="name">The name of the method. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attributes">The attributes of the method.</param>
+      <param name="returnType">The return type of the method.</param>
+      <param name="parameterTypes">The types of the parameters of the method.</param>
+      <returns>The defined method.</returns>
+      <exception cref="T:System.ArgumentException">The length of <paramref name="name" /> is zero.
+-or-
+The type of the parent of this method is an interface, and this method is not virtual (<see langword="Overridable" /> in Visual Basic).</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.
+-or-
+For the current dynamic type, the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericType" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericTypeDefinition" /> property is <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineMethodOverride(System.Reflection.MethodInfo,System.Reflection.MethodInfo)">
+      <summary>Specifies a given method body that implements a given method declaration, potentially with a different name.</summary>
+      <param name="methodInfoBody">The method body to be used. This should be a <see langword="MethodBuilder" /> object.</param>
+      <param name="methodInfoDeclaration">The method whose declaration is to be used.</param>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="methodInfoBody" /> does not belong to this class.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="methodInfoBody" /> or <paramref name="methodInfoDeclaration" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.
+-or-
+The declaring type of <paramref name="methodInfoBody" /> is not the type represented by this <see cref="T:System.Reflection.Emit.TypeBuilder" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineNestedType(System.String)">
+      <summary>Defines a nested type, given its name.</summary>
+      <param name="name">The short name of the type. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <returns>The defined nested type.</returns>
+      <exception cref="T:System.ArgumentException">Length of <paramref name="name" /> is zero or greater than 1023.
+-or-
+This operation would create a type with a duplicate <see cref="P:System.Reflection.Emit.TypeBuilder.FullName" /> in the current assembly.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineNestedType(System.String,System.Reflection.TypeAttributes)">
+      <summary>Defines a nested type, given its name and attributes.</summary>
+      <param name="name">The short name of the type. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attr">The attributes of the type.</param>
+      <returns>The defined nested type.</returns>
+      <exception cref="T:System.ArgumentException">The nested attribute is not specified.
+-or-
+This type is sealed.
+-or-
+This type is an array.
+-or-
+This type is an interface, but the nested type is not an interface.
+-or-
+The length of <paramref name="name" /> is zero or greater than 1023.
+-or-
+This operation would create a type with a duplicate <see cref="P:System.Reflection.Emit.TypeBuilder.FullName" /> in the current assembly.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineNestedType(System.String,System.Reflection.TypeAttributes,System.Type)">
+      <summary>Defines a nested type, given its name, attributes, and the type that it extends.</summary>
+      <param name="name">The short name of the type. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attr">The attributes of the type.</param>
+      <param name="parent">The type that the nested type extends.</param>
+      <returns>The defined nested type.</returns>
+      <exception cref="T:System.ArgumentException">The nested attribute is not specified.
+-or-
+This type is sealed.
+-or-
+This type is an array.
+-or-
+This type is an interface, but the nested type is not an interface.
+-or-
+The length of <paramref name="name" /> is zero or greater than 1023.
+-or-
+This operation would create a type with a duplicate <see cref="P:System.Reflection.Emit.TypeBuilder.FullName" /> in the current assembly.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineNestedType(System.String,System.Reflection.TypeAttributes,System.Type,System.Int32)">
+      <summary>Defines a nested type, given its name, attributes, the total size of the type, and the type that it extends.</summary>
+      <param name="name">The short name of the type. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attr">The attributes of the type.</param>
+      <param name="parent">The type that the nested type extends.</param>
+      <param name="typeSize">The total size of the type.</param>
+      <returns>The defined nested type.</returns>
+      <exception cref="T:System.ArgumentException">The nested attribute is not specified.
+-or-
+This type is sealed.
+-or-
+This type is an array.
+-or-
+This type is an interface, but the nested type is not an interface.
+-or-
+The length of <paramref name="name" /> is zero or greater than 1023.
+-or-
+This operation would create a type with a duplicate <see cref="P:System.Reflection.Emit.TypeBuilder.FullName" /> in the current assembly.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineNestedType(System.String,System.Reflection.TypeAttributes,System.Type,System.Reflection.Emit.PackingSize)">
+      <summary>Defines a nested type, given its name, attributes, the type that it extends, and the packing size.</summary>
+      <param name="name">The short name of the type. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attr">The attributes of the type.</param>
+      <param name="parent">The type that the nested type extends.</param>
+      <param name="packSize">The packing size of the type.</param>
+      <returns>The defined nested type.</returns>
+      <exception cref="T:System.ArgumentException">The nested attribute is not specified.
+-or-
+This type is sealed.
+-or-
+This type is an array.
+-or-
+This type is an interface, but the nested type is not an interface.
+-or-
+The length of <paramref name="name" /> is zero or greater than 1023.
+-or-
+This operation would create a type with a duplicate <see cref="P:System.Reflection.Emit.TypeBuilder.FullName" /> in the current assembly.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineNestedType(System.String,System.Reflection.TypeAttributes,System.Type,System.Reflection.Emit.PackingSize,System.Int32)">
+      <summary>Defines a nested type, given its name, attributes, size, and the type that it extends.</summary>
+      <param name="name">The short name of the type. <paramref name="name" /> cannot contain embedded null values.</param>
+      <param name="attr">The attributes of the type.</param>
+      <param name="parent">The type that the nested type extends.</param>
+      <param name="packSize">The packing size of the type.</param>
+      <param name="typeSize">The total size of the type.</param>
+      <returns>The defined nested type.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineNestedType(System.String,System.Reflection.TypeAttributes,System.Type,System.Type[])">
+      <summary>Defines a nested type, given its name, attributes, the type that it extends, and the interfaces that it implements.</summary>
+      <param name="name">The short name of the type. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attr">The attributes of the type.</param>
+      <param name="parent">The type that the nested type extends.</param>
+      <param name="interfaces">The interfaces that the nested type implements.</param>
+      <returns>The defined nested type.</returns>
+      <exception cref="T:System.ArgumentException">The nested attribute is not specified.
+-or-
+This type is sealed.
+-or-
+This type is an array.
+-or-
+This type is an interface, but the nested type is not an interface.
+-or-
+The length of <paramref name="name" /> is zero or greater than 1023.
+-or-
+This operation would create a type with a duplicate <see cref="P:System.Reflection.Emit.TypeBuilder.FullName" /> in the current assembly.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.
+-or-
+An element of the <paramref name="interfaces" /> array is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefinePInvokeMethod(System.String,System.String,System.Reflection.MethodAttributes,System.Reflection.CallingConventions,System.Type,System.Type[],System.Runtime.InteropServices.CallingConvention,System.Runtime.InteropServices.CharSet)">
+      <summary>Defines a <see langword="PInvoke" /> method given its name, the name of the DLL in which the method is defined, the attributes of the method, the calling convention of the method, the return type of the method, the types of the parameters of the method, and the <see langword="PInvoke" /> flags.</summary>
+      <param name="name">The name of the <see langword="PInvoke" /> method. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="dllName">The name of the DLL in which the <see langword="PInvoke" /> method is defined.</param>
+      <param name="attributes">The attributes of the method.</param>
+      <param name="callingConvention">The method's calling convention.</param>
+      <param name="returnType">The method's return type.</param>
+      <param name="parameterTypes">The types of the method's parameters.</param>
+      <param name="nativeCallConv">The native calling convention.</param>
+      <param name="nativeCharSet">The method's native character set.</param>
+      <returns>The defined <see langword="PInvoke" /> method.</returns>
+      <exception cref="T:System.ArgumentException">The method is not static.
+-or-
+The parent type is an interface.
+-or-
+The method is abstract.
+-or-
+The method was previously defined.
+-or-
+The length of <paramref name="name" /> or <paramref name="dllName" /> is zero.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> or <paramref name="dllName" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The containing type has been previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefinePInvokeMethod(System.String,System.String,System.String,System.Reflection.MethodAttributes,System.Reflection.CallingConventions,System.Type,System.Type[],System.Runtime.InteropServices.CallingConvention,System.Runtime.InteropServices.CharSet)">
+      <summary>Defines a <see langword="PInvoke" /> method given its name, the name of the DLL in which the method is defined, the name of the entry point, the attributes of the method, the calling convention of the method, the return type of the method, the types of the parameters of the method, and the <see langword="PInvoke" /> flags.</summary>
+      <param name="name">The name of the <see langword="PInvoke" /> method. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="dllName">The name of the DLL in which the <see langword="PInvoke" /> method is defined.</param>
+      <param name="entryName">The name of the entry point in the DLL.</param>
+      <param name="attributes">The attributes of the method.</param>
+      <param name="callingConvention">The method's calling convention.</param>
+      <param name="returnType">The method's return type.</param>
+      <param name="parameterTypes">The types of the method's parameters.</param>
+      <param name="nativeCallConv">The native calling convention.</param>
+      <param name="nativeCharSet">The method's native character set.</param>
+      <returns>The defined <see langword="PInvoke" /> method.</returns>
+      <exception cref="T:System.ArgumentException">The method is not static.
+-or-
+The parent type is an interface.
+-or-
+The method is abstract.
+-or-
+The method was previously defined.
+-or-
+The length of <paramref name="name" />, <paramref name="dllName" />, or <paramref name="entryName" /> is zero.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" />, <paramref name="dllName" />, or <paramref name="entryName" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The containing type has been previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefinePInvokeMethod(System.String,System.String,System.Type[][],System.Runtime.InteropServices.CallingConvention,System.Runtime.InteropServices.CharSet,System.String,System.Reflection.MethodAttributes,System.Reflection.CallingConventions,System.Type,System.Type[],System.Type[],System.Type[],System.Type[][])">
+      <summary>Defines a <see langword="PInvoke" /> method given its name, the name of the DLL in which the method is defined, the name of the entry point, the attributes of the method, the calling convention of the method, the return type of the method, the types of the parameters of the method, the <see langword="PInvoke" /> flags, and custom modifiers for the parameters and return type.</summary>
+      <param name="name">The name of the <see langword="PInvoke" /> method. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="dllName">The name of the DLL in which the <see langword="PInvoke" /> method is defined.</param>
+      <param name="parameterTypeOptionalCustomModifiers">An array of arrays of types. Each array of types represents the optional custom modifiers for the corresponding parameter, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />. If a particular parameter has no optional custom modifiers, specify <see langword="null" /> instead of an array of types. If none of the parameters have optional custom modifiers, specify <see langword="null" /> instead of an array of arrays.</param>
+      <param name="nativeCallConv">The native calling convention.</param>
+      <param name="nativeCharSet">The method's native character set.</param>
+      <param name="entryName">The name of the entry point in the DLL.</param>
+      <param name="attributes">The attributes of the method.</param>
+      <param name="callingConvention">The method's calling convention.</param>
+      <param name="returnType">The method's return type.</param>
+      <param name="returnTypeRequiredCustomModifiers">An array of types representing the required custom modifiers, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />, for the return type of the method. If the return type has no required custom modifiers, specify <see langword="null" />.</param>
+      <param name="returnTypeOptionalCustomModifiers">An array of types representing the optional custom modifiers, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />, for the return type of the method. If the return type has no optional custom modifiers, specify <see langword="null" />.</param>
+      <param name="parameterTypes">The types of the method's parameters.</param>
+      <param name="parameterTypeRequiredCustomModifiers">An array of arrays of types. Each array of types represents the required custom modifiers for the corresponding parameter, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />. If a particular parameter has no required custom modifiers, specify <see langword="null" /> instead of an array of types. If none of the parameters have required custom modifiers, specify <see langword="null" /> instead of an array of arrays.</param>
+      <returns>A <see cref="T:System.Reflection.Emit.MethodBuilder" /> representing the defined <see langword="PInvoke" /> method.</returns>
+      <exception cref="T:System.ArgumentException">The method is not static.
+-or-
+The parent type is an interface.
+-or-
+The method is abstract.
+-or-
+The method was previously defined.
+-or-
+The length of <paramref name="name" />, <paramref name="dllName" />, or <paramref name="entryName" /> is zero.
+-or-
+The size of <paramref name="parameterTypeRequiredCustomModifiers" /> or <paramref name="parameterTypeOptionalCustomModifiers" /> does not equal the size of <paramref name="parameterTypes" />.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" />, <paramref name="dllName" />, or <paramref name="entryName" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.
+-or-
+For the current dynamic type, the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericType" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericTypeDefinition" /> property is <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineProperty(System.String,System.Reflection.PropertyAttributes,System.Reflection.CallingConventions,System.Type,System.Type[])">
+      <summary>Adds a new property to the type, with the given name, attributes, calling convention, and property signature.</summary>
+      <param name="name">The name of the property. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attributes">The attributes of the property.</param>
+      <param name="callingConvention">The calling convention of the property accessors.</param>
+      <param name="returnType">The return type of the property.</param>
+      <param name="parameterTypes">The types of the parameters of the property.</param>
+      <returns>The defined property.</returns>
+      <exception cref="T:System.ArgumentException">The length of <paramref name="name" /> is zero.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.
+-or-
+Any of the elements of the <paramref name="parameterTypes" /> array is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineProperty(System.String,System.Reflection.PropertyAttributes,System.Reflection.CallingConventions,System.Type,System.Type[],System.Type[],System.Type[],System.Type[][],System.Type[][])">
+      <summary>Adds a new property to the type, with the given name, calling convention, property signature, and custom modifiers.</summary>
+      <param name="name">The name of the property. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attributes">The attributes of the property.</param>
+      <param name="callingConvention">The calling convention of the property accessors.</param>
+      <param name="returnType">The return type of the property.</param>
+      <param name="returnTypeRequiredCustomModifiers">An array of types representing the required custom modifiers, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />, for the return type of the property. If the return type has no required custom modifiers, specify <see langword="null" />.</param>
+      <param name="returnTypeOptionalCustomModifiers">An array of types representing the optional custom modifiers, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />, for the return type of the property. If the return type has no optional custom modifiers, specify <see langword="null" />.</param>
+      <param name="parameterTypes">The types of the parameters of the property.</param>
+      <param name="parameterTypeRequiredCustomModifiers">An array of arrays of types. Each array of types represents the required custom modifiers for the corresponding parameter, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />. If a particular parameter has no required custom modifiers, specify <see langword="null" /> instead of an array of types. If none of the parameters have required custom modifiers, specify <see langword="null" /> instead of an array of arrays.</param>
+      <param name="parameterTypeOptionalCustomModifiers">An array of arrays of types. Each array of types represents the optional custom modifiers for the corresponding parameter, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />. If a particular parameter has no optional custom modifiers, specify <see langword="null" /> instead of an array of types. If none of the parameters have optional custom modifiers, specify <see langword="null" /> instead of an array of arrays.</param>
+      <returns>The defined property.</returns>
+      <exception cref="T:System.ArgumentException">The length of <paramref name="name" /> is zero.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.
+-or-
+Any of the elements of the <paramref name="parameterTypes" /> array is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineProperty(System.String,System.Reflection.PropertyAttributes,System.Type,System.Type[])">
+      <summary>Adds a new property to the type, with the given name and property signature.</summary>
+      <param name="name">The name of the property. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attributes">The attributes of the property.</param>
+      <param name="returnType">The return type of the property.</param>
+      <param name="parameterTypes">The types of the parameters of the property.</param>
+      <returns>The defined property.</returns>
+      <exception cref="T:System.ArgumentException">The length of <paramref name="name" /> is zero.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.
+-or-
+Any of the elements of the <paramref name="parameterTypes" /> array is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineProperty(System.String,System.Reflection.PropertyAttributes,System.Type,System.Type[],System.Type[],System.Type[],System.Type[][],System.Type[][])">
+      <summary>Adds a new property to the type, with the given name, property signature, and custom modifiers.</summary>
+      <param name="name">The name of the property. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="attributes">The attributes of the property.</param>
+      <param name="returnType">The return type of the property.</param>
+      <param name="returnTypeRequiredCustomModifiers">An array of types representing the required custom modifiers, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />, for the return type of the property. If the return type has no required custom modifiers, specify <see langword="null" />.</param>
+      <param name="returnTypeOptionalCustomModifiers">An array of types representing the optional custom modifiers, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />, for the return type of the property. If the return type has no optional custom modifiers, specify <see langword="null" />.</param>
+      <param name="parameterTypes">The types of the parameters of the property.</param>
+      <param name="parameterTypeRequiredCustomModifiers">An array of arrays of types. Each array of types represents the required custom modifiers for the corresponding parameter, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />. If a particular parameter has no required custom modifiers, specify <see langword="null" /> instead of an array of types. If none of the parameters have required custom modifiers, specify <see langword="null" /> instead of an array of arrays.</param>
+      <param name="parameterTypeOptionalCustomModifiers">An array of arrays of types. Each array of types represents the optional custom modifiers for the corresponding parameter, such as <see cref="T:System.Runtime.CompilerServices.IsConst" />. If a particular parameter has no optional custom modifiers, specify <see langword="null" /> instead of an array of types. If none of the parameters have optional custom modifiers, specify <see langword="null" /> instead of an array of arrays.</param>
+      <returns>The defined property.</returns>
+      <exception cref="T:System.ArgumentException">The length of <paramref name="name" /> is zero.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />
+-or-
+Any of the elements of the <paramref name="parameterTypes" /> array is <see langword="null" /></exception>
+      <exception cref="T:System.InvalidOperationException">The type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineTypeInitializer">
+      <summary>Defines the initializer for this type.</summary>
+      <returns>Returns a type initializer.</returns>
+      <exception cref="T:System.InvalidOperationException">The containing type has been previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.DefineUninitializedData(System.String,System.Int32,System.Reflection.FieldAttributes)">
+      <summary>Defines an uninitialized data field in the <see langword=".sdata" /> section of the portable executable (PE) file.</summary>
+      <param name="name">The name used to refer to the data. <paramref name="name" /> cannot contain embedded nulls.</param>
+      <param name="size">The size of the data field.</param>
+      <param name="attributes">The attributes for the field.</param>
+      <returns>A field to reference the data.</returns>
+      <exception cref="T:System.ArgumentException">Length of <paramref name="name" /> is zero.
+-or-
+<paramref name="size" /> is less than or equal to zero, or greater than or equal to 0x003f0000.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.FullName">
+      <summary>Retrieves the full path of this type.</summary>
+      <returns>Read-only. Retrieves the full path of this type.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.GenericParameterAttributes">
+      <summary>Gets a value that indicates the covariance and special constraints of the current generic type parameter.</summary>
+      <returns>A bitwise combination of <see cref="T:System.Reflection.GenericParameterAttributes" /> values that describes the covariance and special constraints of the current generic type parameter.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.GenericParameterPosition">
+      <summary>Gets the position of a type parameter in the type parameter list of the generic type that declared the parameter.</summary>
+      <returns>If the current <see cref="T:System.Reflection.Emit.TypeBuilder" /> object represents a generic type parameter, the position of the type parameter in the type parameter list of the generic type that declared the parameter; otherwise, undefined.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetConstructor(System.Type,System.Reflection.ConstructorInfo)">
+      <summary>Returns the constructor of the specified constructed generic type that corresponds to the specified constructor of the generic type definition.</summary>
+      <param name="type">The constructed generic type whose constructor is returned.</param>
+      <param name="constructor">A constructor on the generic type definition of <paramref name="type" />, which specifies which constructor of <paramref name="type" /> to return.</param>
+      <returns>A <see cref="T:System.Reflection.ConstructorInfo" /> object that represents the constructor of <paramref name="type" /> corresponding to <paramref name="constructor" />, which specifies a constructor belonging to the generic type definition of <paramref name="type" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="type" /> does not represent a generic type.
+-or-
+<paramref name="type" /> is not of type <see cref="T:System.Reflection.Emit.TypeBuilder" />.
+-or-
+The declaring type of <paramref name="constructor" /> is not a generic type definition.
+-or-
+The declaring type of <paramref name="constructor" /> is not the generic type definition of <paramref name="type" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetConstructors(System.Reflection.BindingFlags)">
+      <summary>Returns an array of <see cref="T:System.Reflection.ConstructorInfo" /> objects representing the public and non-public constructors defined for this class, as specified.</summary>
+      <param name="bindingAttr">This must be a bit flag from <see cref="T:System.Reflection.BindingFlags" /> as in <see langword="InvokeMethod" />, <see langword="NonPublic" />, and so on.</param>
+      <returns>Returns an array of <see cref="T:System.Reflection.ConstructorInfo" /> objects representing the specified constructors defined for this class. If no constructors are defined, an empty array is returned.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not implemented for incomplete types.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetCustomAttributes(System.Boolean)">
+      <summary>Returns all the custom attributes defined for this type.</summary>
+      <param name="inherit">Specifies whether to search this member's inheritance chain to find the attributes.</param>
+      <returns>Returns an array of objects representing all the custom attributes of this type.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported for incomplete types. Retrieve the type using <see cref="M:System.Type.GetType" /> and call <see cref="M:System.Reflection.MemberInfo.GetCustomAttributes(System.Boolean)" /> on the returned <see cref="T:System.Type" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetCustomAttributes(System.Type,System.Boolean)">
+      <summary>Returns all the custom attributes of the current type that are assignable to a specified type.</summary>
+      <param name="attributeType">The type of attribute to search for. Only attributes that are assignable to this type are returned.</param>
+      <param name="inherit">Specifies whether to search this member's inheritance chain to find the attributes.</param>
+      <returns>An array of custom attributes defined on the current type.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported for incomplete types. Retrieve the type using <see cref="M:System.Type.GetType" /> and call <see cref="M:System.Reflection.MemberInfo.GetCustomAttributes(System.Boolean)" /> on the returned <see cref="T:System.Type" />.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="attributeType" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">The type must be a type provided by the underlying runtime system.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetElementType">
+      <summary>Calling this method always throws <see cref="T:System.NotSupportedException" />.</summary>
+      <returns>This method is not supported. No value is returned.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not supported.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetEvent(System.String,System.Reflection.BindingFlags)">
+      <summary>Returns the event with the specified name.</summary>
+      <param name="name">The name of the event to search for.</param>
+      <param name="bindingAttr">A bitwise combination of <see cref="T:System.Reflection.BindingFlags" /> values that limits the search.</param>
+      <returns>An <see cref="T:System.Reflection.EventInfo" /> object representing the event declared or inherited by this type with the specified name, or <see langword="null" /> if there are no matches.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not implemented for incomplete types.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetEvents">
+      <summary>Returns the public events declared or inherited by this type.</summary>
+      <returns>Returns an array of <see cref="T:System.Reflection.EventInfo" /> objects representing the public events declared or inherited by this type. An empty array is returned if there are no public events.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not implemented for incomplete types.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetEvents(System.Reflection.BindingFlags)">
+      <summary>Returns the public and non-public events that are declared by this type.</summary>
+      <param name="bindingAttr">A bitwise combination of <see cref="T:System.Reflection.BindingFlags" /> values that limits the search.</param>
+      <returns>Returns an array of <see cref="T:System.Reflection.EventInfo" /> objects representing the events declared or inherited by this type that match the specified binding flags. An empty array is returned if there are no matching events.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not implemented for incomplete types.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetField(System.String,System.Reflection.BindingFlags)">
+      <summary>Returns the field specified by the given name.</summary>
+      <param name="name">The name of the field to get.</param>
+      <param name="bindingAttr">This must be a bit flag from <see cref="T:System.Reflection.BindingFlags" /> as in <see langword="InvokeMethod" />, <see langword="NonPublic" />, and so on.</param>
+      <returns>Returns the <see cref="T:System.Reflection.FieldInfo" /> object representing the field declared or inherited by this type with the specified name and public or non-public modifier. If there are no matches then <see langword="null" /> is returned.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not implemented for incomplete types.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetField(System.Type,System.Reflection.FieldInfo)">
+      <summary>Returns the field of the specified constructed generic type that corresponds to the specified field of the generic type definition.</summary>
+      <param name="type">The constructed generic type whose field is returned.</param>
+      <param name="field">A field on the generic type definition of <paramref name="type" />, which specifies which field of <paramref name="type" /> to return.</param>
+      <returns>A <see cref="T:System.Reflection.FieldInfo" /> object that represents the field of <paramref name="type" /> corresponding to <paramref name="field" />, which specifies a field belonging to the generic type definition of <paramref name="type" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="type" /> does not represent a generic type.
+-or-
+<paramref name="type" /> is not of type <see cref="T:System.Reflection.Emit.TypeBuilder" />.
+-or-
+The declaring type of <paramref name="field" /> is not a generic type definition.
+-or-
+The declaring type of <paramref name="field" /> is not the generic type definition of <paramref name="type" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetFields(System.Reflection.BindingFlags)">
+      <summary>Returns the public and non-public fields that are declared by this type.</summary>
+      <param name="bindingAttr">This must be a bit flag from <see cref="T:System.Reflection.BindingFlags" /> : <see langword="InvokeMethod" />, <see langword="NonPublic" />, and so on.</param>
+      <returns>Returns an array of <see cref="T:System.Reflection.FieldInfo" /> objects representing the public and non-public fields declared or inherited by this type. An empty array is returned if there are no fields, as specified.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not implemented for incomplete types.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetGenericArguments">
+      <summary>Returns an array of <see cref="T:System.Type" /> objects representing the type arguments of a generic type or the type parameters of a generic type definition.</summary>
+      <returns>An array of <see cref="T:System.Type" /> objects. The elements of the array represent the type arguments of a generic type or the type parameters of a generic type definition.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetGenericTypeDefinition">
+      <summary>Returns a <see cref="T:System.Type" /> object that represents a generic type definition from which the current type can be obtained.</summary>
+      <returns>A <see cref="T:System.Type" /> object representing a generic type definition from which the current type can be obtained.</returns>
+      <exception cref="T:System.InvalidOperationException">The current type is not generic. That is, <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericType" /> returns <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetInterface(System.String,System.Boolean)">
+      <summary>Returns the interface implemented (directly or indirectly) by this class with the fully qualified name matching the given interface name.</summary>
+      <param name="name">The name of the interface.</param>
+      <param name="ignoreCase">If <see langword="true" />, the search is case-insensitive. If <see langword="false" />, the search is case-sensitive.</param>
+      <returns>Returns a <see cref="T:System.Type" /> object representing the implemented interface. Returns null if no interface matching name is found.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not implemented for incomplete types.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetInterfaceMap(System.Type)">
+      <summary>Returns an interface mapping for the requested interface.</summary>
+      <param name="interfaceType">The <see cref="T:System.Type" /> of the interface for which the mapping is to be retrieved.</param>
+      <returns>Returns the requested interface mapping.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not implemented for incomplete types.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetInterfaces">
+      <summary>Returns an array of all the interfaces implemented on this type and its base types.</summary>
+      <returns>Returns an array of <see cref="T:System.Type" /> objects representing the implemented interfaces. If none are defined, an empty array is returned.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetMember(System.String,System.Reflection.MemberTypes,System.Reflection.BindingFlags)">
+      <summary>Returns all the public and non-public members declared or inherited by this type, as specified.</summary>
+      <param name="name">The name of the member.</param>
+      <param name="type">The type of the member to return.</param>
+      <param name="bindingAttr">This must be a bit flag from <see cref="T:System.Reflection.BindingFlags" />, as in <see langword="InvokeMethod" />, <see langword="NonPublic" />, and so on.</param>
+      <returns>Returns an array of <see cref="T:System.Reflection.MemberInfo" /> objects representing the public and non-public members defined on this type if <paramref name="nonPublic" /> is used; otherwise, only the public members are returned.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not implemented for incomplete types.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetMembers(System.Reflection.BindingFlags)">
+      <summary>Returns the members for the public and non-public members declared or inherited by this type.</summary>
+      <param name="bindingAttr">This must be a bit flag from <see cref="T:System.Reflection.BindingFlags" />, such as <see langword="InvokeMethod" />, <see langword="NonPublic" />, and so on.</param>
+      <returns>Returns an array of <see cref="T:System.Reflection.MemberInfo" /> objects representing the public and non-public members declared or inherited by this type. An empty array is returned if there are no matching members.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not implemented for incomplete types.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetMethod(System.Type,System.Reflection.MethodInfo)">
+      <summary>Returns the method of the specified constructed generic type that corresponds to the specified method of the generic type definition.</summary>
+      <param name="type">The constructed generic type whose method is returned.</param>
+      <param name="method">A method on the generic type definition of <paramref name="type" />, which specifies which method of <paramref name="type" /> to return.</param>
+      <returns>A <see cref="T:System.Reflection.MethodInfo" /> object that represents the method of <paramref name="type" /> corresponding to <paramref name="method" />, which specifies a method belonging to the generic type definition of <paramref name="type" />.</returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="method" /> is a generic method that is not a generic method definition.
+-or-
+<paramref name="type" /> does not represent a generic type.
+-or-
+<paramref name="type" /> is not of type <see cref="T:System.Reflection.Emit.TypeBuilder" />.
+-or-
+The declaring type of <paramref name="method" /> is not a generic type definition.
+-or-
+The declaring type of <paramref name="method" /> is not the generic type definition of <paramref name="type" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetMethods(System.Reflection.BindingFlags)">
+      <summary>Returns all the public and non-public methods declared or inherited by this type, as specified.</summary>
+      <param name="bindingAttr">This must be a bit flag from <see cref="T:System.Reflection.BindingFlags" /> as in <see langword="InvokeMethod" />, <see langword="NonPublic" />, and so on.</param>
+      <returns>Returns an array of <see cref="T:System.Reflection.MethodInfo" /> objects representing the public and non-public methods defined on this type if <paramref name="nonPublic" /> is used; otherwise, only the public methods are returned.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not implemented for incomplete types.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetNestedType(System.String,System.Reflection.BindingFlags)">
+      <summary>Returns the public and non-public nested types that are declared by this type.</summary>
+      <param name="name">The <see cref="T:System.String" /> containing the name of the nested type to get.</param>
+      <param name="bindingAttr">A bitmask comprised of one or more <see cref="T:System.Reflection.BindingFlags" /> that specify how the search is conducted.
+-or-
+Zero, to conduct a case-sensitive search for public methods.</param>
+      <returns>A <see cref="T:System.Type" /> object representing the nested type that matches the specified requirements, if found; otherwise, <see langword="null" />.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not implemented for incomplete types.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetNestedTypes(System.Reflection.BindingFlags)">
+      <summary>Returns the public and non-public nested types that are declared or inherited by this type.</summary>
+      <param name="bindingAttr">This must be a bit flag from <see cref="T:System.Reflection.BindingFlags" />, as in <see langword="InvokeMethod" />, <see langword="NonPublic" />, and so on.</param>
+      <returns>An array of <see cref="T:System.Type" /> objects representing all the types nested within the current <see cref="T:System.Type" /> that match the specified binding constraints.
+An empty array of type <see cref="T:System.Type" />, if no types are nested within the current <see cref="T:System.Type" />, or if none of the nested types match the binding constraints.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not implemented for incomplete types.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.GetProperties(System.Reflection.BindingFlags)">
+      <summary>Returns all the public and non-public properties declared or inherited by this type, as specified.</summary>
+      <param name="bindingAttr">This invocation attribute. This must be a bit flag from <see cref="T:System.Reflection.BindingFlags" /> : <see langword="InvokeMethod" />, <see langword="NonPublic" />, and so on.</param>
+      <returns>Returns an array of <see langword="PropertyInfo" /> objects representing the public and non-public properties defined on this type if <paramref name="nonPublic" /> is used; otherwise, only the public properties are returned.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not implemented for incomplete types.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.GUID">
+      <summary>Retrieves the GUID of this type.</summary>
+      <returns>Read-only. Retrieves the GUID of this type</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported for incomplete types.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.InvokeMember(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object,System.Object[],System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[])">
+      <summary>Invokes the specified member. The method that is to be invoked must be accessible and provide the most specific match with the specified argument list, under the constraints of the specified binder and invocation attributes.</summary>
+      <param name="name">The name of the member to invoke. This can be a constructor, method, property, or field. A suitable invocation attribute must be specified. Note that it is possible to invoke the default member of a class by passing an empty string as the name of the member.</param>
+      <param name="invokeAttr">The invocation attribute. This must be a bit flag from <see langword="BindingFlags" />.</param>
+      <param name="binder">An object that enables the binding, coercion of argument types, invocation of members, and retrieval of <see langword="MemberInfo" /> objects using reflection. If binder is <see langword="null" />, the default binder is used. See <see cref="T:System.Reflection.Binder" />.</param>
+      <param name="target">The object on which to invoke the specified member. If the member is static, this parameter is ignored.</param>
+      <param name="args">An argument list. This is an array of Objects that contains the number, order, and type of the parameters of the member to be invoked. If there are no parameters this should be null.</param>
+      <param name="modifiers">An array of the same length as <paramref name="args" /> with elements that represent the attributes associated with the arguments of the member to be invoked. A parameter has attributes associated with it in the metadata. They are used by various interoperability services. See the metadata specs for more details.</param>
+      <param name="culture">An instance of <see langword="CultureInfo" /> used to govern the coercion of types. If this is null, the <see langword="CultureInfo" /> for the current thread is used. (Note that this is necessary to, for example, convert a String that represents 1000 to a Double value, since 1000 is represented differently by different cultures.)</param>
+      <param name="namedParameters">Each parameter in the <paramref name="namedParameters" /> array gets the value in the corresponding element in the <paramref name="args" /> array. If the length of <paramref name="args" /> is greater than the length of <paramref name="namedParameters" />, the remaining argument values are passed in order.</param>
+      <returns>Returns the return value of the invoked member.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported for incomplete types.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.IsAssignableFrom(System.Type)">
+      <summary>Gets a value that indicates whether a specified <see cref="T:System.Type" /> can be assigned to this object.</summary>
+      <param name="c">The object to test.</param>
+      <returns>
+        <see langword="true" /> if the <paramref name="c" /> parameter and the current type represent the same type, or if the current type is in the inheritance hierarchy of <paramref name="c" />, or if the current type is an interface that <paramref name="c" /> supports. <see langword="false" /> if none of these conditions are valid, or if <paramref name="c" /> is <see langword="null" />.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.IsByRefLike" />
+    <member name="P:System.Reflection.Emit.TypeBuilder.IsConstructedGenericType">
+      <summary>Gets a value that indicates whether this object represents a constructed generic type.</summary>
+      <returns>
+        <see langword="true" /> if this object represents a constructed generic type; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.IsCreated">
+      <summary>Returns a value that indicates whether the current dynamic type has been created.</summary>
+      <returns>
+        <see langword="true" /> if the <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> method has been called; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.IsDefined(System.Type,System.Boolean)">
+      <summary>Determines whether a custom attribute is applied to the current type.</summary>
+      <param name="attributeType">The type of attribute to search for. Only attributes that are assignable to this type are returned.</param>
+      <param name="inherit">Specifies whether to search this member's inheritance chain to find the attributes.</param>
+      <returns>
+        <see langword="true" /> if one or more instances of <paramref name="attributeType" />, or an attribute derived from <paramref name="attributeType" />, is defined on this type; otherwise, <see langword="false" />.</returns>
+      <exception cref="T:System.NotSupportedException">This method is not currently supported for incomplete types. Retrieve the type using <see cref="M:System.Type.GetType" /> and call <see cref="M:System.Reflection.MemberInfo.IsDefined(System.Type,System.Boolean)" /> on the returned <see cref="T:System.Type" />.</exception>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="attributeType" /> is not defined.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="attributeType" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.IsGenericParameter">
+      <summary>Gets a value indicating whether the current type is a generic type parameter.</summary>
+      <returns>
+        <see langword="true" /> if the current <see cref="T:System.Reflection.Emit.TypeBuilder" /> object represents a generic type parameter; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.IsGenericType">
+      <summary>Gets a value indicating whether the current type is a generic type.</summary>
+      <returns>
+        <see langword="true" /> if the type represented by the current <see cref="T:System.Reflection.Emit.TypeBuilder" /> object is generic; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.IsGenericTypeDefinition">
+      <summary>Gets a value indicating whether the current <see cref="T:System.Reflection.Emit.TypeBuilder" /> represents a generic type definition from which other generic types can be constructed.</summary>
+      <returns>
+        <see langword="true" /> if this <see cref="T:System.Reflection.Emit.TypeBuilder" /> object represents a generic type definition; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.IsSecurityCritical">
+      <summary>Gets a value that indicates whether the current type is security-critical or security-safe-critical, and therefore can perform critical operations.</summary>
+      <returns>
+        <see langword="true" /> if the current type is security-critical or security-safe-critical; <see langword="false" /> if it is transparent.</returns>
+      <exception cref="T:System.NotSupportedException">The current dynamic type has not been created by calling the <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> method.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.IsSecuritySafeCritical">
+      <summary>Gets a value that indicates whether the current type is security-safe-critical; that is, whether it can perform critical operations and can be accessed by transparent code.</summary>
+      <returns>
+        <see langword="true" /> if the current type is security-safe-critical; <see langword="false" /> if it is security-critical or transparent.</returns>
+      <exception cref="T:System.NotSupportedException">The current dynamic type has not been created by calling the <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> method.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.IsSecurityTransparent">
+      <summary>Gets a value that indicates whether the current type is transparent, and therefore cannot perform critical operations.</summary>
+      <returns>
+        <see langword="true" /> if the type is security-transparent; otherwise, <see langword="false" />.</returns>
+      <exception cref="T:System.NotSupportedException">The current dynamic type has not been created by calling the <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> method.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.IsSubclassOf(System.Type)">
+      <summary>Determines whether this type is derived from a specified type.</summary>
+      <param name="c">A <see cref="T:System.Type" /> that is to be checked.</param>
+      <returns>Read-only. Returns <see langword="true" /> if this type is the same as the type <paramref name="c" />, or is a subtype of type <paramref name="c" />; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.IsSZArray" />
+    <member name="P:System.Reflection.Emit.TypeBuilder.IsTypeDefinition" />
+    <member name="P:System.Reflection.Emit.TypeBuilder.IsVariableBoundArray" />
+    <member name="M:System.Reflection.Emit.TypeBuilder.MakeArrayType">
+      <summary>Returns a <see cref="T:System.Type" /> object that represents a one-dimensional array of the current type, with a lower bound of zero.</summary>
+      <returns>A <see cref="T:System.Type" /> object representing a one-dimensional array type whose element type is the current type, with a lower bound of zero.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.MakeArrayType(System.Int32)">
+      <summary>Returns a <see cref="T:System.Type" /> object that represents an array of the current type, with the specified number of dimensions.</summary>
+      <param name="rank">The number of dimensions for the array.</param>
+      <returns>A <see cref="T:System.Type" /> object that represents a one-dimensional array of the current type.</returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        <paramref name="rank" /> is not a valid array dimension.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.MakeByRefType">
+      <summary>Returns a <see cref="T:System.Type" /> object that represents the current type when passed as a <see langword="ref" /> parameter (<see langword="ByRef" /> in Visual Basic).</summary>
+      <returns>A <see cref="T:System.Type" /> object that represents the current type when passed as a <see langword="ref" /> parameter (<see langword="ByRef" /> in Visual Basic).</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.MakeGenericType(System.Type[])">
+      <summary>Substitutes the elements of an array of types for the type parameters of the current generic type definition, and returns the resulting constructed type.</summary>
+      <param name="typeArguments">An array of types to be substituted for the type parameters of the current generic type definition.</param>
+      <returns>A <see cref="T:System.Type" /> representing the constructed type formed by substituting the elements of <paramref name="typeArguments" /> for the type parameters of the current generic type.</returns>
+      <exception cref="T:System.InvalidOperationException">The current type does not represent the definition of a generic type. That is, <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericTypeDefinition" /> returns <see langword="false" />.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="typeArguments" /> is <see langword="null" />.
+-or-
+Any element of <paramref name="typeArguments" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">The <see cref="P:System.Type.Module" /> property of any element of <paramref name="typeArguments" /> is <see langword="null" />.
+-or-
+The <see cref="P:System.Reflection.Module.Assembly" /> property of the module of any element of <paramref name="typeArguments" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.MakePointerType">
+      <summary>Returns a <see cref="T:System.Type" /> object that represents the type of an unmanaged pointer to the current type.</summary>
+      <returns>A <see cref="T:System.Type" /> object that represents the type of an unmanaged pointer to the current type.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.Module">
+      <summary>Retrieves the dynamic module that contains this type definition.</summary>
+      <returns>Read-only. Retrieves the dynamic module that contains this type definition.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.Name">
+      <summary>Retrieves the name of this type.</summary>
+      <returns>Read-only. Retrieves the <see cref="T:System.String" /> name of this type.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.Namespace">
+      <summary>Retrieves the namespace where this <see langword="TypeBuilder" /> is defined.</summary>
+      <returns>Read-only. Retrieves the namespace where this <see langword="TypeBuilder" /> is defined.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.PackingSize">
+      <summary>Retrieves the packing size of this type.</summary>
+      <returns>Read-only. Retrieves the packing size of this type.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.ReflectedType">
+      <summary>Returns the type that was used to obtain this type.</summary>
+      <returns>Read-only. The type that was used to obtain this type.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.SetCustomAttribute(System.Reflection.ConstructorInfo,System.Byte[])">
+      <summary>Sets a custom attribute using a specified custom attribute blob.</summary>
+      <param name="con">The constructor for the custom attribute.</param>
+      <param name="binaryAttribute">A byte blob representing the attributes.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="con" /> or <paramref name="binaryAttribute" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">For the current dynamic type, the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericType" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericTypeDefinition" /> property is <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder)">
+      <summary>Set a custom attribute using a custom attribute builder.</summary>
+      <param name="customBuilder">An instance of a helper class to define the custom attribute.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="customBuilder" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">For the current dynamic type, the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericType" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericTypeDefinition" /> property is <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.SetParent(System.Type)">
+      <summary>Sets the base type of the type currently under construction.</summary>
+      <param name="parent">The new base type.</param>
+      <exception cref="T:System.InvalidOperationException">The type was previously created using <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" />.
+-or-
+<paramref name="parent" /> is <see langword="null" />, and the current instance represents an interface whose attributes do not include <see cref="F:System.Reflection.TypeAttributes.Abstract" />.
+-or-
+For the current dynamic type, the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericType" /> property is <see langword="true" />, but the <see cref="P:System.Reflection.Emit.TypeBuilder.IsGenericTypeDefinition" /> property is <see langword="false" />.</exception>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="parent" /> is an interface. This exception condition is new in the .NET Framework version 2.0.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.Size">
+      <summary>Retrieves the total size of a type.</summary>
+      <returns>Read-only. Retrieves this type's total size.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.TypeBuilder.ToString">
+      <summary>Returns the name of the type excluding the namespace.</summary>
+      <returns>Read-only. The name of the type excluding the namespace.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.TypeHandle">
+      <summary>Not supported in dynamic modules.</summary>
+      <returns>Read-only.</returns>
+      <exception cref="T:System.NotSupportedException">Not supported in dynamic modules.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.TypeBuilder.UnderlyingSystemType">
+      <summary>Returns the underlying system type for this <see langword="TypeBuilder" />.</summary>
+      <returns>Read-only. Returns the underlying system type.</returns>
+      <exception cref="T:System.InvalidOperationException">This type is an enumeration, but there is no underlying system type.</exception>
+    </member>
+    <member name="F:System.Reflection.Emit.TypeBuilder.UnspecifiedTypeSize">
+      <summary>Represents that total size for the type is not specified.</summary>
+    </member>
+  </members>
+</doc>

--- a/Tests/Plugins/system.reflection.emit.4.7.0/System.Reflection.Emit.xml.meta
+++ b/Tests/Plugins/system.reflection.emit.4.7.0/System.Reflection.Emit.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 346114ab01ecd424bbe7deba0d6cd0b8
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Plugins/system.reflection.emit.ilgeneration.4.7.0.meta
+++ b/Tests/Plugins/system.reflection.emit.ilgeneration.4.7.0.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 48a74165f75e32542bc545bf7bbf221f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Plugins/system.reflection.emit.ilgeneration.4.7.0/System.Reflection.Emit.ILGeneration.dll
+++ b/Tests/Plugins/system.reflection.emit.ilgeneration.4.7.0/System.Reflection.Emit.ILGeneration.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cac0339e1222085ff8bf1e5225f4aa9559a1ce15b6cf5c2e1f65a3b4ef496a86
+size 21576

--- a/Tests/Plugins/system.reflection.emit.ilgeneration.4.7.0/System.Reflection.Emit.ILGeneration.dll.meta
+++ b/Tests/Plugins/system.reflection.emit.ilgeneration.4.7.0/System.Reflection.Emit.ILGeneration.dll.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 92aecf47cb70ee745a8bb650652a066c

--- a/Tests/Plugins/system.reflection.emit.ilgeneration.4.7.0/System.Reflection.Emit.ILGeneration.xml
+++ b/Tests/Plugins/system.reflection.emit.ilgeneration.4.7.0/System.Reflection.Emit.ILGeneration.xml
@@ -1,0 +1,626 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<doc>
+  <assembly>
+    <name>System.Reflection.Emit.ILGeneration</name>
+  </assembly>
+  <members>
+    <member name="T:System.Reflection.Emit.CustomAttributeBuilder">
+      <summary>Helps build custom attributes.</summary>
+    </member>
+    <member name="M:System.Reflection.Emit.CustomAttributeBuilder.#ctor(System.Reflection.ConstructorInfo,System.Object[])">
+      <summary>Initializes an instance of the <see langword="CustomAttributeBuilder" /> class given the constructor for the custom attribute and the arguments to the constructor.</summary>
+      <param name="con">The constructor for the custom attribute.</param>
+      <param name="constructorArgs">The arguments to the constructor of the custom attribute.</param>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="con" /> is static or private.
+-or-
+The number of supplied arguments does not match the number of parameters of the constructor as required by the calling convention of the constructor.
+-or-
+The type of supplied argument does not match the type of the parameter declared in the constructor.
+-or-
+A supplied argument is a reference type other than <see cref="T:System.String" /> or <see cref="T:System.Type" />.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="con" /> or <paramref name="constructorArgs" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.CustomAttributeBuilder.#ctor(System.Reflection.ConstructorInfo,System.Object[],System.Reflection.FieldInfo[],System.Object[])">
+      <summary>Initializes an instance of the <see langword="CustomAttributeBuilder" /> class given the constructor for the custom attribute, the arguments to the constructor, and a set of named field/value pairs.</summary>
+      <param name="con">The constructor for the custom attribute.</param>
+      <param name="constructorArgs">The arguments to the constructor of the custom attribute.</param>
+      <param name="namedFields">Named fields of the custom attribute.</param>
+      <param name="fieldValues">Values for the named fields of the custom attribute.</param>
+      <exception cref="T:System.ArgumentException">The lengths of the <paramref name="namedFields" /> and <paramref name="fieldValues" /> arrays are different.
+-or-
+<paramref name="con" /> is static or private.
+-or-
+The number of supplied arguments does not match the number of parameters of the constructor as required by the calling convention of the constructor.
+-or-
+The type of supplied argument does not match the type of the parameter declared in the constructor.
+-or-
+The types of the field values do not match the types of the named fields.
+-or-
+The field does not belong to the same class or base class as the constructor.
+-or-
+A supplied argument or named field is a reference type other than <see cref="T:System.String" /> or <see cref="T:System.Type" />.</exception>
+      <exception cref="T:System.ArgumentNullException">One of the parameters is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.CustomAttributeBuilder.#ctor(System.Reflection.ConstructorInfo,System.Object[],System.Reflection.PropertyInfo[],System.Object[])">
+      <summary>Initializes an instance of the <see langword="CustomAttributeBuilder" /> class given the constructor for the custom attribute, the arguments to the constructor, and a set of named property or value pairs.</summary>
+      <param name="con">The constructor for the custom attribute.</param>
+      <param name="constructorArgs">The arguments to the constructor of the custom attribute.</param>
+      <param name="namedProperties">Named properties of the custom attribute.</param>
+      <param name="propertyValues">Values for the named properties of the custom attribute.</param>
+      <exception cref="T:System.ArgumentException">The lengths of the <paramref name="namedProperties" /> and <paramref name="propertyValues" /> arrays are different.
+-or-
+<paramref name="con" /> is static or private.
+-or-
+The number of supplied arguments does not match the number of parameters of the constructor as required by the calling convention of the constructor.
+-or-
+The type of supplied argument does not match the type of the parameter declared in the constructor.
+-or-
+The types of the property values do not match the types of the named properties.
+-or-
+A property has no setter method.
+-or-
+The property does not belong to the same class or base class as the constructor.
+-or-
+A supplied argument or named property is a reference type other than <see cref="T:System.String" /> or <see cref="T:System.Type" />.</exception>
+      <exception cref="T:System.ArgumentNullException">One of the parameters is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.CustomAttributeBuilder.#ctor(System.Reflection.ConstructorInfo,System.Object[],System.Reflection.PropertyInfo[],System.Object[],System.Reflection.FieldInfo[],System.Object[])">
+      <summary>Initializes an instance of the <see langword="CustomAttributeBuilder" /> class given the constructor for the custom attribute, the arguments to the constructor, a set of named property or value pairs, and a set of named field or value pairs.</summary>
+      <param name="con">The constructor for the custom attribute.</param>
+      <param name="constructorArgs">The arguments to the constructor of the custom attribute.</param>
+      <param name="namedProperties">Named properties of the custom attribute.</param>
+      <param name="propertyValues">Values for the named properties of the custom attribute.</param>
+      <param name="namedFields">Named fields of the custom attribute.</param>
+      <param name="fieldValues">Values for the named fields of the custom attribute.</param>
+      <exception cref="T:System.ArgumentException">The lengths of the <paramref name="namedProperties" /> and <paramref name="propertyValues" /> arrays are different.
+-or-
+The lengths of the <paramref name="namedFields" /> and <paramref name="fieldValues" /> arrays are different.
+-or-
+<paramref name="con" /> is static or private.
+-or-
+The number of supplied arguments does not match the number of parameters of the constructor as required by the calling convention of the constructor.
+-or-
+The type of supplied argument does not match the type of the parameter declared in the constructor.
+-or-
+The types of the property values do not match the types of the named properties.
+-or-
+The types of the field values do not match the types of the corresponding field types.
+-or-
+A property has no setter.
+-or-
+The property or field does not belong to the same class or base class as the constructor.
+-or-
+A supplied argument, named property, or named field is a reference type other than <see cref="T:System.String" /> or <see cref="T:System.Type" />.</exception>
+      <exception cref="T:System.ArgumentNullException">One of the parameters is <see langword="null" />.</exception>
+    </member>
+    <member name="T:System.Reflection.Emit.ILGenerator">
+      <summary>Generates Microsoft intermediate language (MSIL) instructions.</summary>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.BeginCatchBlock(System.Type)">
+      <summary>Begins a catch block.</summary>
+      <param name="exceptionType">The <see cref="T:System.Type" /> object that represents the exception.</param>
+      <exception cref="T:System.ArgumentException">The catch block is within a filtered exception.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="exceptionType" /> is <see langword="null" />, and the exception filter block has not returned a value that indicates that finally blocks should be run until this catch block is located.</exception>
+      <exception cref="T:System.NotSupportedException">The Microsoft intermediate language (MSIL) being generated is not currently in an exception block.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.BeginExceptFilterBlock">
+      <summary>Begins an exception block for a filtered exception.</summary>
+      <exception cref="T:System.NotSupportedException">The Microsoft intermediate language (MSIL) being generated is not currently in an exception block.
+-or-
+This <see cref="T:System.Reflection.Emit.ILGenerator" /> belongs to a <see cref="T:System.Reflection.Emit.DynamicMethod" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.BeginExceptionBlock">
+      <summary>Begins an exception block for a non-filtered exception.</summary>
+      <returns>The label for the end of the block. This will leave you in the correct place to execute finally blocks or to finish the try.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.BeginFaultBlock">
+      <summary>Begins an exception fault block in the Microsoft intermediate language (MSIL) stream.</summary>
+      <exception cref="T:System.NotSupportedException">The MSIL being generated is not currently in an exception block.
+-or-
+This <see cref="T:System.Reflection.Emit.ILGenerator" /> belongs to a <see cref="T:System.Reflection.Emit.DynamicMethod" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.BeginFinallyBlock">
+      <summary>Begins a finally block in the Microsoft intermediate language (MSIL) instruction stream.</summary>
+      <exception cref="T:System.NotSupportedException">The MSIL being generated is not currently in an exception block.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.BeginScope">
+      <summary>Begins a lexical scope.</summary>
+      <exception cref="T:System.NotSupportedException">This <see cref="T:System.Reflection.Emit.ILGenerator" /> belongs to a <see cref="T:System.Reflection.Emit.DynamicMethod" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.DeclareLocal(System.Type)">
+      <summary>Declares a local variable of the specified type.</summary>
+      <param name="localType">A <see cref="T:System.Type" /> object that represents the type of the local variable.</param>
+      <returns>The declared local variable.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="localType" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The containing type has been created by the <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> method.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.DeclareLocal(System.Type,System.Boolean)">
+      <summary>Declares a local variable of the specified type, optionally pinning the object referred to by the variable.</summary>
+      <param name="localType">A <see cref="T:System.Type" /> object that represents the type of the local variable.</param>
+      <param name="pinned">
+        <see langword="true" /> to pin the object in memory; otherwise, <see langword="false" />.</param>
+      <returns>A <see cref="T:System.Reflection.Emit.LocalBuilder" /> object that represents the local variable.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="localType" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The containing type has been created by the <see cref="M:System.Reflection.Emit.TypeBuilder.CreateType" /> method.
+-or-
+The method body of the enclosing method has been created by the <see cref="M:System.Reflection.Emit.MethodBuilder.CreateMethodBody(System.Byte[],System.Int32)" /> method.</exception>
+      <exception cref="T:System.NotSupportedException">The method with which this <see cref="T:System.Reflection.Emit.ILGenerator" /> is associated is not represented by a <see cref="T:System.Reflection.Emit.MethodBuilder" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.DefineLabel">
+      <summary>Declares a new label.</summary>
+      <returns>A new label that can be used as a token for branching.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.Emit(System.Reflection.Emit.OpCode)">
+      <summary>Puts the specified instruction onto the stream of instructions.</summary>
+      <param name="opcode">The Microsoft Intermediate Language (MSIL) instruction to be put onto the stream.</param>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.Emit(System.Reflection.Emit.OpCode,System.Byte)">
+      <summary>Puts the specified instruction and character argument onto the Microsoft intermediate language (MSIL) stream of instructions.</summary>
+      <param name="opcode">The MSIL instruction to be put onto the stream.</param>
+      <param name="arg">The character argument pushed onto the stream immediately after the instruction.</param>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.Emit(System.Reflection.Emit.OpCode,System.Double)">
+      <summary>Puts the specified instruction and numerical argument onto the Microsoft intermediate language (MSIL) stream of instructions.</summary>
+      <param name="opcode">The MSIL instruction to be put onto the stream. Defined in the <see langword="OpCodes" /> enumeration.</param>
+      <param name="arg">The numerical argument pushed onto the stream immediately after the instruction.</param>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.Emit(System.Reflection.Emit.OpCode,System.Int16)">
+      <summary>Puts the specified instruction and numerical argument onto the Microsoft intermediate language (MSIL) stream of instructions.</summary>
+      <param name="opcode">The MSIL instruction to be emitted onto the stream.</param>
+      <param name="arg">The <see langword="Int" /> argument pushed onto the stream immediately after the instruction.</param>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.Emit(System.Reflection.Emit.OpCode,System.Int32)">
+      <summary>Puts the specified instruction and numerical argument onto the Microsoft intermediate language (MSIL) stream of instructions.</summary>
+      <param name="opcode">The MSIL instruction to be put onto the stream.</param>
+      <param name="arg">The numerical argument pushed onto the stream immediately after the instruction.</param>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.Emit(System.Reflection.Emit.OpCode,System.Int64)">
+      <summary>Puts the specified instruction and numerical argument onto the Microsoft intermediate language (MSIL) stream of instructions.</summary>
+      <param name="opcode">The MSIL instruction to be put onto the stream.</param>
+      <param name="arg">The numerical argument pushed onto the stream immediately after the instruction.</param>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.Emit(System.Reflection.Emit.OpCode,System.Reflection.ConstructorInfo)">
+      <summary>Puts the specified instruction and metadata token for the specified constructor onto the Microsoft intermediate language (MSIL) stream of instructions.</summary>
+      <param name="opcode">The MSIL instruction to be emitted onto the stream.</param>
+      <param name="con">A <see langword="ConstructorInfo" /> representing a constructor.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="con" /> is <see langword="null" />. This exception is new in the .NET Framework 4.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.Emit(System.Reflection.Emit.OpCode,System.Reflection.Emit.Label)">
+      <summary>Puts the specified instruction onto the Microsoft intermediate language (MSIL) stream and leaves space to include a label when fixes are done.</summary>
+      <param name="opcode">The MSIL instruction to be emitted onto the stream.</param>
+      <param name="label">The label to which to branch from this location.</param>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.Emit(System.Reflection.Emit.OpCode,System.Reflection.Emit.Label[])">
+      <summary>Puts the specified instruction onto the Microsoft intermediate language (MSIL) stream and leaves space to include a label when fixes are done.</summary>
+      <param name="opcode">The MSIL instruction to be emitted onto the stream.</param>
+      <param name="labels">The array of label objects to which to branch from this location. All of the labels will be used.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="con" /> is <see langword="null" />. This exception is new in the .NET Framework 4.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.Emit(System.Reflection.Emit.OpCode,System.Reflection.Emit.LocalBuilder)">
+      <summary>Puts the specified instruction onto the Microsoft intermediate language (MSIL) stream followed by the index of the given local variable.</summary>
+      <param name="opcode">The MSIL instruction to be emitted onto the stream.</param>
+      <param name="local">A local variable.</param>
+      <exception cref="T:System.ArgumentException">The parent method of the <paramref name="local" /> parameter does not match the method associated with this <see cref="T:System.Reflection.Emit.ILGenerator" />.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="local" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">
+        <paramref name="opcode" /> is a single-byte instruction, and <paramref name="local" /> represents a local variable with an index greater than <see langword="Byte.MaxValue" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.Emit(System.Reflection.Emit.OpCode,System.Reflection.Emit.SignatureHelper)">
+      <summary>Puts the specified instruction and a signature token onto the Microsoft intermediate language (MSIL) stream of instructions.</summary>
+      <param name="opcode">The MSIL instruction to be emitted onto the stream.</param>
+      <param name="signature">A helper for constructing a signature token.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="signature" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.Emit(System.Reflection.Emit.OpCode,System.Reflection.FieldInfo)">
+      <summary>Puts the specified instruction and metadata token for the specified field onto the Microsoft intermediate language (MSIL) stream of instructions.</summary>
+      <param name="opcode">The MSIL instruction to be emitted onto the stream.</param>
+      <param name="field">A <see langword="FieldInfo" /> representing a field.</param>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.Emit(System.Reflection.Emit.OpCode,System.Reflection.MethodInfo)">
+      <summary>Puts the specified instruction onto the Microsoft intermediate language (MSIL) stream followed by the metadata token for the given method.</summary>
+      <param name="opcode">The MSIL instruction to be emitted onto the stream.</param>
+      <param name="meth">A <see langword="MethodInfo" /> representing a method.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="meth" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.NotSupportedException">
+        <paramref name="meth" /> is a generic method for which the <see cref="P:System.Reflection.MethodBase.IsGenericMethodDefinition" /> property is <see langword="false" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.Emit(System.Reflection.Emit.OpCode,System.SByte)">
+      <summary>Puts the specified instruction and character argument onto the Microsoft intermediate language (MSIL) stream of instructions.</summary>
+      <param name="opcode">The MSIL instruction to be put onto the stream.</param>
+      <param name="arg">The character argument pushed onto the stream immediately after the instruction.</param>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.Emit(System.Reflection.Emit.OpCode,System.Single)">
+      <summary>Puts the specified instruction and numerical argument onto the Microsoft intermediate language (MSIL) stream of instructions.</summary>
+      <param name="opcode">The MSIL instruction to be put onto the stream.</param>
+      <param name="arg">The <see langword="Single" /> argument pushed onto the stream immediately after the instruction.</param>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.Emit(System.Reflection.Emit.OpCode,System.String)">
+      <summary>Puts the specified instruction onto the Microsoft intermediate language (MSIL) stream followed by the metadata token for the given string.</summary>
+      <param name="opcode">The MSIL instruction to be emitted onto the stream.</param>
+      <param name="str">The <see langword="String" /> to be emitted.</param>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.Emit(System.Reflection.Emit.OpCode,System.Type)">
+      <summary>Puts the specified instruction onto the Microsoft intermediate language (MSIL) stream followed by the metadata token for the given type.</summary>
+      <param name="opcode">The MSIL instruction to be put onto the stream.</param>
+      <param name="cls">A <see langword="Type" />.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="cls" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.EmitCall(System.Reflection.Emit.OpCode,System.Reflection.MethodInfo,System.Type[])">
+      <summary>Puts a <see langword="call" /> or <see langword="callvirt" /> instruction onto the Microsoft intermediate language (MSIL) stream to call a <see langword="varargs" /> method.</summary>
+      <param name="opcode">The MSIL instruction to be emitted onto the stream. Must be <see cref="F:System.Reflection.Emit.OpCodes.Call" />, <see cref="F:System.Reflection.Emit.OpCodes.Callvirt" />, or <see cref="F:System.Reflection.Emit.OpCodes.Newobj" />.</param>
+      <param name="methodInfo">The <see langword="varargs" /> method to be called.</param>
+      <param name="optionalParameterTypes">The types of the optional arguments if the method is a <see langword="varargs" /> method; otherwise, <see langword="null" />.</param>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="opcode" /> does not specify a method call.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="methodInfo" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.InvalidOperationException">The calling convention for the method is not <see langword="varargs" />, but optional parameter types are supplied. This exception is thrown in the .NET Framework versions 1.0 and 1.1, In subsequent versions, no exception is thrown.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.EmitCalli(System.Reflection.Emit.OpCode,System.Reflection.CallingConventions,System.Type,System.Type[],System.Type[])">
+      <summary>Puts a <see cref="F:System.Reflection.Emit.OpCodes.Calli" /> instruction onto the Microsoft intermediate language (MSIL) stream, specifying a managed calling convention for the indirect call.</summary>
+      <param name="opcode">The MSIL instruction to be emitted onto the stream. Must be <see cref="F:System.Reflection.Emit.OpCodes.Calli" />.</param>
+      <param name="callingConvention">The managed calling convention to be used.</param>
+      <param name="returnType">The <see cref="T:System.Type" /> of the result.</param>
+      <param name="parameterTypes">The types of the required arguments to the instruction.</param>
+      <param name="optionalParameterTypes">The types of the optional arguments for <see langword="varargs" /> calls.</param>
+      <exception cref="T:System.InvalidOperationException">
+        <paramref name="optionalParameterTypes" /> is not <see langword="null" />, but <paramref name="callingConvention" /> does not include the <see cref="F:System.Reflection.CallingConventions.VarArgs" /> flag.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.EmitCalli(System.Reflection.Emit.OpCode,System.Runtime.InteropServices.CallingConvention,System.Type,System.Type[])">
+      <summary>Puts a <see cref="F:System.Reflection.Emit.OpCodes.Calli" /> instruction onto the Microsoft intermediate language (MSIL) stream, specifying an unmanaged calling convention for the indirect call.</summary>
+      <param name="opcode">The MSIL instruction to be emitted onto the stream. Must be <see cref="F:System.Reflection.Emit.OpCodes.Calli" />.</param>
+      <param name="unmanagedCallConv">The unmanaged calling convention to be used.</param>
+      <param name="returnType">The <see cref="T:System.Type" /> of the result.</param>
+      <param name="parameterTypes">The types of the required arguments to the instruction.</param>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.EmitWriteLine(System.Reflection.Emit.LocalBuilder)">
+      <summary>Emits the Microsoft intermediate language (MSIL) necessary to call <see cref="Overload:System.Console.WriteLine" /> with the given local variable.</summary>
+      <param name="localBuilder">The local variable whose value is to be written to the console.</param>
+      <exception cref="T:System.ArgumentException">The type of <paramref name="localBuilder" /> is <see cref="T:System.Reflection.Emit.TypeBuilder" /> or <see cref="T:System.Reflection.Emit.EnumBuilder" />, which are not supported.
+-or-
+There is no overload of <see cref="Overload:System.Console.WriteLine" /> that accepts the type of <paramref name="localBuilder" />.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="localBuilder" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.EmitWriteLine(System.Reflection.FieldInfo)">
+      <summary>Emits the Microsoft intermediate language (MSIL) necessary to call <see cref="Overload:System.Console.WriteLine" /> with the given field.</summary>
+      <param name="fld">The field whose value is to be written to the console.</param>
+      <exception cref="T:System.ArgumentException">There is no overload of the <see cref="Overload:System.Console.WriteLine" /> method that accepts the type of the specified field.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="fld" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.NotSupportedException">The type of the field is <see cref="T:System.Reflection.Emit.TypeBuilder" /> or <see cref="T:System.Reflection.Emit.EnumBuilder" />, which are not supported.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.EmitWriteLine(System.String)">
+      <summary>Emits the Microsoft intermediate language (MSIL) to call <see cref="Overload:System.Console.WriteLine" /> with a string.</summary>
+      <param name="value">The string to be printed.</param>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.EndExceptionBlock">
+      <summary>Ends an exception block.</summary>
+      <exception cref="T:System.InvalidOperationException">The end exception block occurs in an unexpected place in the code stream.</exception>
+      <exception cref="T:System.NotSupportedException">The Microsoft intermediate language (MSIL) being generated is not currently in an exception block.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.EndScope">
+      <summary>Ends a lexical scope.</summary>
+      <exception cref="T:System.NotSupportedException">This <see cref="T:System.Reflection.Emit.ILGenerator" /> belongs to a <see cref="T:System.Reflection.Emit.DynamicMethod" />.</exception>
+    </member>
+    <member name="P:System.Reflection.Emit.ILGenerator.ILOffset">
+      <summary>Gets the current offset, in bytes, in the Microsoft intermediate language (MSIL) stream that is being emitted by the <see cref="T:System.Reflection.Emit.ILGenerator" />.</summary>
+      <returns>The offset in the MSIL stream at which the next instruction will be emitted.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.MarkLabel(System.Reflection.Emit.Label)">
+      <summary>Marks the Microsoft intermediate language (MSIL) stream's current position with the given label.</summary>
+      <param name="loc">The label for which to set an index.</param>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="loc" /> represents an invalid index into the label array.
+-or-
+An index for <paramref name="loc" /> has already been defined.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.ThrowException(System.Type)">
+      <summary>Emits an instruction to throw an exception.</summary>
+      <param name="excType">The class of the type of exception to throw.</param>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="excType" /> is not the <see cref="T:System.Exception" /> class or a derived class of <see cref="T:System.Exception" />.
+-or-
+The type does not have a parameterless constructor.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="excType" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ILGenerator.UsingNamespace(System.String)">
+      <summary>Specifies the namespace to be used in evaluating locals and watches for the current active lexical scope.</summary>
+      <param name="usingNamespace">The namespace to be used in evaluating locals and watches for the current active lexical scope</param>
+      <exception cref="T:System.ArgumentException">Length of <paramref name="usingNamespace" /> is zero.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="usingNamespace" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.NotSupportedException">This <see cref="T:System.Reflection.Emit.ILGenerator" /> belongs to a <see cref="T:System.Reflection.Emit.DynamicMethod" />.</exception>
+    </member>
+    <member name="T:System.Reflection.Emit.Label">
+      <summary>Represents a label in the instruction stream. <see langword="Label" /> is used in conjunction with the <see cref="T:System.Reflection.Emit.ILGenerator" /> class.</summary>
+    </member>
+    <member name="M:System.Reflection.Emit.Label.Equals(System.Object)">
+      <summary>Checks if the given object is an instance of <see langword="Label" /> and is equal to this instance.</summary>
+      <param name="obj">The object to compare with this <see langword="Label" /> instance.</param>
+      <returns>
+        <see langword="true" /> if <paramref name="obj" /> is an instance of <see langword="Label" /> and is equal to this object; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.Label.Equals(System.Reflection.Emit.Label)">
+      <summary>Indicates whether the current instance is equal to the specified <see cref="T:System.Reflection.Emit.Label" />.</summary>
+      <param name="obj">The <see cref="T:System.Reflection.Emit.Label" /> to compare to the current instance.</param>
+      <returns>
+        <see langword="true" /> if the value of <paramref name="obj" /> is equal to the value of the current instance; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.Label.GetHashCode">
+      <summary>Generates a hash code for this instance.</summary>
+      <returns>A hash code for this instance.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.Label.op_Equality(System.Reflection.Emit.Label,System.Reflection.Emit.Label)">
+      <summary>Indicates whether two <see cref="T:System.Reflection.Emit.Label" /> structures are equal.</summary>
+      <param name="a">The <see cref="T:System.Reflection.Emit.Label" /> to compare to <paramref name="b" />.</param>
+      <param name="b">The <see cref="T:System.Reflection.Emit.Label" /> to compare to <paramref name="a" />.</param>
+      <returns>
+        <see langword="true" /> if <paramref name="a" /> is equal to <paramref name="b" />; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.Label.op_Inequality(System.Reflection.Emit.Label,System.Reflection.Emit.Label)">
+      <summary>Indicates whether two <see cref="T:System.Reflection.Emit.Label" /> structures are not equal.</summary>
+      <param name="a">The <see cref="T:System.Reflection.Emit.Label" /> to compare to <paramref name="b" />.</param>
+      <param name="b">The <see cref="T:System.Reflection.Emit.Label" /> to compare to <paramref name="a" />.</param>
+      <returns>
+        <see langword="true" /> if <paramref name="a" /> is not equal to <paramref name="b" />; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="T:System.Reflection.Emit.LocalBuilder">
+      <summary>Represents a local variable within a method or constructor.</summary>
+    </member>
+    <member name="P:System.Reflection.Emit.LocalBuilder.IsPinned">
+      <summary>Gets a value indicating whether the object referred to by the local variable is pinned in memory.</summary>
+      <returns>
+        <see langword="true" /> if the object referred to by the local variable is pinned in memory; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.LocalBuilder.LocalIndex">
+      <summary>Gets the zero-based index of the local variable within the method body.</summary>
+      <returns>An integer value that represents the order of declaration of the local variable within the method body.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.LocalBuilder.LocalType">
+      <summary>Gets the type of the local variable.</summary>
+      <returns>The <see cref="T:System.Type" /> of the local variable.</returns>
+    </member>
+    <member name="T:System.Reflection.Emit.ParameterBuilder">
+      <summary>Creates or associates parameter information.</summary>
+    </member>
+    <member name="P:System.Reflection.Emit.ParameterBuilder.Attributes">
+      <summary>Retrieves the attributes for this parameter.</summary>
+      <returns>Read-only. Retrieves the attributes for this parameter.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.ParameterBuilder.IsIn">
+      <summary>Retrieves whether this is an input parameter.</summary>
+      <returns>Read-only. Retrieves whether this is an input parameter.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.ParameterBuilder.IsOptional">
+      <summary>Retrieves whether this parameter is optional.</summary>
+      <returns>Read-only. Specifies whether this parameter is optional.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.ParameterBuilder.IsOut">
+      <summary>Retrieves whether this parameter is an output parameter.</summary>
+      <returns>Read-only. Retrieves whether this parameter is an output parameter.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.ParameterBuilder.Name">
+      <summary>Retrieves the name of this parameter.</summary>
+      <returns>Read-only. Retrieves the name of this parameter.</returns>
+    </member>
+    <member name="P:System.Reflection.Emit.ParameterBuilder.Position">
+      <summary>Retrieves the signature position for this parameter.</summary>
+      <returns>Read-only. Retrieves the signature position for this parameter.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.ParameterBuilder.SetConstant(System.Object)">
+      <summary>Sets the default value of the parameter.</summary>
+      <param name="defaultValue">The default value of this parameter.</param>
+      <exception cref="T:System.ArgumentException">The parameter is not one of the supported types.
+-or-
+The type of <paramref name="defaultValue" /> does not match the type of the parameter.
+-or-
+The parameter is of type <see cref="T:System.Object" /> or other reference type, <paramref name="defaultValue" /> is not <see langword="null" />, and the value cannot be assigned to the reference type.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ParameterBuilder.SetCustomAttribute(System.Reflection.ConstructorInfo,System.Byte[])">
+      <summary>Set a custom attribute using a specified custom attribute blob.</summary>
+      <param name="con">The constructor for the custom attribute.</param>
+      <param name="binaryAttribute">A byte blob representing the attributes.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="con" /> or <paramref name="binaryAttribute" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.ParameterBuilder.SetCustomAttribute(System.Reflection.Emit.CustomAttributeBuilder)">
+      <summary>Set a custom attribute using a custom attribute builder.</summary>
+      <param name="customBuilder">An instance of a helper class to define the custom attribute.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="con" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="T:System.Reflection.Emit.SignatureHelper">
+      <summary>Provides methods for building signatures.</summary>
+    </member>
+    <member name="M:System.Reflection.Emit.SignatureHelper.AddArgument(System.Type)">
+      <summary>Adds an argument to the signature.</summary>
+      <param name="clsArgument">The type of the argument.</param>
+      <exception cref="T:System.ArgumentException">The signature has already been finished.</exception>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="clsArgument" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.SignatureHelper.AddArgument(System.Type,System.Boolean)">
+      <summary>Adds an argument of the specified type to the signature, specifying whether the argument is pinned.</summary>
+      <param name="argument">The argument type.</param>
+      <param name="pinned">
+        <see langword="true" /> if the argument is pinned; otherwise, <see langword="false" />.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="argument" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.SignatureHelper.AddArgument(System.Type,System.Type[],System.Type[])">
+      <summary>Adds an argument to the signature, with the specified custom modifiers.</summary>
+      <param name="argument">The argument type.</param>
+      <param name="requiredCustomModifiers">An array of types representing the required custom modifiers for the argument, such as <see cref="T:System.Runtime.CompilerServices.IsConst" /> or <see cref="T:System.Runtime.CompilerServices.IsBoxed" />. If the argument has no required custom modifiers, specify <see langword="null" />.</param>
+      <param name="optionalCustomModifiers">An array of types representing the optional custom modifiers for the argument, such as <see cref="T:System.Runtime.CompilerServices.IsConst" /> or <see cref="T:System.Runtime.CompilerServices.IsBoxed" />. If the argument has no optional custom modifiers, specify <see langword="null" />.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="argument" /> is <see langword="null" />.
+-or-
+An element of <paramref name="requiredCustomModifiers" /> or <paramref name="optionalCustomModifiers" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">The signature has already been finished.
+-or-
+One of the specified custom modifiers is an array type.
+-or-
+One of the specified custom modifiers is an open generic type. That is, the <see cref="P:System.Type.ContainsGenericParameters" /> property is <see langword="true" /> for the custom modifier.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.SignatureHelper.AddArguments(System.Type[],System.Type[][],System.Type[][])">
+      <summary>Adds a set of arguments to the signature, with the specified custom modifiers.</summary>
+      <param name="arguments">The types of the arguments to be added.</param>
+      <param name="requiredCustomModifiers">An array of arrays of types. Each array of types represents the required custom modifiers for the corresponding argument, such as <see cref="T:System.Runtime.CompilerServices.IsConst" /> or <see cref="T:System.Runtime.CompilerServices.IsBoxed" />. If a particular argument has no required custom modifiers, specify <see langword="null" /> instead of an array of types. If none of the arguments have required custom modifiers, specify <see langword="null" /> instead of an array of arrays.</param>
+      <param name="optionalCustomModifiers">An array of arrays of types. Each array of types represents the optional custom modifiers for the corresponding argument, such as <see cref="T:System.Runtime.CompilerServices.IsConst" /> or <see cref="T:System.Runtime.CompilerServices.IsBoxed" />. If a particular argument has no optional custom modifiers, specify <see langword="null" /> instead of an array of types. If none of the arguments have optional custom modifiers, specify <see langword="null" /> instead of an array of arrays.</param>
+      <exception cref="T:System.ArgumentNullException">An element of <paramref name="arguments" /> is <see langword="null" />.
+-or-
+One of the specified custom modifiers is <see langword="null" />. (However, <see langword="null" /> can be specified for the array of custom modifiers for any argument.)</exception>
+      <exception cref="T:System.ArgumentException">The signature has already been finished.
+-or-
+One of the specified custom modifiers is an array type.
+-or-
+One of the specified custom modifiers is an open generic type. That is, the <see cref="P:System.Type.ContainsGenericParameters" /> property is <see langword="true" /> for the custom modifier.
+-or-
+The size of <paramref name="requiredCustomModifiers" /> or <paramref name="optionalCustomModifiers" /> does not equal the size of <paramref name="arguments" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.SignatureHelper.AddSentinel">
+      <summary>Marks the end of a vararg fixed part. This is only used if the caller is creating a vararg signature call site.</summary>
+    </member>
+    <member name="M:System.Reflection.Emit.SignatureHelper.Equals(System.Object)">
+      <summary>Checks if this instance is equal to the given object.</summary>
+      <param name="obj">The object with which this instance should be compared.</param>
+      <returns>
+        <see langword="true" /> if the given object is a <see langword="SignatureHelper" /> and represents the same signature; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.SignatureHelper.GetFieldSigHelper(System.Reflection.Module)">
+      <summary>Returns a signature helper for a field.</summary>
+      <param name="mod">The dynamic module that contains the field for which the <see langword="SignatureHelper" /> is requested.</param>
+      <returns>The <see langword="SignatureHelper" /> object for a field.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.SignatureHelper.GetHashCode">
+      <summary>Creates and returns a hash code for this instance.</summary>
+      <returns>The hash code based on the name.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.SignatureHelper.GetLocalVarSigHelper">
+      <summary>Returns a signature helper for a local variable.</summary>
+      <returns>A <see cref="T:System.Reflection.Emit.SignatureHelper" /> for a local variable.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.SignatureHelper.GetLocalVarSigHelper(System.Reflection.Module)">
+      <summary>Returns a signature helper for a local variable.</summary>
+      <param name="mod">The dynamic module that contains the local variable for which the <see langword="SignatureHelper" /> is requested.</param>
+      <returns>The <see langword="SignatureHelper" /> object for a local variable.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.SignatureHelper.GetMethodSigHelper(System.Reflection.CallingConventions,System.Type)">
+      <summary>Returns a signature helper for a method given the method's calling convention and return type.</summary>
+      <param name="callingConvention">The calling convention of the method.</param>
+      <param name="returnType">The return type of the method, or <see langword="null" /> for a void return type (<see langword="Sub" /> procedure in Visual Basic).</param>
+      <returns>The <see langword="SignatureHelper" /> object for a method.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.SignatureHelper.GetMethodSigHelper(System.Reflection.Module,System.Reflection.CallingConventions,System.Type)">
+      <summary>Returns a signature helper for a method given the method's module, calling convention, and return type.</summary>
+      <param name="mod">The <see cref="T:System.Reflection.Emit.ModuleBuilder" /> that contains the method for which the <see langword="SignatureHelper" /> is requested.</param>
+      <param name="callingConvention">The calling convention of the method.</param>
+      <param name="returnType">The return type of the method, or <see langword="null" /> for a void return type (<see langword="Sub" /> procedure in Visual Basic).</param>
+      <returns>The <see langword="SignatureHelper" /> object for a method.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="mod" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="mod" /> is not a <see cref="T:System.Reflection.Emit.ModuleBuilder" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.SignatureHelper.GetMethodSigHelper(System.Reflection.Module,System.Type,System.Type[])">
+      <summary>Returns a signature helper for a method with a standard calling convention, given the method's module, return type, and argument types.</summary>
+      <param name="mod">The <see cref="T:System.Reflection.Emit.ModuleBuilder" /> that contains the method for which the <see langword="SignatureHelper" /> is requested.</param>
+      <param name="returnType">The return type of the method, or <see langword="null" /> for a void return type (<see langword="Sub" /> procedure in Visual Basic).</param>
+      <param name="parameterTypes">The types of the arguments of the method, or <see langword="null" /> if the method has no arguments.</param>
+      <returns>The <see langword="SignatureHelper" /> object for a method.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="mod" /> is <see langword="null" />.
+-or-
+An element of <paramref name="parameterTypes" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="mod" /> is not a <see cref="T:System.Reflection.Emit.ModuleBuilder" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.SignatureHelper.GetPropertySigHelper(System.Reflection.Module,System.Reflection.CallingConventions,System.Type,System.Type[],System.Type[],System.Type[],System.Type[][],System.Type[][])">
+      <summary>Returns a signature helper for a property, given the dynamic module that contains the property, the calling convention, the property type, the property arguments, and custom modifiers for the return type and arguments.</summary>
+      <param name="mod">The <see cref="T:System.Reflection.Emit.ModuleBuilder" /> that contains the property for which the <see cref="T:System.Reflection.Emit.SignatureHelper" /> is requested.</param>
+      <param name="callingConvention">The calling convention of the property accessors.</param>
+      <param name="returnType">The property type.</param>
+      <param name="requiredReturnTypeCustomModifiers">An array of types representing the required custom modifiers for the return type, such as <see cref="T:System.Runtime.CompilerServices.IsConst" /> or <see cref="T:System.Runtime.CompilerServices.IsBoxed" />. If the return type has no required custom modifiers, specify <see langword="null" />.</param>
+      <param name="optionalReturnTypeCustomModifiers">An array of types representing the optional custom modifiers for the return type, such as <see cref="T:System.Runtime.CompilerServices.IsConst" /> or <see cref="T:System.Runtime.CompilerServices.IsBoxed" />. If the return type has no optional custom modifiers, specify <see langword="null" />.</param>
+      <param name="parameterTypes">The types of the property's arguments, or <see langword="null" /> if the property has no arguments.</param>
+      <param name="requiredParameterTypeCustomModifiers">An array of arrays of types. Each array of types represents the required custom modifiers for the corresponding argument of the property. If a particular argument has no required custom modifiers, specify <see langword="null" /> instead of an array of types. If the property has no arguments, or if none of the arguments have required custom modifiers, specify <see langword="null" /> instead of an array of arrays.</param>
+      <param name="optionalParameterTypeCustomModifiers">An array of arrays of types. Each array of types represents the optional custom modifiers for the corresponding argument of the property. If a particular argument has no optional custom modifiers, specify <see langword="null" /> instead of an array of types. If the property has no arguments, or if none of the arguments have optional custom modifiers, specify <see langword="null" /> instead of an array of arrays.</param>
+      <returns>A <see cref="T:System.Reflection.Emit.SignatureHelper" /> object for a property.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="mod" /> is <see langword="null" />.
+-or-
+An element of <paramref name="parameterTypes" /> is <see langword="null" />.
+-or-
+One of the specified custom modifiers is <see langword="null" />. (However, <see langword="null" /> can be specified for the array of custom modifiers for any argument.)</exception>
+      <exception cref="T:System.ArgumentException">The signature has already been finished.
+-or-
+<paramref name="mod" /> is not a <see cref="T:System.Reflection.Emit.ModuleBuilder" />.
+-or-
+One of the specified custom modifiers is an array type.
+-or-
+One of the specified custom modifiers is an open generic type. That is, the <see cref="P:System.Type.ContainsGenericParameters" /> property is <see langword="true" /> for the custom modifier.
+-or-
+The size of <paramref name="requiredParameterTypeCustomModifiers" /> or <paramref name="optionalParameterTypeCustomModifiers" /> does not equal the size of <paramref name="parameterTypes" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.SignatureHelper.GetPropertySigHelper(System.Reflection.Module,System.Type,System.Type[])">
+      <summary>Returns a signature helper for a property, given the dynamic module that contains the property, the property type, and the property arguments.</summary>
+      <param name="mod">The <see cref="T:System.Reflection.Emit.ModuleBuilder" /> that contains the property for which the <see cref="T:System.Reflection.Emit.SignatureHelper" /> is requested.</param>
+      <param name="returnType">The property type.</param>
+      <param name="parameterTypes">The argument types, or <see langword="null" /> if the property has no arguments.</param>
+      <returns>A <see cref="T:System.Reflection.Emit.SignatureHelper" /> object for a property.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="mod" /> is <see langword="null" />.
+-or-
+An element of <paramref name="parameterTypes" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="mod" /> is not a <see cref="T:System.Reflection.Emit.ModuleBuilder" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.SignatureHelper.GetPropertySigHelper(System.Reflection.Module,System.Type,System.Type[],System.Type[],System.Type[],System.Type[][],System.Type[][])">
+      <summary>Returns a signature helper for a property, given the dynamic module that contains the property, the property type, the property arguments, and custom modifiers for the return type and arguments.</summary>
+      <param name="mod">The <see cref="T:System.Reflection.Emit.ModuleBuilder" /> that contains the property for which the <see cref="T:System.Reflection.Emit.SignatureHelper" /> is requested.</param>
+      <param name="returnType">The property type.</param>
+      <param name="requiredReturnTypeCustomModifiers">An array of types representing the required custom modifiers for the return type, such as <see cref="T:System.Runtime.CompilerServices.IsConst" /> or <see cref="T:System.Runtime.CompilerServices.IsBoxed" />. If the return type has no required custom modifiers, specify <see langword="null" />.</param>
+      <param name="optionalReturnTypeCustomModifiers">An array of types representing the optional custom modifiers for the return type, such as <see cref="T:System.Runtime.CompilerServices.IsConst" /> or <see cref="T:System.Runtime.CompilerServices.IsBoxed" />. If the return type has no optional custom modifiers, specify <see langword="null" />.</param>
+      <param name="parameterTypes">The types of the property's arguments, or <see langword="null" /> if the property has no arguments.</param>
+      <param name="requiredParameterTypeCustomModifiers">An array of arrays of types. Each array of types represents the required custom modifiers for the corresponding argument of the property. If a particular argument has no required custom modifiers, specify <see langword="null" /> instead of an array of types. If the property has no arguments, or if none of the arguments have required custom modifiers, specify <see langword="null" /> instead of an array of arrays.</param>
+      <param name="optionalParameterTypeCustomModifiers">An array of arrays of types. Each array of types represents the optional custom modifiers for the corresponding argument of the property. If a particular argument has no optional custom modifiers, specify <see langword="null" /> instead of an array of types. If the property has no arguments, or if none of the arguments have optional custom modifiers, specify <see langword="null" /> instead of an array of arrays.</param>
+      <returns>A <see cref="T:System.Reflection.Emit.SignatureHelper" /> object for a property.</returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="mod" /> is <see langword="null" />.
+-or-
+An element of <paramref name="parameterTypes" /> is <see langword="null" />.
+-or-
+One of the specified custom modifiers is <see langword="null" />. (However, <see langword="null" /> can be specified for the array of custom modifiers for any argument.)</exception>
+      <exception cref="T:System.ArgumentException">The signature has already been finished.
+-or-
+<paramref name="mod" /> is not a <see cref="T:System.Reflection.Emit.ModuleBuilder" />.
+-or-
+One of the specified custom modifiers is an array type.
+-or-
+One of the specified custom modifiers is an open generic type. That is, the <see cref="P:System.Type.ContainsGenericParameters" /> property is <see langword="true" /> for the custom modifier.
+-or-
+The size of <paramref name="requiredParameterTypeCustomModifiers" /> or <paramref name="optionalParameterTypeCustomModifiers" /> does not equal the size of <paramref name="parameterTypes" />.</exception>
+    </member>
+    <member name="M:System.Reflection.Emit.SignatureHelper.GetSignature">
+      <summary>Adds the end token to the signature and marks the signature as finished, so no further tokens can be added.</summary>
+      <returns>A byte array made up of the full signature.</returns>
+    </member>
+    <member name="M:System.Reflection.Emit.SignatureHelper.ToString">
+      <summary>Returns a string representing the signature arguments.</summary>
+      <returns>A string representing the arguments of this signature.</returns>
+    </member>
+  </members>
+</doc>

--- a/Tests/Plugins/system.reflection.emit.ilgeneration.4.7.0/System.Reflection.Emit.ILGeneration.xml.meta
+++ b/Tests/Plugins/system.reflection.emit.ilgeneration.4.7.0/System.Reflection.Emit.ILGeneration.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 52fd24794b560e4409f5a14e79096178
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Plugins/system.runtime.compilerservices.unsafe.6.1.2.meta
+++ b/Tests/Plugins/system.runtime.compilerservices.unsafe.6.1.2.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6d153348672d8104aa2cab659d07c600
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Plugins/system.runtime.compilerservices.unsafe.6.1.2/System.Runtime.CompilerServices.Unsafe.dll
+++ b/Tests/Plugins/system.runtime.compilerservices.unsafe.6.1.2/System.Runtime.CompilerServices.Unsafe.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd67abc4c4af10affbcd42fd68a2a7bc361b26714afe6965d4d0d139459d8297
+size 19256

--- a/Tests/Plugins/system.runtime.compilerservices.unsafe.6.1.2/System.Runtime.CompilerServices.Unsafe.dll.meta
+++ b/Tests/Plugins/system.runtime.compilerservices.unsafe.6.1.2/System.Runtime.CompilerServices.Unsafe.dll.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3c7f7754ea565fd4d99be418137ab1ab

--- a/Tests/Plugins/system.runtime.compilerservices.unsafe.6.1.2/System.Runtime.CompilerServices.Unsafe.xml
+++ b/Tests/Plugins/system.runtime.compilerservices.unsafe.6.1.2/System.Runtime.CompilerServices.Unsafe.xml
@@ -1,0 +1,353 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>System.Runtime.CompilerServices.Unsafe</name>
+    </assembly>
+    <members>
+        <member name="T:System.Runtime.CompilerServices.Unsafe">
+            <summary>
+            Contains generic, low-level functionality for manipulating pointers.
+            </summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.Read``1(System.Void*)">
+            <summary>
+            Reads a value of type <typeparamref name="T"/> from the given location.
+            </summary>
+            <typeparam name="T">The type to read.</typeparam>
+            <param name="source">The location to read from.</param>
+            <returns>An object of type <typeparamref name="T"/> read from the given location.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.ReadUnaligned``1(System.Void*)">
+            <summary>
+            Reads a value of type <typeparamref name="T"/> from the given location.
+            </summary>
+            <typeparam name="T">The type to read.</typeparam>
+            <param name="source">The location to read from.</param>
+            <returns>An object of type <typeparamref name="T"/> read from the given location.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.ReadUnaligned``1(System.Byte@)">
+            <summary>
+            Reads a value of type <typeparamref name="T"/> from the given location.
+            </summary>
+            <typeparam name="T">The type to read.</typeparam>
+            <param name="source">The location to read from.</param>
+            <returns>An object of type <typeparamref name="T"/> read from the given location.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.Write``1(System.Void*,``0)">
+            <summary>
+            Writes a value of type <typeparamref name="T"/> to the given location.
+            </summary>
+            <typeparam name="T">The type of value to write.</typeparam>
+            <param name="destination">The location to write to.</param>
+            <param name="value">The value to write.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.WriteUnaligned``1(System.Void*,``0)">
+            <summary>
+            Writes a value of type <typeparamref name="T"/> to the given location.
+            </summary>
+            <typeparam name="T">The type of value to write.</typeparam>
+            <param name="destination">The location to write to.</param>
+            <param name="value">The value to write.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.WriteUnaligned``1(System.Byte@,``0)">
+            <summary>
+            Writes a value of type <typeparamref name="T"/> to the given location.
+            </summary>
+            <typeparam name="T">The type of value to write.</typeparam>
+            <param name="destination">The location to write to.</param>
+            <param name="value">The value to write.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.Copy``1(System.Void*,``0@)">
+            <summary>
+            Copies a value of type <typeparamref name="T"/> to the given location.
+            </summary>
+            <typeparam name="T">The type of value to copy.</typeparam>
+            <param name="destination">The location to copy to.</param>
+            <param name="source">A reference to the value to copy.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.Copy``1(``0@,System.Void*)">
+            <summary>
+            Copies a value of type <typeparamref name="T"/> to the given location.
+            </summary>
+            <typeparam name="T">The type of value to copy.</typeparam>
+            <param name="destination">The location to copy to.</param>
+            <param name="source">A pointer to the value to copy.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.AsPointer``1(``0@)">
+            <summary>
+            Returns a pointer to the given by-ref parameter.
+            </summary>
+            <typeparam name="T">The type of object.</typeparam>
+            <param name="value">The object whose pointer is obtained.</param>
+            <returns>A pointer to the given value.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.SizeOf``1">
+            <summary>
+            Returns the size of an object of the given type parameter.
+            </summary>
+            <typeparam name="T">The type of object whose size is retrieved.</typeparam>
+            <returns>The size of an object of type <typeparamref name="T"/>.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.As``1(System.Object)">
+            <summary>
+            Casts the given object to the specified type, performs no dynamic type checking.
+            </summary>
+            <typeparam name="T">The type which the object will be cast to.</typeparam>
+            <param name="o">The object to cast.</param>
+            <returns>The original object, casted to the given type.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.AsRef``1(System.Void*)">
+            <summary>
+            Reinterprets the given location as a reference to a value of type <typeparamref name="T"/>.
+            </summary>
+            <typeparam name="T">The type of the interpreted location.</typeparam>
+            <param name="source">The location of the value to reference.</param>
+            <returns>A reference to a value of type <typeparamref name="T"/>.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.AsRef``1(``0@)">
+            <summary>
+            Reinterprets the given read-only reference as a reference.
+            </summary>
+            <typeparam name="T">The type of reference.</typeparam>
+            <param name="source">The read-only reference to reinterpret.</param>
+            <returns>A reference to a value of type <typeparamref name="T"/>.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.As``2(``0@)">
+            <summary>
+            Reinterprets the given reference as a reference to a value of type <typeparamref name="TTo"/>.
+            </summary>
+            <typeparam name="TFrom">The type of reference to reinterpret.</typeparam>
+            <typeparam name="TTo">The desired type of the reference.</typeparam>
+            <param name="source">The reference to reinterpret.</param>
+            <returns>A reference to a value of type <typeparamref name="TTo"/>.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.Unbox``1(System.Object)">
+            <summary>
+            Returns a reference to the value type contained with the specified box object.
+            </summary>
+            <typeparam name="T">The type of the value type contained within the box.</typeparam>
+            <param name="box">The boxed value type.</param>
+            <returns>A reference to a value of type <typeparamref name="T"/> in the box object.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.Add``1(``0@,System.Int32)">
+            <summary>
+            Adds an element offset to the given reference.
+            </summary>
+            <typeparam name="T">The type of reference.</typeparam>
+            <param name="source">The reference to add the offset to.</param>
+            <param name="elementOffset">The offset to add.</param>
+            <returns>A new reference that reflects the addition of offset to pointer.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.Add``1(System.Void*,System.Int32)">
+            <summary>
+            Adds an element offset to the given pointer.
+            </summary>
+            <typeparam name="T">The type of reference.</typeparam>
+            <param name="source">The pointer to add the offset to.</param>
+            <param name="elementOffset">The offset to add.</param>
+            <returns>A new pointer that reflects the addition of offset to pointer.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.Add``1(``0@,System.IntPtr)">
+            <summary>
+            Adds an element offset to the given reference.
+            </summary>
+            <typeparam name="T">The type of reference.</typeparam>
+            <param name="source">The reference to add the offset to.</param>
+            <param name="elementOffset">The offset to add.</param>
+            <returns>A new reference that reflects the addition of offset to pointer.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.Add``1(``0@,System.UIntPtr)">
+            <summary>
+            Adds an element offset to the given reference.
+            </summary>
+            <typeparam name="T">The type of reference.</typeparam>
+            <param name="source">The reference to add the offset to.</param>
+            <param name="elementOffset">The offset to add.</param>
+            <returns>A new reference that reflects the addition of offset to pointer.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.AddByteOffset``1(``0@,System.IntPtr)">
+            <summary>
+            Adds a byte offset to the given reference.
+            </summary>
+            <typeparam name="T">The type of reference.</typeparam>
+            <param name="source">The reference to add the offset to.</param>
+            <param name="byteOffset">The offset to add.</param>
+            <returns>A new reference that reflects the addition of byte offset to pointer.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.AddByteOffset``1(``0@,System.UIntPtr)">
+            <summary>
+            Adds a byte offset to the given reference.
+            </summary>
+            <typeparam name="T">The type of reference.</typeparam>
+            <param name="source">The reference to add the offset to.</param>
+            <param name="byteOffset">The offset to add.</param>
+            <returns>A new reference that reflects the addition of byte offset to pointer.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.Subtract``1(``0@,System.Int32)">
+            <summary>
+            Subtracts an element offset from the given reference.
+            </summary>
+            <typeparam name="T">The type of reference.</typeparam>
+            <param name="source">The reference to subtract the offset from.</param>
+            <param name="elementOffset">The offset to subtract.</param>
+            <returns>A new reference that reflects the subraction of offset from pointer.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.Subtract``1(``0@,System.IntPtr)">
+            <summary>
+            Subtracts an element offset from the given reference.
+            </summary>
+            <typeparam name="T">The type of reference.</typeparam>
+            <param name="source">The reference to subtract the offset from.</param>
+            <param name="elementOffset">The offset to subtract.</param>
+            <returns>A new reference that reflects the subraction of offset from pointer.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.Subtract``1(``0@,System.UIntPtr)">
+            <summary>
+            Subtracts an element offset from the given reference.
+            </summary>
+            <typeparam name="T">The type of reference.</typeparam>
+            <param name="source">The reference to subtract the offset from.</param>
+            <param name="elementOffset">The offset to subtract.</param>
+            <returns>A new reference that reflects the subraction of offset from pointer.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.SubtractByteOffset``1(``0@,System.IntPtr)">
+            <summary>
+            Subtracts a byte offset from the given reference.
+            </summary>
+            <typeparam name="T">The type of reference.</typeparam>
+            <param name="source">The reference to subtract the offset from.</param>
+            <param name="byteOffset">The offset to subtract.</param>
+            <returns>A new reference that reflects the subraction of byte offset from pointer.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.SubtractByteOffset``1(``0@,System.UIntPtr)">
+            <summary>
+            Subtracts a byte offset from the given reference.
+            </summary>
+            <typeparam name="T">The type of reference.</typeparam>
+            <param name="source">The reference to subtract the offset from.</param>
+            <param name="byteOffset">The offset to subtract.</param>
+            <returns>A new reference that reflects the subraction of byte offset from pointer.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.ByteOffset``1(``0@,``0@)">
+            <summary>
+            Determines the byte offset from origin to target from the given references.
+            </summary>
+            <typeparam name="T">The type of reference.</typeparam>
+            <param name="origin">The reference to origin.</param>
+            <param name="target">The reference to target.</param>
+            <returns>Byte offset from origin to target i.e. <paramref name="target"/> - <paramref name="origin"/>.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.AreSame``1(``0@,``0@)">
+            <summary>
+            Determines whether the specified references point to the same location.
+            </summary>
+            <param name="left">The first reference to compare.</param>
+            <param name="right">The second reference to compare.</param>
+            <returns><c>true</c> if <paramref name="left"/> and <paramref name="right"/> point to the same location; otherwise <c>false</c>.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.IsAddressGreaterThan``1(``0@,``0@)">
+            <summary>
+            Determines whether the memory address referenced by <paramref name="left"/> is greater than the memory address referenced by <paramref name="right"/>.
+            </summary>
+            <param name="left">The first reference to compare.</param>
+            <param name="right">The second reference to compare.</param>
+            <returns><c>true</c> if the memory address referenced by <paramref name="left"/> is greater than the memory address referenced by <paramref name="right"/>; otherwise <c>false</c>.</returns>
+            <remarks>
+            This check is conceptually similar to "(void*)(&amp;left) &gt; (void*)(&amp;right)". Both parameters must reference the same object, array, or span;
+            or the objects being referenced must both be pinned; or both references must represent unmanaged pointers; otherwise the result is undefined.
+            </remarks>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.IsAddressLessThan``1(``0@,``0@)">
+            <summary>
+            Determines whether the memory address referenced by <paramref name="left"/> is less than the memory address referenced by <paramref name="right"/>.
+            </summary>
+            <param name="left">The first reference to compare.</param>
+            <param name="right">The second reference to compare.</param>
+            <returns><c>true</c> if the memory address referenced by <paramref name="left"/> is less than the memory address referenced by <paramref name="right"/>; otherwise <c>false</c>.</returns>
+            <remarks>
+            This check is conceptually similar to "(void*)(&amp;left) &lt; (void*)(&amp;right)". Both parameters must reference the same object, array, or span;
+            or the objects being referenced must both be pinned; or both references must represent unmanaged pointers; otherwise the result is undefined.
+            </remarks>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.IsNullRef``1(``0@)">
+          <summary>
+            Returns if a given reference to a value of type <typeparamref name="T"/> is a null reference.
+          </summary>
+          <param name="source">The reference to check.</param>
+          <remarks>This check is conceptually similar to "(void*)(&amp;source) == nullptr".</remarks>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.NullRef``1">
+          <summary>
+            Returns a reference to a value of type <typeparamref name="T"/> that is a null reference.
+          </summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlock(System.Void*,System.Void*,System.UInt32)">
+            <summary>
+            Copies bytes from the source address to the destination address.
+            </summary>
+            <param name="destination">The destination address to copy to.</param>
+            <param name="source">The source address to copy from.</param>
+            <param name="byteCount">The number of bytes to copy.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlock(System.Byte@,System.Byte@,System.UInt32)">
+            <summary>
+            Copies bytes from the source address to the destination address.
+            </summary>
+            <param name="destination">The destination address to copy to.</param>
+            <param name="source">The source address to copy from.</param>
+            <param name="byteCount">The number of bytes to copy.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned(System.Void*,System.Void*,System.UInt32)">
+            <summary>
+            Copies bytes from the source address to the destination address 
+            without assuming architecture dependent alignment of the addresses.
+            </summary>
+            <param name="destination">The destination address to copy to.</param>
+            <param name="source">The source address to copy from.</param>
+            <param name="byteCount">The number of bytes to copy.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned(System.Byte@,System.Byte@,System.UInt32)">
+            <summary>
+            Copies bytes from the source address to the destination address 
+            without assuming architecture dependent alignment of the addresses.
+            </summary>
+            <param name="destination">The destination address to copy to.</param>
+            <param name="source">The source address to copy from.</param>
+            <param name="byteCount">The number of bytes to copy.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.InitBlock(System.Void*,System.Byte,System.UInt32)">
+            <summary>
+            Initializes a block of memory at the given location with a given initial value.
+            </summary>
+            <param name="startAddress">The address of the start of the memory block to initialize.</param>
+            <param name="value">The value to initialize the block to.</param>
+            <param name="byteCount">The number of bytes to initialize.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.InitBlock(System.Byte@,System.Byte,System.UInt32)">
+            <summary>
+            Initializes a block of memory at the given location with a given initial value.
+            </summary>
+            <param name="startAddress">The address of the start of the memory block to initialize.</param>
+            <param name="value">The value to initialize the block to.</param>
+            <param name="byteCount">The number of bytes to initialize.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.InitBlockUnaligned(System.Void*,System.Byte,System.UInt32)">
+            <summary>
+            Initializes a block of memory at the given location with a given initial value 
+            without assuming architecture dependent alignment of the address.
+            </summary>
+            <param name="startAddress">The address of the start of the memory block to initialize.</param>
+            <param name="value">The value to initialize the block to.</param>
+            <param name="byteCount">The number of bytes to initialize.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.Unsafe.InitBlockUnaligned(System.Byte@,System.Byte,System.UInt32)">
+            <summary>
+            Initializes a block of memory at the given location with a given initial value 
+            without assuming architecture dependent alignment of the address.
+            </summary>
+            <param name="startAddress">The address of the start of the memory block to initialize.</param>
+            <param name="value">The value to initialize the block to.</param>
+            <param name="byteCount">The number of bytes to initialize.</param>
+        </member>
+    </members>
+</doc>

--- a/Tests/Plugins/system.runtime.compilerservices.unsafe.6.1.2/System.Runtime.CompilerServices.Unsafe.xml.meta
+++ b/Tests/Plugins/system.runtime.compilerservices.unsafe.6.1.2/System.Runtime.CompilerServices.Unsafe.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4d64e8e5858f3fc43ba7c270cc68dc1d
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Plugins/system.security.principal.windows.5.0.0.meta
+++ b/Tests/Plugins/system.security.principal.windows.5.0.0.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2e5b8a7b536d84346a7f75ef5629477e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Plugins/system.security.principal.windows.5.0.0/System.Security.Principal.Windows.dll
+++ b/Tests/Plugins/system.security.principal.windows.5.0.0/System.Security.Principal.Windows.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7828dfd952a9fd49404477baff714849177d9f18c0654adafadbdcafb4b21f47
+size 37768

--- a/Tests/Plugins/system.security.principal.windows.5.0.0/System.Security.Principal.Windows.dll.meta
+++ b/Tests/Plugins/system.security.principal.windows.5.0.0/System.Security.Principal.Windows.dll.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ae175260fd3b2aa419433a95d24062e2

--- a/Tests/Plugins/system.security.principal.windows.5.0.0/System.Security.Principal.Windows.xml
+++ b/Tests/Plugins/system.security.principal.windows.5.0.0/System.Security.Principal.Windows.xml
@@ -1,0 +1,1091 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<doc>
+  <assembly>
+    <name>System.Security.Principal.Windows</name>
+  </assembly>
+  <members>
+    <member name="T:Microsoft.Win32.SafeHandles.SafeAccessTokenHandle">
+      <summary>Provides a safe handle to a Windows thread or process access token. For more information, see Access Tokens.</summary>
+    </member>
+    <member name="M:Microsoft.Win32.SafeHandles.SafeAccessTokenHandle.#ctor(System.IntPtr)">
+      <summary>Initializes a new instance of the <see cref="T:Microsoft.Win32.SafeHandles.SafeAccessTokenHandle" /> class.</summary>
+      <param name="handle">An <see cref="T:System.IntPtr" /> object that represents the pre-existing handle to use. Using <see cref="F:System.IntPtr.Zero" /> returns an invalid handle.</param>
+    </member>
+    <member name="P:Microsoft.Win32.SafeHandles.SafeAccessTokenHandle.InvalidHandle">
+      <summary>Returns an invalid handle by instantiating a <see cref="T:Microsoft.Win32.SafeHandles.SafeAccessTokenHandle" /> object with <see cref="F:System.IntPtr.Zero" />.</summary>
+      <returns>Returns a <see cref="T:Microsoft.Win32.SafeHandles.SafeAccessTokenHandle" /> object.</returns>
+    </member>
+    <member name="P:Microsoft.Win32.SafeHandles.SafeAccessTokenHandle.IsInvalid">
+      <summary>Gets a value that indicates whether the handle is invalid.</summary>
+      <returns>
+        <see langword="true" /> if the handle is not valid; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="T:System.Security.Principal.IdentityNotMappedException">
+      <summary>Represents an exception for a principal whose identity could not be mapped to a known identity.</summary>
+    </member>
+    <member name="M:System.Security.Principal.IdentityNotMappedException.#ctor">
+      <summary>Initializes a new instance of the <see cref="T:System.Security.Principal.IdentityNotMappedException" /> class.</summary>
+    </member>
+    <member name="M:System.Security.Principal.IdentityNotMappedException.#ctor(System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Security.Principal.IdentityNotMappedException" /> class by using the specified error message.</summary>
+      <param name="message">The error message that explains the reason for the exception.</param>
+    </member>
+    <member name="M:System.Security.Principal.IdentityNotMappedException.#ctor(System.String,System.Exception)">
+      <summary>Initializes a new instance of the <see cref="T:System.Security.Principal.IdentityNotMappedException" /> class by using the specified error message and inner exception.</summary>
+      <param name="message">The error message that explains the reason for the exception.</param>
+      <param name="inner">The exception that is the cause of the current exception. If <paramref name="inner" /> is not null, the current exception is raised in a <see langword="catch" /> block that handles the inner exception.</param>
+    </member>
+    <member name="M:System.Security.Principal.IdentityNotMappedException.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)">
+      <summary>Gets serialization information with the data needed to create an instance of this <see cref="T:System.Security.Principal.IdentityNotMappedException" /> object.</summary>
+      <param name="serializationInfo">The object that holds the serialized object data about the exception being thrown.</param>
+      <param name="streamingContext">The object that contains contextual information about the source or destination.</param>
+    </member>
+    <member name="P:System.Security.Principal.IdentityNotMappedException.UnmappedIdentities">
+      <summary>Represents the collection of unmapped identities for an <see cref="T:System.Security.Principal.IdentityNotMappedException" /> exception.</summary>
+      <returns>The collection of unmapped identities.</returns>
+    </member>
+    <member name="T:System.Security.Principal.IdentityReference">
+      <summary>Represents an identity and is the base class for the <see cref="T:System.Security.Principal.NTAccount" /> and <see cref="T:System.Security.Principal.SecurityIdentifier" /> classes. This class does not provide a public constructor, and therefore cannot be inherited.</summary>
+    </member>
+    <member name="M:System.Security.Principal.IdentityReference.Equals(System.Object)">
+      <summary>Returns a value that indicates whether the specified object equals this instance of the <see cref="T:System.Security.Principal.IdentityReference" /> class.</summary>
+      <param name="o">An object to compare with this <see cref="T:System.Security.Principal.IdentityReference" /> instance, or a null reference.</param>
+      <returns>
+        <see langword="true" /> if <paramref name="o" /> is an object with the same underlying type and value as this <see cref="T:System.Security.Principal.IdentityReference" /> instance; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Security.Principal.IdentityReference.GetHashCode">
+      <summary>Serves as a hash function for <see cref="T:System.Security.Principal.IdentityReference" />. <see cref="M:System.Security.Principal.IdentityReference.GetHashCode" /> is suitable for use in hashing algorithms and data structures like a hash table.</summary>
+      <returns>The hash code for this <see cref="T:System.Security.Principal.IdentityReference" /> object.</returns>
+    </member>
+    <member name="M:System.Security.Principal.IdentityReference.IsValidTargetType(System.Type)">
+      <summary>Returns a value that indicates whether the specified type is a valid translation type for the <see cref="T:System.Security.Principal.IdentityReference" /> class.</summary>
+      <param name="targetType">The type being queried for validity to serve as a conversion from <see cref="T:System.Security.Principal.IdentityReference" />. The following target types are valid:  
+  
+ <see cref="T:System.Security.Principal.NTAccount" /><see cref="T:System.Security.Principal.SecurityIdentifier" /></param>
+      <returns>
+        <see langword="true" /> if <paramref name="targetType" /> is a valid translation type for the <see cref="T:System.Security.Principal.IdentityReference" /> class; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Security.Principal.IdentityReference.op_Equality(System.Security.Principal.IdentityReference,System.Security.Principal.IdentityReference)">
+      <summary>Compares two <see cref="T:System.Security.Principal.IdentityReference" /> objects to determine whether they are equal. They are considered equal if they have the same canonical name representation as the one returned by the <see cref="P:System.Security.Principal.IdentityReference.Value" /> property or if they are both <see langword="null" />.</summary>
+      <param name="left">The left <see cref="T:System.Security.Principal.IdentityReference" /> operand to use for the equality comparison. This parameter can be <see langword="null" />.</param>
+      <param name="right">The right <see cref="T:System.Security.Principal.IdentityReference" /> operand to use for the equality comparison. This parameter can be <see langword="null" />.</param>
+      <returns>
+        <see langword="true" /> if <paramref name="left" /> and <paramref name="right" /> are equal; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Security.Principal.IdentityReference.op_Inequality(System.Security.Principal.IdentityReference,System.Security.Principal.IdentityReference)">
+      <summary>Compares two <see cref="T:System.Security.Principal.IdentityReference" /> objects to determine whether they are not equal. They are considered not equal if they have different canonical name representations than the one returned by the <see cref="P:System.Security.Principal.IdentityReference.Value" /> property or if one of the objects is <see langword="null" /> and the other is not.</summary>
+      <param name="left">The left <see cref="T:System.Security.Principal.IdentityReference" /> operand to use for the inequality comparison. This parameter can be <see langword="null" />.</param>
+      <param name="right">The right <see cref="T:System.Security.Principal.IdentityReference" /> operand to use for the inequality comparison. This parameter can be <see langword="null" />.</param>
+      <returns>
+        <see langword="true" /> if <paramref name="left" /> and <paramref name="right" /> are not equal; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Security.Principal.IdentityReference.ToString">
+      <summary>Returns the string representation of the identity represented by the <see cref="T:System.Security.Principal.IdentityReference" /> object.</summary>
+      <returns>The identity in string format.</returns>
+    </member>
+    <member name="M:System.Security.Principal.IdentityReference.Translate(System.Type)">
+      <summary>Translates the account name represented by the <see cref="T:System.Security.Principal.IdentityReference" /> object into another <see cref="T:System.Security.Principal.IdentityReference" />-derived type.</summary>
+      <param name="targetType">The target type for the conversion from <see cref="T:System.Security.Principal.IdentityReference" />.</param>
+      <returns>The converted identity.</returns>
+    </member>
+    <member name="P:System.Security.Principal.IdentityReference.Value">
+      <summary>Gets the string value of the identity represented by the <see cref="T:System.Security.Principal.IdentityReference" /> object.</summary>
+      <returns>The string value of the identity represented by the <see cref="T:System.Security.Principal.IdentityReference" /> object.</returns>
+    </member>
+    <member name="T:System.Security.Principal.IdentityReferenceCollection">
+      <summary>Represents a collection of <see cref="T:System.Security.Principal.IdentityReference" /> objects and provides a means of converting sets of <see cref="T:System.Security.Principal.IdentityReference" />-derived objects to <see cref="T:System.Security.Principal.IdentityReference" />-derived types.</summary>
+    </member>
+    <member name="M:System.Security.Principal.IdentityReferenceCollection.#ctor">
+      <summary>Initializes a new instance of the <see cref="T:System.Security.Principal.IdentityReferenceCollection" /> class with zero items in the collection.</summary>
+    </member>
+    <member name="M:System.Security.Principal.IdentityReferenceCollection.#ctor(System.Int32)">
+      <summary>Initializes a new instance of the <see cref="T:System.Security.Principal.IdentityReferenceCollection" /> class by using the specified initial size.</summary>
+      <param name="capacity">The initial number of items in the collection. The value of <paramref name="capacity" /> is a hint only; it is not necessarily the maximum number of items created.</param>
+    </member>
+    <member name="M:System.Security.Principal.IdentityReferenceCollection.Add(System.Security.Principal.IdentityReference)">
+      <summary>Adds an <see cref="T:System.Security.Principal.IdentityReference" /> object to the <see cref="T:System.Security.Principal.IdentityReferenceCollection" /> collection.</summary>
+      <param name="identity">The <see cref="T:System.Security.Principal.IdentityReference" /> object to add to the collection.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="identity" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Security.Principal.IdentityReferenceCollection.Clear">
+      <summary>Clears all <see cref="T:System.Security.Principal.IdentityReference" /> objects from the <see cref="T:System.Security.Principal.IdentityReferenceCollection" /> collection.</summary>
+    </member>
+    <member name="M:System.Security.Principal.IdentityReferenceCollection.Contains(System.Security.Principal.IdentityReference)">
+      <summary>Indicates whether the <see cref="T:System.Security.Principal.IdentityReferenceCollection" /> collection contains the specified <see cref="T:System.Security.Principal.IdentityReference" /> object.</summary>
+      <param name="identity">The <see cref="T:System.Security.Principal.IdentityReference" /> object to check for.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="identity" /> is <see langword="null" />.</exception>
+      <returns>
+        <see langword="true" /> if the collection contains the specified object.</returns>
+    </member>
+    <member name="M:System.Security.Principal.IdentityReferenceCollection.CopyTo(System.Security.Principal.IdentityReference[],System.Int32)">
+      <summary>Copies the <see cref="T:System.Security.Principal.IdentityReferenceCollection" /> collection to an <see cref="T:System.Security.Principal.IdentityReferenceCollection" /> array, starting at the specified index.</summary>
+      <param name="array">An <see cref="T:System.Security.Principal.IdentityReferenceCollection" /> array object to which the <see cref="T:System.Security.Principal.IdentityReferenceCollection" /> collection is to be copied.</param>
+      <param name="offset">The zero-based index in <paramref name="array" /> where the <see cref="T:System.Security.Principal.IdentityReferenceCollection" /> collection is to be copied.</param>
+    </member>
+    <member name="M:System.Security.Principal.IdentityReferenceCollection.GetEnumerator">
+      <summary>Gets an enumerator that can be used to iterate through the <see cref="T:System.Security.Principal.IdentityReferenceCollection" /> collection.</summary>
+      <returns>An enumerator for the <see cref="T:System.Security.Principal.IdentityReferenceCollection" /> collection.</returns>
+    </member>
+    <member name="M:System.Security.Principal.IdentityReferenceCollection.Remove(System.Security.Principal.IdentityReference)">
+      <summary>Removes the specified <see cref="T:System.Security.Principal.IdentityReference" /> object from the collection.</summary>
+      <param name="identity">The <see cref="T:System.Security.Principal.IdentityReference" /> object to remove.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="identity" /> is <see langword="null" />.</exception>
+      <returns>
+        <see langword="true" /> if the specified object was removed from the collection.</returns>
+    </member>
+    <member name="M:System.Security.Principal.IdentityReferenceCollection.System#Collections#IEnumerable#GetEnumerator">
+      <summary>Gets an enumerator that can be used to iterate through the <see cref="T:System.Security.Principal.IdentityReferenceCollection" /> collection.</summary>
+      <returns>An enumerator for the <see cref="T:System.Security.Principal.IdentityReferenceCollection" /> collection.</returns>
+    </member>
+    <member name="M:System.Security.Principal.IdentityReferenceCollection.Translate(System.Type)">
+      <summary>Converts the objects in the collection to the specified type. Calling this method is the same as calling <see cref="M:System.Security.Principal.IdentityReferenceCollection.Translate(System.Type,System.Boolean)" /> with the second parameter set to <see langword="false" />, which means that exceptions will not be thrown for items that fail conversion.</summary>
+      <param name="targetType">The type to which items in the collection are being converted.</param>
+      <returns>A <see cref="T:System.Security.Principal.IdentityReferenceCollection" /> collection that represents the converted contents of the original collection.</returns>
+    </member>
+    <member name="M:System.Security.Principal.IdentityReferenceCollection.Translate(System.Type,System.Boolean)">
+      <summary>Converts the objects in the collection to the specified type and uses the specified fault tolerance to handle or ignore errors associated with a type not having a conversion mapping.</summary>
+      <param name="targetType">The type to which items in the collection are being converted.</param>
+      <param name="forceSuccess">A Boolean value that determines how conversion errors are handled.  
+  
+ If <paramref name="forceSuccess" /> is <see langword="true" />, conversion errors due to a mapping not being found for the translation result in a failed conversion and exceptions being thrown.  
+  
+ If <paramref name="forceSuccess" /> is <see langword="false" />, types that failed to convert due to a mapping not being found for the translation are copied without being converted into the collection being returned.</param>
+      <returns>A <see cref="T:System.Security.Principal.IdentityReferenceCollection" /> collection that represents the converted contents of the original collection.</returns>
+    </member>
+    <member name="P:System.Security.Principal.IdentityReferenceCollection.Count">
+      <summary>Gets the number of items in the <see cref="T:System.Security.Principal.IdentityReferenceCollection" /> collection.</summary>
+      <returns>The number of <see cref="T:System.Security.Principal.IdentityReference" /> objects in the <see cref="T:System.Security.Principal.IdentityReferenceCollection" /> collection.</returns>
+    </member>
+    <member name="P:System.Security.Principal.IdentityReferenceCollection.Item(System.Int32)">
+      <summary>Gets or sets the node at the specified index of the <see cref="T:System.Security.Principal.IdentityReferenceCollection" /> collection.</summary>
+      <param name="index">The zero-based index in the <see cref="T:System.Security.Principal.IdentityReferenceCollection" /> collection.</param>
+      <returns>The <see cref="T:System.Security.Principal.IdentityReference" /> at the specified index in the collection. If <paramref name="index" /> is greater than or equal to the number of nodes in the collection, the return value is <see langword="null" />.</returns>
+    </member>
+    <member name="P:System.Security.Principal.IdentityReferenceCollection.System#Collections#Generic#ICollection{System#Security#Principal#IdentityReference}#IsReadOnly">
+      <summary>Gets a value indicating whether the <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only.</summary>
+      <returns>
+        <see langword="true" /> if the <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="T:System.Security.Principal.NTAccount">
+      <summary>Represents a user or group account.</summary>
+    </member>
+    <member name="M:System.Security.Principal.NTAccount.#ctor(System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Security.Principal.NTAccount" /> class by using the specified name.</summary>
+      <param name="name">The name used to create the <see cref="T:System.Security.Principal.NTAccount" /> object. This parameter cannot be <see langword="null" /> or an empty string.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="name" /> is an empty string.  
+  
+ -or-  
+  
+ <paramref name="name" /> is too long.</exception>
+    </member>
+    <member name="M:System.Security.Principal.NTAccount.#ctor(System.String,System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Security.Principal.NTAccount" /> class by using the specified domain name and account name.</summary>
+      <param name="domainName">The name of the domain. This parameter can be <see langword="null" /> or an empty string. Domain names that are null values are treated like an empty string.</param>
+      <param name="accountName">The name of the account. This parameter cannot be <see langword="null" /> or an empty string.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="accountName" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="accountName" /> is an empty string.  
+  
+ -or-  
+  
+ <paramref name="accountName" /> is too long.  
+  
+ -or-  
+  
+ <paramref name="domainName" /> is too long.</exception>
+    </member>
+    <member name="M:System.Security.Principal.NTAccount.Equals(System.Object)">
+      <summary>Returns a value that indicates whether this <see cref="T:System.Security.Principal.NTAccount" /> object is equal to a specified object.</summary>
+      <param name="o">An object to compare with this <see cref="T:System.Security.Principal.NTAccount" /> object, or <see langword="null" />.</param>
+      <returns>
+        <see langword="true" /> if <paramref name="o" /> is an object with the same underlying type and value as this <see cref="T:System.Security.Principal.NTAccount" /> object; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Security.Principal.NTAccount.GetHashCode">
+      <summary>Serves as a hash function for the current <see cref="T:System.Security.Principal.NTAccount" /> object. The <see cref="M:System.Security.Principal.NTAccount.GetHashCode" /> method is suitable for hashing algorithms and data structures like a hash table.</summary>
+      <returns>A hash value for the current <see cref="T:System.Security.Principal.NTAccount" /> object.</returns>
+    </member>
+    <member name="M:System.Security.Principal.NTAccount.IsValidTargetType(System.Type)">
+      <summary>Returns a value that indicates whether the specified type is a valid translation type for the <see cref="T:System.Security.Principal.NTAccount" /> class.</summary>
+      <param name="targetType">The type being queried for validity to serve as a conversion from <see cref="T:System.Security.Principal.NTAccount" />. The following target types are valid:  
+  
+ - <see cref="T:System.Security.Principal.NTAccount" />  
+  
+ - <see cref="T:System.Security.Principal.SecurityIdentifier" /></param>
+      <returns>
+        <see langword="true" /> if <paramref name="targetType" /> is a valid translation type for the <see cref="T:System.Security.Principal.NTAccount" /> class; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Security.Principal.NTAccount.op_Equality(System.Security.Principal.NTAccount,System.Security.Principal.NTAccount)">
+      <summary>Compares two <see cref="T:System.Security.Principal.NTAccount" /> objects to determine whether they are equal. They are considered equal if they have the same canonical name representation as the one returned by the <see cref="P:System.Security.Principal.NTAccount.Value" /> property or if they are both <see langword="null" />.</summary>
+      <param name="left">The left operand to use for the equality comparison. This parameter can be <see langword="null" />.</param>
+      <param name="right">The right operand to use for the equality comparison. This parameter can be <see langword="null" />.</param>
+      <returns>
+        <see langword="true" /> if <paramref name="left" /> and <paramref name="right" /> are equal; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Security.Principal.NTAccount.op_Inequality(System.Security.Principal.NTAccount,System.Security.Principal.NTAccount)">
+      <summary>Compares two <see cref="T:System.Security.Principal.NTAccount" /> objects to determine whether they are not equal. They are considered not equal if they have different canonical name representations than the one returned by the <see cref="P:System.Security.Principal.NTAccount.Value" /> property or if one of the objects is <see langword="null" /> and the other is not.</summary>
+      <param name="left">The left operand to use for the inequality comparison. This parameter can be <see langword="null" />.</param>
+      <param name="right">The right operand to use for the inequality comparison. This parameter can be <see langword="null" />.</param>
+      <returns>
+        <see langword="true" /> if <paramref name="left" /> and <paramref name="right" /> are not equal; otherwise <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Security.Principal.NTAccount.ToString">
+      <summary>Returns the account name, in Domain \ Account format, for the account represented by the <see cref="T:System.Security.Principal.NTAccount" /> object.</summary>
+      <returns>The account name, in Domain \ Account format.</returns>
+    </member>
+    <member name="M:System.Security.Principal.NTAccount.Translate(System.Type)">
+      <summary>Translates the account name represented by the <see cref="T:System.Security.Principal.NTAccount" /> object into another <see cref="T:System.Security.Principal.IdentityReference" />-derived type.</summary>
+      <param name="targetType">The target type for the conversion from <see cref="T:System.Security.Principal.NTAccount" />. The target type must be a type that is considered valid by the <see cref="M:System.Security.Principal.NTAccount.IsValidTargetType(System.Type)" /> method.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="targetType" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="targetType" /> is not an <see cref="T:System.Security.Principal.IdentityReference" /> type.</exception>
+      <exception cref="T:System.Security.Principal.IdentityNotMappedException">Some or all identity references could not be translated.</exception>
+      <exception cref="T:System.SystemException">The source account name is too long.  
+  
+ -or-  
+  
+ A Win32 error code was returned.</exception>
+      <returns>The converted identity.</returns>
+    </member>
+    <member name="P:System.Security.Principal.NTAccount.Value">
+      <summary>Returns a string representation of this <see cref="T:System.Security.Principal.NTAccount" /> object.</summary>
+      <returns>The string representation of this <see cref="T:System.Security.Principal.NTAccount" /> object.</returns>
+    </member>
+    <member name="T:System.Security.Principal.SecurityIdentifier">
+      <summary>Represents a security identifier (SID) and provides marshaling and comparison operations for SIDs.</summary>
+    </member>
+    <member name="F:System.Security.Principal.SecurityIdentifier.MaxBinaryLength">
+      <summary>Returns the maximum size, in bytes, of the binary representation of the security identifier.</summary>
+    </member>
+    <member name="F:System.Security.Principal.SecurityIdentifier.MinBinaryLength">
+      <summary>Returns the minimum size, in bytes, of the binary representation of the security identifier.</summary>
+    </member>
+    <member name="M:System.Security.Principal.SecurityIdentifier.#ctor(System.Byte[],System.Int32)">
+      <summary>Initializes a new instance of the <see cref="T:System.Security.Principal.SecurityIdentifier" /> class by using a specified binary representation of a security identifier (SID).</summary>
+      <param name="binaryForm">The byte array that represents the SID.</param>
+      <param name="offset">The byte offset to use as the starting index in <paramref name="binaryForm" />.</param>
+    </member>
+    <member name="M:System.Security.Principal.SecurityIdentifier.#ctor(System.IntPtr)">
+      <summary>Initializes a new instance of the <see cref="T:System.Security.Principal.SecurityIdentifier" /> class by using an integer that represents the binary form of a security identifier (SID).</summary>
+      <param name="binaryForm">An integer that represents the binary form of a SID.</param>
+    </member>
+    <member name="M:System.Security.Principal.SecurityIdentifier.#ctor(System.Security.Principal.WellKnownSidType,System.Security.Principal.SecurityIdentifier)">
+      <summary>Initializes a new instance of the <see cref="T:System.Security.Principal.SecurityIdentifier" /> class by using the specified well known security identifier (SID) type and domain SID.</summary>
+      <param name="sidType">One of the enumeration values. This value must not be <see cref="F:System.Security.Principal.WellKnownSidType.LogonIdsSid" />.</param>
+      <param name="domainSid">The domain SID. This value is required for the following <see cref="T:System.Security.Principal.WellKnownSidType" /> values. This parameter is ignored for any other <see cref="T:System.Security.Principal.WellKnownSidType" /> values.  
+  
+ - <see cref="F:System.Security.Principal.WellKnownSidType.AccountAdministratorSid" />  
+  
+ - <see cref="F:System.Security.Principal.WellKnownSidType.AccountGuestSid" />  
+  
+ - <see cref="F:System.Security.Principal.WellKnownSidType.AccountKrbtgtSid" />  
+  
+ - <see cref="F:System.Security.Principal.WellKnownSidType.AccountDomainAdminsSid" />  
+  
+ - <see cref="F:System.Security.Principal.WellKnownSidType.AccountDomainUsersSid" />  
+  
+ - <see cref="F:System.Security.Principal.WellKnownSidType.AccountDomainGuestsSid" />  
+  
+ - <see cref="F:System.Security.Principal.WellKnownSidType.AccountComputersSid" />  
+  
+ - <see cref="F:System.Security.Principal.WellKnownSidType.AccountControllersSid" />  
+  
+ - <see cref="F:System.Security.Principal.WellKnownSidType.AccountCertAdminsSid" />  
+  
+ - <see cref="F:System.Security.Principal.WellKnownSidType.AccountSchemaAdminsSid" />  
+  
+ - <see cref="F:System.Security.Principal.WellKnownSidType.AccountEnterpriseAdminsSid" />  
+  
+ - <see cref="F:System.Security.Principal.WellKnownSidType.AccountPolicyAdminsSid" />  
+  
+ - <see cref="F:System.Security.Principal.WellKnownSidType.AccountRasAndIasServersSid" /></param>
+    </member>
+    <member name="M:System.Security.Principal.SecurityIdentifier.#ctor(System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Security.Principal.SecurityIdentifier" /> class by using the specified security identifier (SID) in Security Descriptor Definition Language (SDDL) format.</summary>
+      <param name="sddlForm">SDDL string for the SID used to create the <see cref="T:System.Security.Principal.SecurityIdentifier" /> object.</param>
+    </member>
+    <member name="M:System.Security.Principal.SecurityIdentifier.CompareTo(System.Security.Principal.SecurityIdentifier)">
+      <summary>Compares the current <see cref="T:System.Security.Principal.SecurityIdentifier" /> object with the specified <see cref="T:System.Security.Principal.SecurityIdentifier" /> object.</summary>
+      <param name="sid">The object to compare with the current object.</param>
+      <returns>A signed number indicating the relative values of this instance and <paramref name="sid" />.  
+  
+ <list type="table"><listheader><term> Return Value</term><description> Description</description></listheader><item><term> Less than zero</term><description> This instance is less than <paramref name="sid" />.</description></item><item><term> Zero</term><description> This instance is equal to <paramref name="sid" />.</description></item><item><term> Greater than zero</term><description> This instance is greater than <paramref name="sid" />.</description></item></list></returns>
+    </member>
+    <member name="M:System.Security.Principal.SecurityIdentifier.Equals(System.Object)">
+      <summary>Returns a value that indicates whether this <see cref="T:System.Security.Principal.SecurityIdentifier" /> object is equal to a specified object.</summary>
+      <param name="o">An object to compare with this <see cref="T:System.Security.Principal.SecurityIdentifier" /> object, or <see langword="null" />.</param>
+      <returns>
+        <see langword="true" /> if <paramref name="o" /> is an object with the same underlying type and value as this <see cref="T:System.Security.Principal.SecurityIdentifier" /> object; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Security.Principal.SecurityIdentifier.Equals(System.Security.Principal.SecurityIdentifier)">
+      <summary>Indicates whether the specified <see cref="T:System.Security.Principal.SecurityIdentifier" /> object is equal to the current <see cref="T:System.Security.Principal.SecurityIdentifier" /> object.</summary>
+      <param name="sid">The object to compare with the current object.</param>
+      <returns>
+        <see langword="true" /> if the value of <paramref name="sid" /> is equal to the value of the current <see cref="T:System.Security.Principal.SecurityIdentifier" /> object.</returns>
+    </member>
+    <member name="M:System.Security.Principal.SecurityIdentifier.GetBinaryForm(System.Byte[],System.Int32)">
+      <summary>Copies the binary representation of the specified security identifier (SID) represented by the <see cref="T:System.Security.Principal.SecurityIdentifier" /> class to a byte array.</summary>
+      <param name="binaryForm">The byte array to receive the copied SID.</param>
+      <param name="offset">The byte offset to use as the starting index in <paramref name="binaryForm" />.</param>
+    </member>
+    <member name="M:System.Security.Principal.SecurityIdentifier.GetHashCode">
+      <summary>Serves as a hash function for the current <see cref="T:System.Security.Principal.SecurityIdentifier" /> object. The <see cref="M:System.Security.Principal.SecurityIdentifier.GetHashCode" /> method is suitable for hashing algorithms and data structures like a hash table.</summary>
+      <returns>A hash value for the current <see cref="T:System.Security.Principal.SecurityIdentifier" /> object.</returns>
+    </member>
+    <member name="M:System.Security.Principal.SecurityIdentifier.IsAccountSid">
+      <summary>Returns a value that indicates whether the security identifier (SID) represented by this <see cref="T:System.Security.Principal.SecurityIdentifier" /> object is a valid Windows account SID.</summary>
+      <returns>
+        <see langword="true" /> if the SID represented by this <see cref="T:System.Security.Principal.SecurityIdentifier" /> object is a valid Windows account SID; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Security.Principal.SecurityIdentifier.IsEqualDomainSid(System.Security.Principal.SecurityIdentifier)">
+      <summary>Returns a value that indicates whether the security identifier (SID) represented by this <see cref="T:System.Security.Principal.SecurityIdentifier" /> object is from the same domain as the specified SID.</summary>
+      <param name="sid">The SID to compare with this <see cref="T:System.Security.Principal.SecurityIdentifier" /> object.</param>
+      <returns>
+        <see langword="true" /> if the SID represented by this <see cref="T:System.Security.Principal.SecurityIdentifier" /> object is in the same domain as the <paramref name="sid" /> SID; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Security.Principal.SecurityIdentifier.IsValidTargetType(System.Type)">
+      <summary>Returns a value that indicates whether the specified type is a valid translation type for the <see cref="T:System.Security.Principal.SecurityIdentifier" /> class.</summary>
+      <param name="targetType">The type being queried for validity to serve as a conversion from <see cref="T:System.Security.Principal.SecurityIdentifier" />. The following target types are valid:  
+  
+ - <see cref="T:System.Security.Principal.NTAccount" />  
+  
+ - <see cref="T:System.Security.Principal.SecurityIdentifier" /></param>
+      <returns>
+        <see langword="true" /> if <paramref name="targetType" /> is a valid translation type for the <see cref="T:System.Security.Principal.SecurityIdentifier" /> class; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Security.Principal.SecurityIdentifier.IsWellKnown(System.Security.Principal.WellKnownSidType)">
+      <summary>Returns a value that indicates whether the <see cref="T:System.Security.Principal.SecurityIdentifier" /> object matches the specified well known security identifier (SID) type.</summary>
+      <param name="type">A value to compare with the <see cref="T:System.Security.Principal.SecurityIdentifier" /> object.</param>
+      <returns>
+        <see langword="true" /> if <paramref name="type" /> is the SID type for the <see cref="T:System.Security.Principal.SecurityIdentifier" /> object; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Security.Principal.SecurityIdentifier.op_Equality(System.Security.Principal.SecurityIdentifier,System.Security.Principal.SecurityIdentifier)">
+      <summary>Compares two <see cref="T:System.Security.Principal.SecurityIdentifier" /> objects to determine whether they are equal. They are considered equal if they have the same canonical representation as the one returned by the <see cref="P:System.Security.Principal.SecurityIdentifier.Value" /> property or if they are both <see langword="null" />.</summary>
+      <param name="left">The left operand to use for the equality comparison. This parameter can be <see langword="null" />.</param>
+      <param name="right">The right operand to use for the equality comparison. This parameter can be <see langword="null" />.</param>
+      <returns>
+        <see langword="true" /> if <paramref name="left" /> and <paramref name="right" /> are equal; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Security.Principal.SecurityIdentifier.op_Inequality(System.Security.Principal.SecurityIdentifier,System.Security.Principal.SecurityIdentifier)">
+      <summary>Compares two <see cref="T:System.Security.Principal.SecurityIdentifier" /> objects to determine whether they are not equal. They are considered not equal if they have different canonical name representations than the one returned by the <see cref="P:System.Security.Principal.SecurityIdentifier.Value" /> property or if one of the objects is <see langword="null" /> and the other is not.</summary>
+      <param name="left">The left operand to use for the inequality comparison. This parameter can be <see langword="null" />.</param>
+      <param name="right">The right operand to use for the inequality comparison. This parameter can be <see langword="null" />.</param>
+      <returns>
+        <see langword="true" /> if <paramref name="left" /> and <paramref name="right" /> are not equal; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Security.Principal.SecurityIdentifier.ToString">
+      <summary>Returns the security identifier (SID), in Security Descriptor Definition Language (SDDL) format, for the account represented by the <see cref="T:System.Security.Principal.SecurityIdentifier" /> object. An example of the SDDL format is S-1-5-9.</summary>
+      <returns>The SID, in SDDL format, for the account represented by the <see cref="T:System.Security.Principal.SecurityIdentifier" /> object.</returns>
+    </member>
+    <member name="M:System.Security.Principal.SecurityIdentifier.Translate(System.Type)">
+      <summary>Translates the account name represented by the <see cref="T:System.Security.Principal.SecurityIdentifier" /> object into another <see cref="T:System.Security.Principal.IdentityReference" />-derived type.</summary>
+      <param name="targetType">The target type for the conversion from <see cref="T:System.Security.Principal.SecurityIdentifier" />. The target type must be a type that is considered valid by the <see cref="M:System.Security.Principal.SecurityIdentifier.IsValidTargetType(System.Type)" /> method.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="targetType" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="targetType" /> is not an <see cref="T:System.Security.Principal.IdentityReference" /> type.</exception>
+      <exception cref="T:System.Security.Principal.IdentityNotMappedException">Some or all identity references could not be translated.</exception>
+      <exception cref="T:System.SystemException">A Win32 error code was returned.</exception>
+      <returns>The converted identity.</returns>
+    </member>
+    <member name="P:System.Security.Principal.SecurityIdentifier.AccountDomainSid">
+      <summary>Returns the account domain security identifier (SID) portion from the SID represented by the <see cref="T:System.Security.Principal.SecurityIdentifier" /> object if the SID represents a Windows account SID. If the SID does not represent a Windows account SID, this property returns <see langword="null" />.</summary>
+      <returns>The account domain SID portion from the SID represented by the <see cref="T:System.Security.Principal.SecurityIdentifier" /> object if the SID represents a Windows account SID; otherwise, it returns <see langword="null" />.</returns>
+    </member>
+    <member name="P:System.Security.Principal.SecurityIdentifier.BinaryLength">
+      <summary>Returns the length, in bytes, of the security identifier (SID) represented by the <see cref="T:System.Security.Principal.SecurityIdentifier" /> object.</summary>
+      <returns>The length, in bytes, of the SID represented by the <see cref="T:System.Security.Principal.SecurityIdentifier" /> object.</returns>
+    </member>
+    <member name="P:System.Security.Principal.SecurityIdentifier.Value">
+      <summary>Returns an uppercase Security Descriptor Definition Language (SDDL) string for the security identifier (SID) represented by this <see cref="T:System.Security.Principal.SecurityIdentifier" /> object.</summary>
+      <returns>An uppercase SDDL string for the SID represented by the <see cref="T:System.Security.Principal.SecurityIdentifier" /> object.</returns>
+    </member>
+    <member name="T:System.Security.Principal.TokenAccessLevels">
+      <summary>Defines the privileges of the user account associated with the access token.</summary>
+    </member>
+    <member name="F:System.Security.Principal.TokenAccessLevels.AdjustDefault">
+      <summary>The user can change the default owner, primary group, or discretionary access control list (DACL) of the token.</summary>
+    </member>
+    <member name="F:System.Security.Principal.TokenAccessLevels.AdjustGroups">
+      <summary>The user can change the attributes of the groups in the token.</summary>
+    </member>
+    <member name="F:System.Security.Principal.TokenAccessLevels.AdjustPrivileges">
+      <summary>The user can enable or disable privileges in the token.</summary>
+    </member>
+    <member name="F:System.Security.Principal.TokenAccessLevels.AdjustSessionId">
+      <summary>The user can adjust the session identifier of the token.</summary>
+    </member>
+    <member name="F:System.Security.Principal.TokenAccessLevels.AllAccess">
+      <summary>The user has all possible access to the token.</summary>
+    </member>
+    <member name="F:System.Security.Principal.TokenAccessLevels.AssignPrimary">
+      <summary>The user can attach a primary token to a process.</summary>
+    </member>
+    <member name="F:System.Security.Principal.TokenAccessLevels.Duplicate">
+      <summary>The user can duplicate the token.</summary>
+    </member>
+    <member name="F:System.Security.Principal.TokenAccessLevels.Impersonate">
+      <summary>The user can impersonate a client.</summary>
+    </member>
+    <member name="F:System.Security.Principal.TokenAccessLevels.MaximumAllowed">
+      <summary>The maximum value that can be assigned for the <see cref="T:System.Security.Principal.TokenAccessLevels" /> enumeration.</summary>
+    </member>
+    <member name="F:System.Security.Principal.TokenAccessLevels.Query">
+      <summary>The user can query the token.</summary>
+    </member>
+    <member name="F:System.Security.Principal.TokenAccessLevels.QuerySource">
+      <summary>The user can query the source of the token.</summary>
+    </member>
+    <member name="F:System.Security.Principal.TokenAccessLevels.Read">
+      <summary>The user has standard read rights and the <see cref="F:System.Security.Principal.TokenAccessLevels.Query" /> privilege for the token.</summary>
+    </member>
+    <member name="F:System.Security.Principal.TokenAccessLevels.Write">
+      <summary>The user has standard write rights and the <see cref="F:System.Security.Principal.TokenAccessLevels.AdjustPrivileges" />, <see cref="F:System.Security.Principal.TokenAccessLevels.AdjustGroups" /> and <see cref="F:System.Security.Principal.TokenAccessLevels.AdjustDefault" /> privileges for the token.</summary>
+    </member>
+    <member name="T:System.Security.Principal.WellKnownSidType">
+      <summary>Defines a set of commonly used security identifiers (SIDs).</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.AccountAdministratorSid">
+      <summary>Indicates a SID that matches the account administrators group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.AccountCertAdminsSid">
+      <summary>Indicates a SID that matches the certificate administrators group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.AccountComputersSid">
+      <summary>Indicates a SID that matches the account computer group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.AccountControllersSid">
+      <summary>Indicates a SID that matches the account controller group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.AccountDomainAdminsSid">
+      <summary>Indicates a SID that matches the account domain administrator group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.AccountDomainGuestsSid">
+      <summary>Indicates a SID that matches the account domain guests group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.AccountDomainUsersSid">
+      <summary>Indicates a SID that matches the account domain users group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.AccountEnterpriseAdminsSid">
+      <summary>Indicates a SID that matches the enterprise administrators group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.AccountGuestSid">
+      <summary>Indicates a SID that matches the account guest group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.AccountKrbtgtSid">
+      <summary>Indicates a SID that matches the account Kerberos target group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.AccountPolicyAdminsSid">
+      <summary>Indicates a SID that matches the policy administrators group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.AccountRasAndIasServersSid">
+      <summary>Indicates a SID that matches the RAS and IAS server account.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.AccountSchemaAdminsSid">
+      <summary>Indicates a SID that matches the schema administrators group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.AnonymousSid">
+      <summary>Indicates a SID for the anonymous account.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.AuthenticatedUserSid">
+      <summary>Indicates a SID for an authenticated user.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.BatchSid">
+      <summary>Indicates a SID for a batch process. This SID is added to the process of a token when it logs on as a batch job.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.BuiltinAccountOperatorsSid">
+      <summary>Indicates a SID that matches the account operators account.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.BuiltinAdministratorsSid">
+      <summary>Indicates a SID that matches the administrator account.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.BuiltinAuthorizationAccessSid">
+      <summary>Indicates a SID that matches the Windows Authorization Access group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.BuiltinBackupOperatorsSid">
+      <summary>Indicates a SID that matches the backup operators group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.BuiltinDomainSid">
+      <summary>Indicates a SID that matches the domain account.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.BuiltinGuestsSid">
+      <summary>Indicates a SID that matches the guest account.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.BuiltinIncomingForestTrustBuildersSid">
+      <summary>Indicates a SID that allows a user to create incoming forest trusts. It is added to the token of users who are a member of the Incoming Forest Trust Builders built-in group in the root domain of the forest.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.BuiltinNetworkConfigurationOperatorsSid">
+      <summary>Indicates a SID that matches the network operators group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.BuiltinPerformanceLoggingUsersSid">
+      <summary>Indicates a SID that matches the group of users that have remote access to monitor the computer.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.BuiltinPerformanceMonitoringUsersSid">
+      <summary>Indicates a SID that matches the group of users that have remote access to schedule logging of performance counters on this computer.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.BuiltinPowerUsersSid">
+      <summary>Indicates a SID that matches the power users group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.BuiltinPreWindows2000CompatibleAccessSid">
+      <summary>Indicates a SID that matches pre-Windows 2000 compatible accounts.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.BuiltinPrintOperatorsSid">
+      <summary>Indicates a SID that matches the print operators group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.BuiltinRemoteDesktopUsersSid">
+      <summary>Indicates a SID that matches remote desktop users.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.BuiltinReplicatorSid">
+      <summary>Indicates a SID that matches the replicator account.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.BuiltinSystemOperatorsSid">
+      <summary>Indicates a SID that matches the system operators group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.BuiltinUsersSid">
+      <summary>Indicates a SID that matches built-in user accounts.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.CreatorGroupServerSid">
+      <summary>Indicates a creator group server SID.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.CreatorGroupSid">
+      <summary>Indicates a SID that matches the creator group of an object.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.CreatorOwnerServerSid">
+      <summary>Indicates a creator owner server SID.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.CreatorOwnerSid">
+      <summary>Indicates a SID that matches the owner or creator of an object.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.DialupSid">
+      <summary>Indicates a SID for a dial-up account.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.DigestAuthenticationSid">
+      <summary>Indicates a SID present when the Microsoft Digest authentication package authenticated the client.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.EnterpriseControllersSid">
+      <summary>Indicates a SID for an enterprise controller.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.InteractiveSid">
+      <summary>Indicates a SID for an interactive account. This SID is added to the process of a token when it logs on interactively.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.LocalServiceSid">
+      <summary>Indicates a SID that matches a local service.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.LocalSid">
+      <summary>Indicates a local SID.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.LocalSystemSid">
+      <summary>Indicates a SID that matches the local system.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.LogonIdsSid">
+      <summary>Indicates a SID that matches logon IDs.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.MaxDefined">
+      <summary>Indicates the maximum defined SID in the <see cref="T:System.Security.Principal.WellKnownSidType" /> enumeration.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.NetworkServiceSid">
+      <summary>Indicates a SID that matches a network service.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.NetworkSid">
+      <summary>Indicates a SID for a network account. This SID is added to the process of a token when it logs on across a network.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.NTAuthoritySid">
+      <summary>Indicates a SID for the Windows NT authority.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.NtlmAuthenticationSid">
+      <summary>Indicates a SID present when the Microsoft NTLM authentication package authenticated the client.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.NullSid">
+      <summary>Indicates a null SID.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.OtherOrganizationSid">
+      <summary>Indicates a SID present when the user authenticated across a forest with the selective authentication option enabled. If this SID is present, then <see cref="F:System.Security.Principal.WellKnownSidType.ThisOrganizationSid" /> cannot be present.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.ProxySid">
+      <summary>Indicates a proxy SID.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.RemoteLogonIdSid">
+      <summary>Indicates a SID that matches remote logons.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.RestrictedCodeSid">
+      <summary>Indicates a SID for restricted code.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.SChannelAuthenticationSid">
+      <summary>Indicates a SID present when the Secure Channel (SSL/TLS) authentication package authenticated the client.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.SelfSid">
+      <summary>Indicates a SID for self.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.ServiceSid">
+      <summary>Indicates a SID for a service. This SID is added to the process of a token when it logs on as a service.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.TerminalServerSid">
+      <summary>Indicates a SID that matches a terminal server account.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.ThisOrganizationSid">
+      <summary>Indicates a SID present when the user authenticated from within the forest or across a trust that does not have the selective authentication option enabled. If this SID is present, then <see cref="F:System.Security.Principal.WellKnownSidType.OtherOrganizationSid" /> cannot be present.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinAccountReadonlyControllersSid">
+      <summary>Indicates a SID that matches an account read-only controllers group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinApplicationPackageAuthoritySid">
+      <summary>Indicates a SID that matches the application package authority.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinBuiltinAnyPackageSid">
+      <summary>Indicates a SID that applies to all app containers.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinBuiltinCertSvcDComAccessGroup">
+      <summary>Indicates a SID that matches the built-in DCOM certification services access group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinBuiltinCryptoOperatorsSid">
+      <summary>Indicates a SID that allows a user to use cryptographic operations. It is added to the token of users who are a member of the CryptoOperators built-in group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinBuiltinDCOMUsersSid">
+      <summary>Indicates a SID that matches the distributed COM user group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinBuiltinEventLogReadersGroup">
+      <summary>Indicates a SID that matches an event log readers group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinBuiltinIUsersSid">
+      <summary>Indicates a SID that matches the Internet built-in user group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinBuiltinTerminalServerLicenseServersSid">
+      <summary>Indicates a SID is present in a server that can issue Terminal Server licenses.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinCacheablePrincipalsGroupSid">
+      <summary>Indicates a SID that matches a cacheable principals group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinCapabilityDocumentsLibrarySid">
+      <summary>Indicates a SID for documents library capability for app containers.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinCapabilityEnterpriseAuthenticationSid">
+      <summary>Indicates a SID for Windows credentials capability for app containers.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinCapabilityInternetClientServerSid">
+      <summary>Indicates a SID of Internet client and server capability for app containers.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinCapabilityInternetClientSid">
+      <summary>Indicates a SID of Internet client capability for app containers.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinCapabilityMusicLibrarySid">
+      <summary>Indicates a SID for music library capability for app containers.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinCapabilityPicturesLibrarySid">
+      <summary>Indicates a SID for pictures library capability for app containers.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinCapabilityPrivateNetworkClientServerSid">
+      <summary>Indicates a SID of private network client and server capability for app containers.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinCapabilityRemovableStorageSid">
+      <summary>Indicates a SID for removable storage capability for app containers.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinCapabilitySharedUserCertificatesSid">
+      <summary>Indicates a SID for shared user certificates capability for app containers.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinCapabilityVideosLibrarySid">
+      <summary>Indicates a SID for videos library capability for app containers.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinConsoleLogonSid">
+      <summary>Indicates a SID that matches a console logon group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinCreatorOwnerRightsSid">
+      <summary>Indicates a SID that matches a creator and owner rights group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinEnterpriseReadonlyControllersSid">
+      <summary>Indicates a SID that matches an enterprise wide read-only controllers group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinHighLabelSid">
+      <summary>Indicates a SID that matches a high level of trust label.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinIUserSid">
+      <summary>Indicates a SID that matches the Internet user group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinLocalLogonSid">
+      <summary>Indicates a SID that matches a local logon group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinLowLabelSid">
+      <summary>Indicates a SID that matches an low level of trust label.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinMediumLabelSid">
+      <summary>Indicates a SID that matches an medium level of trust label.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinMediumPlusLabelSid">
+      <summary>Indicates a SID that matches the medium plus integrity label.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinNewEnterpriseReadonlyControllersSid">
+      <summary>Indicates a SID that matches a read-only enterprise domain controller.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinNonCacheablePrincipalsGroupSid">
+      <summary>Indicates a SID that matches a non-cacheable principals group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinSystemLabelSid">
+      <summary>Indicates a SID that matches a system label.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinThisOrganizationCertificateSid">
+      <summary>Indicates a SID that matches a certificate for the given organization.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinUntrustedLabelSid">
+      <summary>Indicates a SID that matches an untrusted label.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WinWriteRestrictedCodeSid">
+      <summary>Indicates a SID that matches a write restricted code group.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WellKnownSidType.WorldSid">
+      <summary>Indicates a SID that matches everyone.</summary>
+    </member>
+    <member name="T:System.Security.Principal.WindowsAccountType">
+      <summary>Specifies the type of Windows account used.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WindowsAccountType.Anonymous">
+      <summary>An anonymous account.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WindowsAccountType.Guest">
+      <summary>A Windows guest account.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WindowsAccountType.Normal">
+      <summary>A standard user account.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WindowsAccountType.System">
+      <summary>A Windows system account.</summary>
+    </member>
+    <member name="T:System.Security.Principal.WindowsBuiltInRole">
+      <summary>Specifies common roles to be used with <see cref="M:System.Security.Principal.WindowsPrincipal.IsInRole(System.String)" />.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WindowsBuiltInRole.AccountOperator">
+      <summary>Account operators manage the user accounts on a computer or domain.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WindowsBuiltInRole.Administrator">
+      <summary>Administrators have complete and unrestricted access to the computer or domain.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WindowsBuiltInRole.BackupOperator">
+      <summary>Backup operators can override security restrictions for the sole purpose of backing up or restoring files.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WindowsBuiltInRole.Guest">
+      <summary>Guests are more restricted than users.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WindowsBuiltInRole.PowerUser">
+      <summary>Power users possess most administrative permissions with some restrictions. Thus, power users can run legacy applications, in addition to certified applications.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WindowsBuiltInRole.PrintOperator">
+      <summary>Print operators can take control of a printer.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WindowsBuiltInRole.Replicator">
+      <summary>Replicators support file replication in a domain.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WindowsBuiltInRole.SystemOperator">
+      <summary>System operators manage a particular computer.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WindowsBuiltInRole.User">
+      <summary>Users are prevented from making accidental or intentional system-wide changes. Thus, users can run certified applications, but not most legacy applications.</summary>
+    </member>
+    <member name="T:System.Security.Principal.WindowsIdentity">
+      <summary>Represents a Windows user.</summary>
+    </member>
+    <member name="F:System.Security.Principal.WindowsIdentity.DefaultIssuer">
+      <summary>Identifies the name of the default <see cref="T:System.Security.Claims.ClaimsIdentity" /> issuer.</summary>
+    </member>
+    <member name="M:System.Security.Principal.WindowsIdentity.#ctor(System.IntPtr)">
+      <summary>Initializes a new instance of the <see cref="T:System.Security.Principal.WindowsIdentity" /> class for the user represented by the specified Windows account token.</summary>
+      <param name="userToken">The account token for the user on whose behalf the code is running.</param>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="userToken" /> is 0.  
+  
+ -or-  
+  
+ <paramref name="userToken" /> is duplicated and invalid for impersonation.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the correct permissions.  
+  
+ -or-  
+  
+ A Win32 error occurred.</exception>
+    </member>
+    <member name="M:System.Security.Principal.WindowsIdentity.#ctor(System.IntPtr,System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Security.Principal.WindowsIdentity" /> class for the user represented by the specified Windows account token and the specified authentication type.</summary>
+      <param name="userToken">The account token for the user on whose behalf the code is running.</param>
+      <param name="type">(Informational use only.) The type of authentication used to identify the user.</param>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="userToken" /> is 0.  
+  
+ -or-  
+  
+ <paramref name="userToken" /> is duplicated and invalid for impersonation.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the correct permissions.  
+  
+ -or-  
+  
+ A Win32 error occurred.</exception>
+    </member>
+    <member name="M:System.Security.Principal.WindowsIdentity.#ctor(System.IntPtr,System.String,System.Security.Principal.WindowsAccountType)">
+      <summary>Initializes a new instance of the <see cref="T:System.Security.Principal.WindowsIdentity" /> class for the user represented by the specified Windows account token, the specified authentication type, and the specified Windows account type.</summary>
+      <param name="userToken">The account token for the user on whose behalf the code is running.</param>
+      <param name="type">(Informational use only.) The type of authentication used to identify the user.</param>
+      <param name="acctType">One of the enumeration values.</param>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="userToken" /> is 0.  
+  
+ -or-  
+  
+ <paramref name="userToken" /> is duplicated and invalid for impersonation.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the correct permissions.  
+  
+ -or-  
+  
+ A Win32 error occurred.</exception>
+    </member>
+    <member name="M:System.Security.Principal.WindowsIdentity.#ctor(System.IntPtr,System.String,System.Security.Principal.WindowsAccountType,System.Boolean)">
+      <summary>Initializes a new instance of the <see cref="T:System.Security.Principal.WindowsIdentity" /> class for the user represented by the specified Windows account token, the specified authentication type, the specified Windows account type, and the specified authentication status.</summary>
+      <param name="userToken">The account token for the user on whose behalf the code is running.</param>
+      <param name="type">(Informational use only.) The type of authentication used to identify the user.</param>
+      <param name="acctType">One of the enumeration values.</param>
+      <param name="isAuthenticated">
+        <see langword="true" /> to indicate that the user is authenticated; otherwise, <see langword="false" />.</param>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="userToken" /> is 0.  
+  
+ -or-  
+  
+ <paramref name="userToken" /> is duplicated and invalid for impersonation.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the correct permissions.  
+  
+ -or-  
+  
+ A Win32 error occurred.</exception>
+    </member>
+    <member name="M:System.Security.Principal.WindowsIdentity.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)">
+      <summary>Initializes a new instance of the <see cref="T:System.Security.Principal.WindowsIdentity" /> class for the user represented by information in a <see cref="T:System.Runtime.Serialization.SerializationInfo" /> stream.</summary>
+      <param name="info">The object containing the account information for the user.</param>
+      <param name="context">An object that indicates the stream characteristics.</param>
+      <exception cref="T:System.NotSupportedException">A <see cref="T:System.Security.Principal.WindowsIdentity" /> cannot be serialized across processes.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the correct permissions.  
+  
+ -or-  
+  
+ A Win32 error occurred.</exception>
+    </member>
+    <member name="M:System.Security.Principal.WindowsIdentity.#ctor(System.Security.Principal.WindowsIdentity)">
+      <summary>Initializes a new instance of the <see cref="T:System.Security.Principal.WindowsIdentity" /> class by using the specified <see cref="T:System.Security.Principal.WindowsIdentity" /> object.</summary>
+      <param name="identity">The object from which to construct the new instance of <see cref="T:System.Security.Principal.WindowsIdentity" />.</param>
+    </member>
+    <member name="M:System.Security.Principal.WindowsIdentity.#ctor(System.String)">
+      <summary>Initializes a new instance of the <see cref="T:System.Security.Principal.WindowsIdentity" /> class for the user represented by the specified User Principal Name (UPN).</summary>
+      <param name="sUserPrincipalName">The UPN for the user on whose behalf the code is running.</param>
+      <exception cref="T:System.UnauthorizedAccessException">Windows returned the Windows NT status code STATUS_ACCESS_DENIED.</exception>
+      <exception cref="T:System.OutOfMemoryException">There is insufficient memory available.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the correct permissions.  
+  
+ -or-  
+  
+ The computer is not attached to a Windows 2003 or later domain.  
+  
+ -or-  
+  
+ The computer is not running Windows 2003 or later.  
+  
+ -or-  
+  
+ The user is not a member of the domain the computer is attached to.</exception>
+    </member>
+    <member name="M:System.Security.Principal.WindowsIdentity.Clone">
+      <summary>Creates a new  object that is a copy of the current instance.</summary>
+      <returns>A copy of the current instance.</returns>
+    </member>
+    <member name="M:System.Security.Principal.WindowsIdentity.Dispose">
+      <summary>Releases all resources used by the <see cref="T:System.Security.Principal.WindowsIdentity" />.</summary>
+    </member>
+    <member name="M:System.Security.Principal.WindowsIdentity.Dispose(System.Boolean)">
+      <summary>Releases the unmanaged resources used by the <see cref="T:System.Security.Principal.WindowsIdentity" /> and optionally releases the managed resources.</summary>
+      <param name="disposing">
+        <see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>
+    </member>
+    <member name="M:System.Security.Principal.WindowsIdentity.GetAnonymous">
+      <summary>Returns a <see cref="T:System.Security.Principal.WindowsIdentity" /> object that you can use as a sentinel value in your code to represent an anonymous user. The property value does not represent the built-in anonymous identity used by the Windows operating system.</summary>
+      <returns>An object that represents an anonymous user.</returns>
+    </member>
+    <member name="M:System.Security.Principal.WindowsIdentity.GetCurrent">
+      <summary>Returns a <see cref="T:System.Security.Principal.WindowsIdentity" /> object that represents the current Windows user.</summary>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the correct permissions.</exception>
+      <returns>An object that represents the current user.</returns>
+    </member>
+    <member name="M:System.Security.Principal.WindowsIdentity.GetCurrent(System.Boolean)">
+      <summary>Returns a <see cref="T:System.Security.Principal.WindowsIdentity" /> object that represents the Windows identity for either the thread or the process, depending on the value of the <paramref name="ifImpersonating" /> parameter.</summary>
+      <param name="ifImpersonating">
+        <see langword="true" /> to return the <see cref="T:System.Security.Principal.WindowsIdentity" /> only if the thread is currently impersonating; <see langword="false" /> to return the <see cref="T:System.Security.Principal.WindowsIdentity" /> of the thread if it is impersonating or the <see cref="T:System.Security.Principal.WindowsIdentity" /> of the process if the thread is not currently impersonating.</param>
+      <returns>An object that represents a Windows user.</returns>
+    </member>
+    <member name="M:System.Security.Principal.WindowsIdentity.GetCurrent(System.Security.Principal.TokenAccessLevels)">
+      <summary>Returns a <see cref="T:System.Security.Principal.WindowsIdentity" /> object that represents the current Windows user, using the specified desired token access level.</summary>
+      <param name="desiredAccess">A bitwise combination of the enumeration values.</param>
+      <returns>An object that represents the current user.</returns>
+    </member>
+    <member name="M:System.Security.Principal.WindowsIdentity.RunImpersonated(Microsoft.Win32.SafeHandles.SafeAccessTokenHandle,System.Action)">
+      <summary>Runs the specified action as the impersonated Windows identity. Instead of using an impersonated method call and running your function in <see cref="T:System.Security.Principal.WindowsImpersonationContext" />, you can use <see cref="M:System.Security.Principal.WindowsIdentity.RunImpersonated(Microsoft.Win32.SafeHandles.SafeAccessTokenHandle,System.Action)" /> and provide your function directly as a parameter.</summary>
+      <param name="safeAccessTokenHandle">The SafeAccessTokenHandle of the impersonated Windows identity.</param>
+      <param name="action">The System.Action to run.</param>
+    </member>
+    <member name="M:System.Security.Principal.WindowsIdentity.RunImpersonated``1(Microsoft.Win32.SafeHandles.SafeAccessTokenHandle,System.Func{``0})">
+      <summary>Runs the specified function as the impersonated Windows identity. Instead of using an impersonated method call and running your function in <see cref="T:System.Security.Principal.WindowsImpersonationContext" />, you can use <see cref="M:System.Security.Principal.WindowsIdentity.RunImpersonated(Microsoft.Win32.SafeHandles.SafeAccessTokenHandle,System.Action)" /> and provide your function directly as a parameter.</summary>
+      <param name="safeAccessTokenHandle">The SafeAccessTokenHandle of the impersonated Windows identity.</param>
+      <param name="func">The System.Func to run.</param>
+      <typeparam name="T">The type of object used by and returned by the function.</typeparam>
+      <returns>The result of the function.</returns>
+    </member>
+    <member name="M:System.Security.Principal.WindowsIdentity.RunImpersonatedAsync(Microsoft.Win32.SafeHandles.SafeAccessTokenHandle,System.Func{System.Threading.Tasks.Task})">
+      <summary>Runs the specified asynchronous action as the impersonated Windows identity.</summary>
+      <param name="safeAccessTokenHandle">The handle of the impersonated Windows identity.</param>
+      <param name="func">The function to run.</param>
+      <returns>A task that represents the asynchronous operation of the provided <see cref="T:System.Func`1" />.</returns>
+    </member>
+    <member name="M:System.Security.Principal.WindowsIdentity.RunImpersonatedAsync``1(Microsoft.Win32.SafeHandles.SafeAccessTokenHandle,System.Func{System.Threading.Tasks.Task{``0}})">
+      <summary>Runs the specified asynchronous action as the impersonated Windows identity.</summary>
+      <param name="safeAccessTokenHandle">The handle of the impersonated Windows identity.</param>
+      <param name="func">The function to run.</param>
+      <typeparam name="T">The type of the object to return.</typeparam>
+      <returns>A task that represents the asynchronous operation of <paramref name="func" />.</returns>
+    </member>
+    <member name="M:System.Security.Principal.WindowsIdentity.System#Runtime#Serialization#IDeserializationCallback#OnDeserialization(System.Object)">
+      <summary>Implements the <see cref="T:System.Runtime.Serialization.ISerializable" /> interface and is called back by the deserialization event when deserialization is complete.</summary>
+      <param name="sender">The source of the deserialization event.</param>
+    </member>
+    <member name="M:System.Security.Principal.WindowsIdentity.System#Runtime#Serialization#ISerializable#GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)">
+      <summary>Sets the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object with the logical context information needed to recreate an instance of this execution context.</summary>
+      <param name="info">An object containing the information required to serialize the <see cref="T:System.Collections.Hashtable" />.</param>
+      <param name="context">An object containing the source and destination of the serialized stream associated with the <see cref="T:System.Collections.Hashtable" />.</param>
+    </member>
+    <member name="P:System.Security.Principal.WindowsIdentity.AccessToken">
+      <summary>Gets this <see cref="T:Microsoft.Win32.SafeHandles.SafeAccessTokenHandle" /> for this <see cref="T:System.Security.Principal.WindowsIdentity" /> instance.</summary>
+      <returns>Returns a <see cref="T:Microsoft.Win32.SafeHandles.SafeAccessTokenHandle" />.</returns>
+    </member>
+    <member name="P:System.Security.Principal.WindowsIdentity.AuthenticationType">
+      <summary>Gets the type of authentication used to identify the user.</summary>
+      <exception cref="T:System.UnauthorizedAccessException">Windows returned the Windows NT status code STATUS_ACCESS_DENIED.</exception>
+      <exception cref="T:System.OutOfMemoryException">There is insufficient memory available.</exception>
+      <exception cref="T:System.Security.SecurityException">The caller does not have the correct permissions.  
+  
+ -or-  
+  
+ The computer is not attached to a Windows 2003 or later domain.  
+  
+ -or-  
+  
+ The computer is not running Windows 2003 or later.  
+  
+ -or-  
+  
+ The user is not a member of the domain the computer is attached to.</exception>
+      <returns>The type of authentication used to identify the user.</returns>
+    </member>
+    <member name="P:System.Security.Principal.WindowsIdentity.Claims">
+      <summary>Gets all claims for the user represented by this Windows identity.</summary>
+      <returns>A collection of claims for this <see cref="T:System.Security.Principal.WindowsIdentity" /> object.</returns>
+    </member>
+    <member name="P:System.Security.Principal.WindowsIdentity.DeviceClaims">
+      <summary>Gets claims that have the <see cref="F:System.Security.Claims.ClaimTypes.WindowsDeviceClaim" /> property key.</summary>
+      <returns>A collection of claims that have the <see cref="F:System.Security.Claims.ClaimTypes.WindowsDeviceClaim" /> property key.</returns>
+    </member>
+    <member name="P:System.Security.Principal.WindowsIdentity.Groups">
+      <summary>Gets the groups the current Windows user belongs to.</summary>
+      <returns>An object representing the groups the current Windows user belongs to.</returns>
+    </member>
+    <member name="P:System.Security.Principal.WindowsIdentity.ImpersonationLevel">
+      <summary>Gets the impersonation level for the user.</summary>
+      <returns>One of the enumeration values that specifies the impersonation level.</returns>
+    </member>
+    <member name="P:System.Security.Principal.WindowsIdentity.IsAnonymous">
+      <summary>Gets a value that indicates whether the user account is identified as an anonymous account by the system.</summary>
+      <returns>
+        <see langword="true" /> if the user account is an anonymous account; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Security.Principal.WindowsIdentity.IsAuthenticated">
+      <summary>Gets a value indicating whether the user has been authenticated by Windows.</summary>
+      <returns>
+        <see langword="true" /> if the user was authenticated; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Security.Principal.WindowsIdentity.IsGuest">
+      <summary>Gets a value indicating whether the user account is identified as a <see cref="F:System.Security.Principal.WindowsAccountType.Guest" /> account by the system.</summary>
+      <returns>
+        <see langword="true" /> if the user account is a <see cref="F:System.Security.Principal.WindowsAccountType.Guest" /> account; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Security.Principal.WindowsIdentity.IsSystem">
+      <summary>Gets a value indicating whether the user account is identified as a <see cref="F:System.Security.Principal.WindowsAccountType.System" /> account by the system.</summary>
+      <returns>
+        <see langword="true" /> if the user account is a <see cref="F:System.Security.Principal.WindowsAccountType.System" /> account; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Security.Principal.WindowsIdentity.Name">
+      <summary>Gets the user's Windows logon name.</summary>
+      <returns>The Windows logon name of the user on whose behalf the code is being run.</returns>
+    </member>
+    <member name="P:System.Security.Principal.WindowsIdentity.Owner">
+      <summary>Gets the security identifier (SID) for the token owner.</summary>
+      <returns>An object for the token owner.</returns>
+    </member>
+    <member name="P:System.Security.Principal.WindowsIdentity.Token">
+      <summary>Gets the Windows account token for the user.</summary>
+      <returns>The handle of the access token associated with the current execution thread.</returns>
+    </member>
+    <member name="P:System.Security.Principal.WindowsIdentity.User">
+      <summary>Gets the security identifier (SID) for the user.</summary>
+      <returns>An object for the user.</returns>
+    </member>
+    <member name="P:System.Security.Principal.WindowsIdentity.UserClaims">
+      <summary>Gets claims that have the <see cref="F:System.Security.Claims.ClaimTypes.WindowsUserClaim" /> property key.</summary>
+      <returns>A collection of claims that have the <see cref="F:System.Security.Claims.ClaimTypes.WindowsUserClaim" /> property key.</returns>
+    </member>
+    <member name="T:System.Security.Principal.WindowsPrincipal">
+      <summary>Enables code to check the Windows group membership of a Windows user.</summary>
+    </member>
+    <member name="M:System.Security.Principal.WindowsPrincipal.#ctor(System.Security.Principal.WindowsIdentity)">
+      <summary>Initializes a new instance of the <see cref="T:System.Security.Principal.WindowsPrincipal" /> class by using the specified <see cref="T:System.Security.Principal.WindowsIdentity" /> object.</summary>
+      <param name="ntIdentity">The object from which to construct the new instance of <see cref="T:System.Security.Principal.WindowsPrincipal" />.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="ntIdentity" /> is <see langword="null" />.</exception>
+    </member>
+    <member name="M:System.Security.Principal.WindowsPrincipal.IsInRole(System.Int32)">
+      <summary>Determines whether the current principal belongs to the Windows user group with the specified relative identifier (RID).</summary>
+      <param name="rid">The RID of the Windows user group in which to check for the principal's membership status.</param>
+      <returns>
+        <see langword="true" /> if the current principal is a member of the specified Windows user group, that is, in a particular role; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Security.Principal.WindowsPrincipal.IsInRole(System.Security.Principal.SecurityIdentifier)">
+      <summary>Determines whether the current principal belongs to the Windows user group with the specified security identifier (SID).</summary>
+      <param name="sid">A <see cref="T:System.Security.Principal.SecurityIdentifier" /> that uniquely identifies a Windows user group.</param>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="sid" /> is <see langword="null" />.</exception>
+      <exception cref="T:System.Security.SecurityException">Windows returned a Win32 error.</exception>
+      <returns>
+        <see langword="true" /> if the current principal is a member of the specified Windows user group; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Security.Principal.WindowsPrincipal.IsInRole(System.Security.Principal.WindowsBuiltInRole)">
+      <summary>Determines whether the current principal belongs to the Windows user group with the specified <see cref="T:System.Security.Principal.WindowsBuiltInRole" />.</summary>
+      <param name="role">One of the <see cref="T:System.Security.Principal.WindowsBuiltInRole" /> values.</param>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="role" /> is not a valid <see cref="T:System.Security.Principal.WindowsBuiltInRole" /> value.</exception>
+      <returns>
+        <see langword="true" /> if the current principal is a member of the specified Windows user group; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="M:System.Security.Principal.WindowsPrincipal.IsInRole(System.String)">
+      <summary>Determines whether the current principal belongs to the Windows user group with the specified name.</summary>
+      <param name="role">The name of the Windows user group for which to check membership.</param>
+      <returns>
+        <see langword="true" /> if the current principal is a member of the specified Windows user group; otherwise, <see langword="false" />.</returns>
+    </member>
+    <member name="P:System.Security.Principal.WindowsPrincipal.DeviceClaims">
+      <summary>Gets all Windows device claims from this principal.</summary>
+      <returns>A collection of all Windows device claims from this principal.</returns>
+    </member>
+    <member name="P:System.Security.Principal.WindowsPrincipal.Identity">
+      <summary>Gets the identity of the current principal.</summary>
+      <returns>The <see cref="T:System.Security.Principal.WindowsIdentity" /> object of the current principal.</returns>
+    </member>
+    <member name="P:System.Security.Principal.WindowsPrincipal.UserClaims">
+      <summary>Gets all Windows user claims from this principal.</summary>
+      <returns>A collection of all Windows user claims from this principal.</returns>
+    </member>
+  </members>
+</doc>

--- a/Tests/Plugins/system.security.principal.windows.5.0.0/System.Security.Principal.Windows.xml.meta
+++ b/Tests/Plugins/system.security.principal.windows.5.0.0/System.Security.Principal.Windows.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 80ab4cc24ab7c704eb68404f2de9dc28
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Plugins/system.threading.tasks.extensions.4.6.3.meta
+++ b/Tests/Plugins/system.threading.tasks.extensions.4.6.3.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c59c44ab2839df4b917a87465f83cff
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Plugins/system.threading.tasks.extensions.4.6.3/System.Threading.Tasks.Extensions.dll
+++ b/Tests/Plugins/system.threading.tasks.extensions.4.6.3/System.Threading.Tasks.Extensions.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb1655039bad6141a4739e39793e787545380f8cb59de6c431d1c92a67bd351b
+size 27936

--- a/Tests/Plugins/system.threading.tasks.extensions.4.6.3/System.Threading.Tasks.Extensions.dll.meta
+++ b/Tests/Plugins/system.threading.tasks.extensions.4.6.3/System.Threading.Tasks.Extensions.dll.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 195212f5ef2e4184f915e6ac17adc7c4

--- a/Tests/Plugins/system.threading.tasks.extensions.4.6.3/System.Threading.Tasks.Extensions.xml
+++ b/Tests/Plugins/system.threading.tasks.extensions.4.6.3/System.Threading.Tasks.Extensions.xml
@@ -1,0 +1,545 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>System.Threading.Tasks.Extensions</name>
+    </assembly>
+    <members>
+        <member name="T:System.Runtime.CompilerServices.AsyncMethodBuilderAttribute">
+            <summary>
+            Indicates the type of the async method builder that should be used by a language compiler to
+            build the attributed type when used as the return type of an async method.
+            </summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncMethodBuilderAttribute.#ctor(System.Type)">
+            <summary>Initializes the <see cref="T:System.Runtime.CompilerServices.AsyncMethodBuilderAttribute"/>.</summary>
+            <param name="builderType">The <see cref="T:System.Type"/> of the associated builder.</param>
+        </member>
+        <member name="P:System.Runtime.CompilerServices.AsyncMethodBuilderAttribute.BuilderType">
+            <summary>Gets the <see cref="T:System.Type"/> of the associated builder.</summary>
+        </member>
+        <member name="T:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder">
+            <summary>Represents a builder for asynchronous methods that return a <see cref="T:System.Threading.Tasks.ValueTask"/>.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder._methodBuilder">
+            <summary>The <see cref="T:System.Runtime.CompilerServices.AsyncTaskMethodBuilder"/> to which most operations are delegated.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder._haveResult">
+            <summary>true if completed synchronously and successfully; otherwise, false.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder._useBuilder">
+            <summary>true if the builder should be used for setting/getting the result; otherwise, false.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder.Create">
+            <summary>Creates an instance of the <see cref="T:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder"/> struct.</summary>
+            <returns>The initialized instance.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder.Start``1(``0@)">
+            <summary>Begins running the builder with the associated state machine.</summary>
+            <typeparam name="TStateMachine">The type of the state machine.</typeparam>
+            <param name="stateMachine">The state machine instance, passed by reference.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder.SetStateMachine(System.Runtime.CompilerServices.IAsyncStateMachine)">
+            <summary>Associates the builder with the specified state machine.</summary>
+            <param name="stateMachine">The state machine instance to associate with the builder.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder.SetResult">
+            <summary>Marks the task as successfully completed.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder.SetException(System.Exception)">
+            <summary>Marks the task as failed and binds the specified exception to the task.</summary>
+            <param name="exception">The exception to bind to the task.</param>
+        </member>
+        <member name="P:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder.Task">
+            <summary>Gets the task for this builder.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder.AwaitOnCompleted``2(``0@,``1@)">
+            <summary>Schedules the state machine to proceed to the next action when the specified awaiter completes.</summary>
+            <typeparam name="TAwaiter">The type of the awaiter.</typeparam>
+            <typeparam name="TStateMachine">The type of the state machine.</typeparam>
+            <param name="awaiter">The awaiter.</param>
+            <param name="stateMachine">The state machine.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder.AwaitUnsafeOnCompleted``2(``0@,``1@)">
+            <summary>Schedules the state machine to proceed to the next action when the specified awaiter completes.</summary>
+            <typeparam name="TAwaiter">The type of the awaiter.</typeparam>
+            <typeparam name="TStateMachine">The type of the state machine.</typeparam>
+            <param name="awaiter">The awaiter.</param>
+            <param name="stateMachine">The state machine.</param>
+        </member>
+        <member name="T:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1">
+            <summary>Represents a builder for asynchronous methods that returns a <see cref="T:System.Threading.Tasks.ValueTask`1"/>.</summary>
+            <typeparam name="TResult">The type of the result.</typeparam>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1._methodBuilder">
+            <summary>The <see cref="T:System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1"/> to which most operations are delegated.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1._result">
+            <summary>The result for this builder, if it's completed before any awaits occur.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1._haveResult">
+            <summary>true if <see cref="F:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1._result"/> contains the synchronous result for the async method; otherwise, false.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1._useBuilder">
+            <summary>true if the builder should be used for setting/getting the result; otherwise, false.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1.Create">
+            <summary>Creates an instance of the <see cref="T:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1"/> struct.</summary>
+            <returns>The initialized instance.</returns>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1.Start``1(``0@)">
+            <summary>Begins running the builder with the associated state machine.</summary>
+            <typeparam name="TStateMachine">The type of the state machine.</typeparam>
+            <param name="stateMachine">The state machine instance, passed by reference.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1.SetStateMachine(System.Runtime.CompilerServices.IAsyncStateMachine)">
+            <summary>Associates the builder with the specified state machine.</summary>
+            <param name="stateMachine">The state machine instance to associate with the builder.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1.SetResult(`0)">
+            <summary>Marks the task as successfully completed.</summary>
+            <param name="result">The result to use to complete the task.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1.SetException(System.Exception)">
+            <summary>Marks the task as failed and binds the specified exception to the task.</summary>
+            <param name="exception">The exception to bind to the task.</param>
+        </member>
+        <member name="P:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1.Task">
+            <summary>Gets the task for this builder.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1.AwaitOnCompleted``2(``0@,``1@)">
+            <summary>Schedules the state machine to proceed to the next action when the specified awaiter completes.</summary>
+            <typeparam name="TAwaiter">The type of the awaiter.</typeparam>
+            <typeparam name="TStateMachine">The type of the state machine.</typeparam>
+            <param name="awaiter">the awaiter</param>
+            <param name="stateMachine">The state machine.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1.AwaitUnsafeOnCompleted``2(``0@,``1@)">
+            <summary>Schedules the state machine to proceed to the next action when the specified awaiter completes.</summary>
+            <typeparam name="TAwaiter">The type of the awaiter.</typeparam>
+            <typeparam name="TStateMachine">The type of the state machine.</typeparam>
+            <param name="awaiter">the awaiter</param>
+            <param name="stateMachine">The state machine.</param>
+        </member>
+        <member name="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable">
+            <summary>Provides an awaitable type that enables configured awaits on a <see cref="T:System.Threading.Tasks.ValueTask"/>.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable._value">
+            <summary>The wrapped <see cref="T:System.Threading.Tasks.Task"/>.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.#ctor(System.Threading.Tasks.ValueTask)">
+            <summary>Initializes the awaitable.</summary>
+            <param name="value">The wrapped <see cref="T:System.Threading.Tasks.ValueTask"/>.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.GetAwaiter">
+            <summary>Returns an awaiter for this <see cref="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable"/> instance.</summary>
+        </member>
+        <member name="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter">
+            <summary>Provides an awaiter for a <see cref="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable"/>.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter._value">
+            <summary>The value being awaited.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter.#ctor(System.Threading.Tasks.ValueTask)">
+            <summary>Initializes the awaiter.</summary>
+            <param name="value">The value to be awaited.</param>
+        </member>
+        <member name="P:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter.IsCompleted">
+            <summary>Gets whether the <see cref="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable"/> has completed.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter.GetResult">
+            <summary>Gets the result of the ValueTask.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter.OnCompleted(System.Action)">
+            <summary>Schedules the continuation action for the <see cref="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable"/>.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter.UnsafeOnCompleted(System.Action)">
+            <summary>Schedules the continuation action for the <see cref="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable"/>.</summary>
+        </member>
+        <member name="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1">
+            <summary>Provides an awaitable type that enables configured awaits on a <see cref="T:System.Threading.Tasks.ValueTask`1"/>.</summary>
+            <typeparam name="TResult">The type of the result produced.</typeparam>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1._value">
+            <summary>The wrapped <see cref="T:System.Threading.Tasks.ValueTask`1"/>.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.#ctor(System.Threading.Tasks.ValueTask{`0})">
+            <summary>Initializes the awaitable.</summary>
+            <param name="value">The wrapped <see cref="T:System.Threading.Tasks.ValueTask`1"/>.</param>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.GetAwaiter">
+            <summary>Returns an awaiter for this <see cref="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1"/> instance.</summary>
+        </member>
+        <member name="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.ConfiguredValueTaskAwaiter">
+            <summary>Provides an awaiter for a <see cref="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1"/>.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.ConfiguredValueTaskAwaiter._value">
+            <summary>The value being awaited.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.ConfiguredValueTaskAwaiter.#ctor(System.Threading.Tasks.ValueTask{`0})">
+            <summary>Initializes the awaiter.</summary>
+            <param name="value">The value to be awaited.</param>
+        </member>
+        <member name="P:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.ConfiguredValueTaskAwaiter.IsCompleted">
+            <summary>Gets whether the <see cref="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1"/> has completed.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.ConfiguredValueTaskAwaiter.GetResult">
+            <summary>Gets the result of the ValueTask.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.ConfiguredValueTaskAwaiter.OnCompleted(System.Action)">
+            <summary>Schedules the continuation action for the <see cref="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1"/>.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.ConfiguredValueTaskAwaiter.UnsafeOnCompleted(System.Action)">
+            <summary>Schedules the continuation action for the <see cref="T:System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1"/>.</summary>
+        </member>
+        <member name="T:System.Runtime.CompilerServices.ValueTaskAwaiter">
+            <summary>Provides an awaiter for a <see cref="T:System.Threading.Tasks.ValueTask"/>.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.ValueTaskAwaiter.s_invokeActionDelegate">
+            <summary>Shim used to invoke an <see cref="T:System.Action"/> passed as the state argument to a <see cref="T:System.Action`1"/>.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.ValueTaskAwaiter._value">
+            <summary>The value being awaited.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ValueTaskAwaiter.#ctor(System.Threading.Tasks.ValueTask)">
+            <summary>Initializes the awaiter.</summary>
+            <param name="value">The value to be awaited.</param>
+        </member>
+        <member name="P:System.Runtime.CompilerServices.ValueTaskAwaiter.IsCompleted">
+            <summary>Gets whether the <see cref="T:System.Threading.Tasks.ValueTask"/> has completed.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ValueTaskAwaiter.GetResult">
+            <summary>Gets the result of the ValueTask.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ValueTaskAwaiter.OnCompleted(System.Action)">
+            <summary>Schedules the continuation action for this ValueTask.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ValueTaskAwaiter.UnsafeOnCompleted(System.Action)">
+            <summary>Schedules the continuation action for this ValueTask.</summary>
+        </member>
+        <member name="T:System.Runtime.CompilerServices.ValueTaskAwaiter`1">
+            <summary>Provides an awaiter for a <see cref="T:System.Threading.Tasks.ValueTask`1"/>.</summary>
+        </member>
+        <member name="F:System.Runtime.CompilerServices.ValueTaskAwaiter`1._value">
+            <summary>The value being awaited.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ValueTaskAwaiter`1.#ctor(System.Threading.Tasks.ValueTask{`0})">
+            <summary>Initializes the awaiter.</summary>
+            <param name="value">The value to be awaited.</param>
+        </member>
+        <member name="P:System.Runtime.CompilerServices.ValueTaskAwaiter`1.IsCompleted">
+            <summary>Gets whether the <see cref="T:System.Threading.Tasks.ValueTask`1"/> has completed.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ValueTaskAwaiter`1.GetResult">
+            <summary>Gets the result of the ValueTask.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ValueTaskAwaiter`1.OnCompleted(System.Action)">
+            <summary>Schedules the continuation action for this ValueTask.</summary>
+        </member>
+        <member name="M:System.Runtime.CompilerServices.ValueTaskAwaiter`1.UnsafeOnCompleted(System.Action)">
+            <summary>Schedules the continuation action for this ValueTask.</summary>
+        </member>
+        <member name="T:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags">
+            <summary>
+            Flags passed from <see cref="T:System.Threading.Tasks.ValueTask"/> and <see cref="T:System.Threading.Tasks.ValueTask`1"/> to
+            <see cref="M:System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted(System.Action{System.Object},System.Object,System.Int16,System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)"/> and <see cref="M:System.Threading.Tasks.Sources.IValueTaskSource`1.OnCompleted(System.Action{System.Object},System.Object,System.Int16,System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)"/>
+            to control behavior.
+            </summary>
+        </member>
+        <member name="F:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags.None">
+            <summary>
+            No requirements are placed on how the continuation is invoked.
+            </summary>
+        </member>
+        <member name="F:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags.UseSchedulingContext">
+            <summary>
+            Set if OnCompleted should capture the current scheduling context (e.g. SynchronizationContext)
+            and use it when queueing the continuation for execution.  If this is not set, the implementation
+            may choose to execute the continuation in an arbitrary location.
+            </summary>
+        </member>
+        <member name="F:System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags.FlowExecutionContext">
+            <summary>
+            Set if OnCompleted should capture the current ExecutionContext and use it to run the continuation.
+            </summary>
+        </member>
+        <member name="T:System.Threading.Tasks.Sources.ValueTaskSourceStatus">
+            <summary>Indicates the status of an <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/> or <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource`1"/>.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.Sources.ValueTaskSourceStatus.Pending">
+            <summary>The operation has not yet completed.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.Sources.ValueTaskSourceStatus.Succeeded">
+            <summary>The operation completed successfully.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.Sources.ValueTaskSourceStatus.Faulted">
+            <summary>The operation completed with an error.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.Sources.ValueTaskSourceStatus.Canceled">
+            <summary>The operation completed due to cancellation.</summary>
+        </member>
+        <member name="T:System.Threading.Tasks.Sources.IValueTaskSource">
+            <summary>Represents an object that can be wrapped by a <see cref="T:System.Threading.Tasks.ValueTask"/>.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.Sources.IValueTaskSource.GetStatus(System.Int16)">
+            <summary>Gets the status of the current operation.</summary>
+            <param name="token">Opaque value that was provided to the <see cref="T:System.Threading.Tasks.ValueTask"/>'s constructor.</param>
+        </member>
+        <member name="M:System.Threading.Tasks.Sources.IValueTaskSource.OnCompleted(System.Action{System.Object},System.Object,System.Int16,System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)">
+            <summary>Schedules the continuation action for this <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>.</summary>
+            <param name="continuation">The continuation to invoke when the operation has completed.</param>
+            <param name="state">The state object to pass to <paramref name="continuation"/> when it's invoked.</param>
+            <param name="token">Opaque value that was provided to the <see cref="T:System.Threading.Tasks.ValueTask"/>'s constructor.</param>
+            <param name="flags">The flags describing the behavior of the continuation.</param>
+        </member>
+        <member name="M:System.Threading.Tasks.Sources.IValueTaskSource.GetResult(System.Int16)">
+            <summary>Gets the result of the <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>.</summary>
+            <param name="token">Opaque value that was provided to the <see cref="T:System.Threading.Tasks.ValueTask"/>'s constructor.</param>
+        </member>
+        <member name="T:System.Threading.Tasks.Sources.IValueTaskSource`1">
+            <summary>Represents an object that can be wrapped by a <see cref="T:System.Threading.Tasks.ValueTask`1"/>.</summary>
+            <typeparam name="TResult">Specifies the type of data returned from the object.</typeparam>
+        </member>
+        <member name="M:System.Threading.Tasks.Sources.IValueTaskSource`1.GetStatus(System.Int16)">
+            <summary>Gets the status of the current operation.</summary>
+            <param name="token">Opaque value that was provided to the <see cref="T:System.Threading.Tasks.ValueTask"/>'s constructor.</param>
+        </member>
+        <member name="M:System.Threading.Tasks.Sources.IValueTaskSource`1.OnCompleted(System.Action{System.Object},System.Object,System.Int16,System.Threading.Tasks.Sources.ValueTaskSourceOnCompletedFlags)">
+            <summary>Schedules the continuation action for this <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource`1"/>.</summary>
+            <param name="continuation">The continuation to invoke when the operation has completed.</param>
+            <param name="state">The state object to pass to <paramref name="continuation"/> when it's invoked.</param>
+            <param name="token">Opaque value that was provided to the <see cref="T:System.Threading.Tasks.ValueTask"/>'s constructor.</param>
+            <param name="flags">The flags describing the behavior of the continuation.</param>
+        </member>
+        <member name="M:System.Threading.Tasks.Sources.IValueTaskSource`1.GetResult(System.Int16)">
+            <summary>Gets the result of the <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource`1"/>.</summary>
+            <param name="token">Opaque value that was provided to the <see cref="T:System.Threading.Tasks.ValueTask"/>'s constructor.</param>
+        </member>
+        <member name="T:System.Threading.Tasks.ValueTask">
+            <summary>Provides an awaitable result of an asynchronous operation.</summary>
+            <remarks>
+            <see cref="T:System.Threading.Tasks.ValueTask"/>s are meant to be directly awaited.  To do more complicated operations with them, a <see cref="T:System.Threading.Tasks.Task"/>
+            should be extracted using <see cref="M:System.Threading.Tasks.ValueTask.AsTask"/>.  Such operations might include caching an instance to be awaited later,
+            registering multiple continuations with a single operation, awaiting the same task multiple times, and using combinators over
+            multiple operations.
+            </remarks>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask.s_canceledTask">
+            <summary>A task canceled using `new CancellationToken(true)`.</summary>
+        </member>
+        <member name="P:System.Threading.Tasks.ValueTask.CompletedTask">
+            <summary>A successfully completed task.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask._obj">
+            <summary>null if representing a successful synchronous completion, otherwise a <see cref="T:System.Threading.Tasks.Task"/> or a <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask._token">
+            <summary>Opaque value passed through to the <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask._continueOnCapturedContext">
+            <summary>true to continue on the capture context; otherwise, true.</summary>
+            <remarks>Stored in the <see cref="T:System.Threading.Tasks.ValueTask"/> rather than in the configured awaiter to utilize otherwise padding space.</remarks>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.#ctor(System.Threading.Tasks.Task)">
+            <summary>Initialize the <see cref="T:System.Threading.Tasks.ValueTask"/> with a <see cref="T:System.Threading.Tasks.Task"/> that represents the operation.</summary>
+            <param name="task">The task.</param>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.#ctor(System.Threading.Tasks.Sources.IValueTaskSource,System.Int16)">
+            <summary>Initialize the <see cref="T:System.Threading.Tasks.ValueTask"/> with a <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/> object that represents the operation.</summary>
+            <param name="source">The source.</param>
+            <param name="token">Opaque value passed through to the <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>.</param>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.GetHashCode">
+            <summary>Returns the hash code for this instance.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.Equals(System.Object)">
+            <summary>Returns a value indicating whether this value is equal to a specified <see cref="T:System.Object"/>.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.Equals(System.Threading.Tasks.ValueTask)">
+            <summary>Returns a value indicating whether this value is equal to a specified <see cref="T:System.Threading.Tasks.ValueTask"/> value.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.op_Equality(System.Threading.Tasks.ValueTask,System.Threading.Tasks.ValueTask)">
+            <summary>Returns a value indicating whether two <see cref="T:System.Threading.Tasks.ValueTask"/> values are equal.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.op_Inequality(System.Threading.Tasks.ValueTask,System.Threading.Tasks.ValueTask)">
+            <summary>Returns a value indicating whether two <see cref="T:System.Threading.Tasks.ValueTask"/> values are not equal.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.AsTask">
+            <summary>
+            Gets a <see cref="T:System.Threading.Tasks.Task"/> object to represent this ValueTask.
+            </summary>
+            <remarks>
+            It will either return the wrapped task object if one exists, or it'll
+            manufacture a new task object to represent the result.
+            </remarks>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.Preserve">
+            <summary>Gets a <see cref="T:System.Threading.Tasks.ValueTask"/> that may be used at any point in the future.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.GetTaskForValueTaskSource(System.Threading.Tasks.Sources.IValueTaskSource)">
+            <summary>Creates a <see cref="T:System.Threading.Tasks.Task"/> to represent the <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>.</summary>
+            <remarks>
+            The <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/> is passed in rather than reading and casting <see cref="F:System.Threading.Tasks.ValueTask._obj"/>
+            so that the caller can pass in an object it's already validated.
+            </remarks>
+        </member>
+        <member name="T:System.Threading.Tasks.ValueTask.ValueTaskSourceAsTask">
+            <summary>Type used to create a <see cref="T:System.Threading.Tasks.Task"/> to represent a <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask.ValueTaskSourceAsTask._source">
+            <summary>The associated <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask.ValueTaskSourceAsTask._token">
+            <summary>The token to pass through to operations on <see cref="F:System.Threading.Tasks.ValueTask.ValueTaskSourceAsTask._source"/></summary>
+        </member>
+        <member name="P:System.Threading.Tasks.ValueTask.IsCompleted">
+            <summary>Gets whether the <see cref="T:System.Threading.Tasks.ValueTask"/> represents a completed operation.</summary>
+        </member>
+        <member name="P:System.Threading.Tasks.ValueTask.IsCompletedSuccessfully">
+            <summary>Gets whether the <see cref="T:System.Threading.Tasks.ValueTask"/> represents a successfully completed operation.</summary>
+        </member>
+        <member name="P:System.Threading.Tasks.ValueTask.IsFaulted">
+            <summary>Gets whether the <see cref="T:System.Threading.Tasks.ValueTask"/> represents a failed operation.</summary>
+        </member>
+        <member name="P:System.Threading.Tasks.ValueTask.IsCanceled">
+            <summary>Gets whether the <see cref="T:System.Threading.Tasks.ValueTask"/> represents a canceled operation.</summary>
+            <remarks>
+            If the <see cref="T:System.Threading.Tasks.ValueTask"/> is backed by a result or by a <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>,
+            this will always return false.  If it's backed by a <see cref="T:System.Threading.Tasks.Task"/>, it'll return the
+            value of the task's <see cref="P:System.Threading.Tasks.Task.IsCanceled"/> property.
+            </remarks>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.ThrowIfCompletedUnsuccessfully">
+            <summary>Throws the exception that caused the <see cref="T:System.Threading.Tasks.ValueTask"/> to fail.  If it completed successfully, nothing is thrown.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.GetAwaiter">
+            <summary>Gets an awaiter for this <see cref="T:System.Threading.Tasks.ValueTask"/>.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask.ConfigureAwait(System.Boolean)">
+            <summary>Configures an awaiter for this <see cref="T:System.Threading.Tasks.ValueTask"/>.</summary>
+            <param name="continueOnCapturedContext">
+            true to attempt to marshal the continuation back to the captured context; otherwise, false.
+            </param>
+        </member>
+        <member name="T:System.Threading.Tasks.ValueTask`1">
+            <summary>Provides a value type that can represent a synchronously available value or a task object.</summary>
+            <typeparam name="TResult">Specifies the type of the result.</typeparam>
+            <remarks>
+            <see cref="T:System.Threading.Tasks.ValueTask`1"/>s are meant to be directly awaited.  To do more complicated operations with them, a <see cref="T:System.Threading.Tasks.Task"/>
+            should be extracted using <see cref="M:System.Threading.Tasks.ValueTask`1.AsTask"/> or <see cref="M:System.Threading.Tasks.ValueTask`1.Preserve"/>.  Such operations might include caching an instance to
+            be awaited later, registering multiple continuations with a single operation, awaiting the same task multiple times, and using
+            combinators over multiple operations.
+            </remarks>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask`1.s_canceledTask">
+            <summary>A task canceled using `new CancellationToken(true)`. Lazily created only when first needed.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask`1._obj">
+            <summary>null if <see cref="F:System.Threading.Tasks.ValueTask`1._result"/> has the result, otherwise a <see cref="T:System.Threading.Tasks.Task`1"/> or a <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource`1"/>.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask`1._result">
+            <summary>The result to be used if the operation completed successfully synchronously.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask`1._token">
+            <summary>Opaque value passed through to the <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource`1"/>.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask`1._continueOnCapturedContext">
+            <summary>true to continue on the captured context; otherwise, false.</summary>
+            <remarks>Stored in the <see cref="T:System.Threading.Tasks.ValueTask`1"/> rather than in the configured awaiter to utilize otherwise padding space.</remarks>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.#ctor(`0)">
+            <summary>Initialize the <see cref="T:System.Threading.Tasks.ValueTask`1"/> with a <typeparamref name="TResult"/> result value.</summary>
+            <param name="result">The result.</param>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.#ctor(System.Threading.Tasks.Task{`0})">
+            <summary>Initialize the <see cref="T:System.Threading.Tasks.ValueTask`1"/> with a <see cref="T:System.Threading.Tasks.Task`1"/> that represents the operation.</summary>
+            <param name="task">The task.</param>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.#ctor(System.Threading.Tasks.Sources.IValueTaskSource{`0},System.Int16)">
+            <summary>Initialize the <see cref="T:System.Threading.Tasks.ValueTask`1"/> with a <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource`1"/> object that represents the operation.</summary>
+            <param name="source">The source.</param>
+            <param name="token">Opaque value passed through to the <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>.</param>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.#ctor(System.Object,`0,System.Int16,System.Boolean)">
+            <summary>Non-verified initialization of the struct to the specified values.</summary>
+            <param name="obj">The object.</param>
+            <param name="result">The result.</param>
+            <param name="token">The token.</param>
+            <param name="continueOnCapturedContext">true to continue on captured context; otherwise, false.</param>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.GetHashCode">
+            <summary>Returns the hash code for this instance.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.Equals(System.Object)">
+            <summary>Returns a value indicating whether this value is equal to a specified <see cref="T:System.Object"/>.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.Equals(System.Threading.Tasks.ValueTask{`0})">
+            <summary>Returns a value indicating whether this value is equal to a specified <see cref="T:System.Threading.Tasks.ValueTask`1"/> value.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.op_Equality(System.Threading.Tasks.ValueTask{`0},System.Threading.Tasks.ValueTask{`0})">
+            <summary>Returns a value indicating whether two <see cref="T:System.Threading.Tasks.ValueTask`1"/> values are equal.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.op_Inequality(System.Threading.Tasks.ValueTask{`0},System.Threading.Tasks.ValueTask{`0})">
+            <summary>Returns a value indicating whether two <see cref="T:System.Threading.Tasks.ValueTask`1"/> values are not equal.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.AsTask">
+            <summary>
+            Gets a <see cref="T:System.Threading.Tasks.Task`1"/> object to represent this ValueTask.
+            </summary>
+            <remarks>
+            It will either return the wrapped task object if one exists, or it'll
+            manufacture a new task object to represent the result.
+            </remarks>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.Preserve">
+            <summary>Gets a <see cref="T:System.Threading.Tasks.ValueTask`1"/> that may be used at any point in the future.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.GetTaskForValueTaskSource(System.Threading.Tasks.Sources.IValueTaskSource{`0})">
+            <summary>Creates a <see cref="T:System.Threading.Tasks.Task`1"/> to represent the <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource`1"/>.</summary>
+            <remarks>
+            The <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource`1"/> is passed in rather than reading and casting <see cref="F:System.Threading.Tasks.ValueTask`1._obj"/>
+            so that the caller can pass in an object it's already validated.
+            </remarks>
+        </member>
+        <member name="T:System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask">
+            <summary>Type used to create a <see cref="T:System.Threading.Tasks.Task`1"/> to represent a <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource`1"/>.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask._source">
+            <summary>The associated <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource"/>.</summary>
+        </member>
+        <member name="F:System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask._token">
+            <summary>The token to pass through to operations on <see cref="F:System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask._source"/></summary>
+        </member>
+        <member name="P:System.Threading.Tasks.ValueTask`1.IsCompleted">
+            <summary>Gets whether the <see cref="T:System.Threading.Tasks.ValueTask`1"/> represents a completed operation.</summary>
+        </member>
+        <member name="P:System.Threading.Tasks.ValueTask`1.IsCompletedSuccessfully">
+            <summary>Gets whether the <see cref="T:System.Threading.Tasks.ValueTask`1"/> represents a successfully completed operation.</summary>
+        </member>
+        <member name="P:System.Threading.Tasks.ValueTask`1.IsFaulted">
+            <summary>Gets whether the <see cref="T:System.Threading.Tasks.ValueTask`1"/> represents a failed operation.</summary>
+        </member>
+        <member name="P:System.Threading.Tasks.ValueTask`1.IsCanceled">
+            <summary>Gets whether the <see cref="T:System.Threading.Tasks.ValueTask`1"/> represents a canceled operation.</summary>
+            <remarks>
+            If the <see cref="T:System.Threading.Tasks.ValueTask`1"/> is backed by a result or by a <see cref="T:System.Threading.Tasks.Sources.IValueTaskSource`1"/>,
+            this will always return false.  If it's backed by a <see cref="T:System.Threading.Tasks.Task"/>, it'll return the
+            value of the task's <see cref="P:System.Threading.Tasks.Task.IsCanceled"/> property.
+            </remarks>
+        </member>
+        <member name="P:System.Threading.Tasks.ValueTask`1.Result">
+            <summary>Gets the result.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.GetAwaiter">
+            <summary>Gets an awaiter for this <see cref="T:System.Threading.Tasks.ValueTask`1"/>.</summary>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.ConfigureAwait(System.Boolean)">
+            <summary>Configures an awaiter for this <see cref="T:System.Threading.Tasks.ValueTask`1"/>.</summary>
+            <param name="continueOnCapturedContext">
+            true to attempt to marshal the continuation back to the captured context; otherwise, false.
+            </param>
+        </member>
+        <member name="M:System.Threading.Tasks.ValueTask`1.ToString">
+            <summary>Gets a string-representation of this <see cref="T:System.Threading.Tasks.ValueTask`1"/>.</summary>
+        </member>
+    </members>
+</doc>

--- a/Tests/Plugins/system.threading.tasks.extensions.4.6.3/System.Threading.Tasks.Extensions.xml.meta
+++ b/Tests/Plugins/system.threading.tasks.extensions.4.6.3/System.Threading.Tasks.Extensions.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 68032f506ee7517429410a9b88375c52
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.mazemodels.testingtoolkit",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "displayName": "Testing Toolkit",
   "description": "A lightweight package containing reusable test utilities and wrappers for common testing libraries designed for integration across multiple Unity projects and packages.",
   "hideInEditor": false,

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 782ae65daf1f16f4cb616be4da4f1ba5
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Summary
- Added the [NSubstitute 5.3.0](https://www.nuget.org/packages/NSubstitute/5.3.0) DLL compiled for .NET Standard 2.0, along with its dependencies.
- Each dependency DLL is also imported in its .NET Standard 2.0 version.

## Issue
- Closes #1